### PR TITLE
fix initialization Error: Missing signature Attribute

### DIFF
--- a/vastai_sdk.py
+++ b/vastai_sdk.py
@@ -173,8 +173,8 @@ class VastAI(VastAIBase):
                hasDoc = True
                wrapper.__doc__ += f"{doc}\n\n"
 
-        sig = getattr(func, "signature")
-        sig_help = getattr(func, "signature_help")
+        sig = getattr(func, "signature", None)
+        sig_help = getattr(func, "signature_help", None)
         if sig:
             try:
                 wrapper.__signature__, docappend = self.generate_signature_from_argparse(sig)


### PR DESCRIPTION
## Description
When trying to initialize the VastAI object, the following error is raised:
```AttributeError: 'function' object has no attribute 'signature'. Did you mean: 'mysignature'?```

## Steps to Reproduce
1. Create a file with the following content:
 ```
from vastai import VastAI

API_KEY = vast_api_key
vast_sdk = VastAI(api_key=API_KEY)
```
2. Run the script

During the initialization VastAI, the following error
```Traceback (most recent call last):
  File "/home/gerbylev/workspace/gpu_hunter/main.py", line 7, in <module>
    vast_sdk = VastAI(api_key=API_KEY)
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gerbylev/workspace/gpu_hunter/.venv/lib/python3.12/site-packages/vastai/vastai_sdk.py", line 37, in __init__
    self.import_cli_functions()
  File "/home/gerbylev/workspace/gpu_hunter/.venv/lib/python3.12/site-packages/vastai/vastai_sdk.py", line 106, in import_cli_functions
    wrapped_func = self.create_wrapper(func, func_name)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gerbylev/workspace/gpu_hunter/.venv/lib/python3.12/site-packages/vastai/vastai_sdk.py", line 179, in create_wrapper
    sig = getattr(func, "signature")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'function' object has no attribute 'signature'. Did you mean: 'mysignature'?
```