### PR TITLE
Add `host id` search field to vol_offer_fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ failed_machines.txt
 Pass_testresults.log
 dist/
 __pycache__/
+.idea/*
+.venv/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@ failed_machines.txt
 Pass_testresults.log
 dist/
 __pycache__/
-.idea/*
-.venv/*

--- a/vast.py
+++ b/vast.py
@@ -649,6 +649,7 @@ vol_offers_fields = {
         "geolocation",
         "gpu_arch",
         "has_avx",
+        "host_id",
         "id",
         "inet_down",
         "inet_up",


### PR DESCRIPTION
Hey vast.ai team.

When im doing `vastai search volumes "host_id=<some_host>"` im getting results but with warning telling me:

`Warning: Unrecognized field: host_id, see list of recognized fields.`

But the search is not failing and returns the results, so we can search by it. This super tiny PR fixes this warning.

<img width="1118" height="68" alt="image" src="https://github.com/user-attachments/assets/7c3f34ec-58b8-4451-bf3a-a854a6e1e39e" />

