### PR TITLE
Volume fixes, defjob fixes

### DIFF
--- a/vast.py
+++ b/vast.py
@@ -5128,15 +5128,13 @@ def set_ask(args):
 
 @parser.command(
     argument("id", help="id of machine to launch default instance on", type=int),
-    argument("--price_gpu", help="per gpu rental price in $/hour", type=float),
-    argument("--price_inetu", help="price for internet upload bandwidth in $/GB", type=float),
-    argument("--price_inetd", help="price for internet download bandwidth in $/GB", type=float),
     argument("--image", help="docker container image to launch", type=str),
     argument("--args", nargs=argparse.REMAINDER, help="list of arguments passed to container launch"),
-    usage="vastai set defjob id [--api-key API_KEY] [--price_gpu PRICE_GPU] [--price_inetu PRICE_INETU] [--price_inetd PRICE_INETD] [--image IMAGE] [--args ...]",
+    usage="vastai set defjob id [--api-key API_KEY] [--image IMAGE] [--args ...]",
     help="[Host] Create default jobs for a machine",
     epilog=deindent("""
-        Performs the same action as creating a background job at https://cloud.vast.ai/host/create.       
+        Performs the same action as creating a background job at https://cloud.vast.ai/host/create.
+        Image is required.
                     
     """)
     
@@ -5148,7 +5146,7 @@ def set__defjob(args):
     :rtype:
     """
     req_url   = apiurl(args, "/machines/create_bids/");
-    json_blob = {'machine': args.id, 'price_gpu': args.price_gpu, 'price_inetu': args.price_inetu, 'price_inetd': args.price_inetd, 'image': args.image, 'args': args.args}
+    json_blob = {'machine': args.id, 'image': args.image, 'args': args.args}
     if (args.explain):
         print("request json: ")
         print(json_blob)

--- a/vast.py
+++ b/vast.py
@@ -5008,9 +5008,9 @@ def list__machines(args):
 @parser.command(
     argument("id", help="id of machine to list", type=int),
     argument("-p", "--price_disk",
-             help="storage price in $/GB/month, default: $0.15/GB/month", default=.15, type=float),
+             help="storage price in $/GB/month, default: $0.10/GB/month", type=float),
     argument("-e", "--end_date", help="contract offer expiration - the available until date (optional, in unix float timestamp or MM/DD/YYYY format), default 1 month", type=str),
-    argument("-s", "--size", help="size of disk space allocated to offer in GB, default 15 GB", default=15),
+    argument("-s", "--size", help="size of disk space allocated to offer in GB, default 5 GB"),
     usage="vastai list volume ID [options]",
     help="[Host] list disk space for rent as a volume on a machine",
     epilog=deindent("""
@@ -5019,19 +5019,18 @@ def list__machines(args):
 )
 def list__volume(args):        
     size = args.size
-    if not size:
-        size = 15.0
     price_disk = args.price_disk
-    if not price_disk:
-        price_disk = .15
-
     json_blob ={
-        "size": int(size),
-        "machine": int(args.id)
+        "machine": int(args.id),
     }
     if args.end_date:
         json_blob["end_date"] = string_to_unix_epoch(args.end_date)
 
+    
+    if size:
+        json_blob["size"] = float(size)
+    if price_disk:
+        json_blob["price_disk"] = float(price_disk)
 
     url = apiurl(args, "/volumes/")
 
@@ -5060,20 +5059,19 @@ def list__volume(args):
 )
 def list__volumes(args):
     size = args.size
-    if not size:
-        size = 15.0
     price_disk = args.price_disk
-    if not price_disk:
-        price_disk = .15
 
     json_blob ={
-        "size": int(size),
-        "machine": [int(id) for id in args.ids]
+        "machine": [int(id) for id in args.ids],
     }
     if args.end_date:
         json_blob["end_date"] = string_to_unix_epoch(args.end_date)
-
-
+    
+    
+    if size:
+        json_blob["size"] = float(size)
+    if price_disk:
+        json_blob["price_disk"] = float(price_disk)
     url = apiurl(args, "/volumes/")
 
     if (args.explain):
@@ -5085,7 +5083,6 @@ def list__volumes(args):
         return r
     else:
         print("Created. {}".format(r.json()))
-
 
 
 @parser.command(


### PR DESCRIPTION
don't send defaults to webserver, because this prevents us from updating fields without setting other fields to the default, i.e, if I just want to update price I can call `vastai list volume 179 -p .4` and it will update my price to .4 without changing allocation. 