### PR TITLE
Ensure correct launch command for self-test machine

### DIFF
--- a/vast.py
+++ b/vast.py
@@ -5999,7 +5999,7 @@ def self_test__machine(args):
                 login=None,
                 label=None,
                 onstart=None,
-                onstart_cmd="python3 remote.py",
+                onstart_cmd="/verification/remote.sh",
                 entrypoint=None,
                 ssh=False,  # Set ssh to False
                 jupyter=True,  # Set jupyter to True


### PR DESCRIPTION
We must launch with /verification/remote.sh so that environmental overrides are applied before remote.py runs

Override is necessary to preload libnccl.so.2 for RTX5 series GPUs