### PR TITLE
removed dependency version pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,20 +21,21 @@ requires-python = ">3.9.1, <4.0"
 license = { text = "MIT" }
 dynamic = ["version"]
 dependencies = [
-  "xdg",
-  "argcomplete==3.5.1",
-  "requests",
-  "borb (==2.1.25)",
-  "python-dateutil==2.6.1",
-  "pytz",
-  "urllib3==2.2.3",
+  "xdg (>=5.0.0)",
+  "argcomplete (>=3.5.1,<4.0.0)",
+  "requests (>=2.25.0)",
+  "borb (>=2.1.25,<3.0.0)",
+  "python-dateutil (>=2.8.0,<3.0.0)",
+  "pytz (>=2021.1)",
+  "urllib3 (>=2.2.3,<3.0.0)",
   "poetry-dynamic-versioning (>=1.8.1,<2.0.0)",
   "gitpython (>=3.1.44,<4.0.0)",
-  "toml (>=0.10.2,<0.11.0)",
+  "toml (>=0.10.2,<1.0.0)",
   "curlify (>=2.2.1,<3.0.0)",
-  "setuptools",
+  "setuptools (>=42.0.0)",
   "cryptography (>=44.0.2,<45.0.0)",
 ]
+
 
 [tool.poetry]
 packages = [{ include = "utils" }, { include = "vast.py" }]


### PR DESCRIPTION
In the dependencies section in pyproject.toml, changes pinned version like

"argcomplete==3.5.1",
  
to ranges like 

"argcomplete (>=3.5.1,<4.0.0)",

to improve interoperability and reduce version conflict when useing the vast.ai CLI in other environments.