### PR TITLE
Fix for update command broken due to missing search params. leading t…

### DIFF
--- a/vast.py
+++ b/vast.py
@@ -5454,7 +5454,9 @@ def update__workergroup(args):
         query = ""
     else:
         query = " verified=True rentable=True rented=False"
-    json_blob = {"client_id": "me", "autojob_id": args.id, "min_load": args.min_load, "target_util": args.target_util, "cold_mult": args.cold_mult, "test_workers" : args.test_workers, "template_hash": args.template_hash, "template_id": args.template_id, "search_params": args.search_params + query, "launch_args": args.launch_args, "gpu_ram": args.gpu_ram, "endpoint_name": args.endpoint_name, "endpoint_id": args.endpoint_id}
+    if args.search_params is not None:
+        query = args.search_params + query
+    json_blob = {"client_id": "me", "autojob_id": args.id, "min_load": args.min_load, "target_util": args.target_util, "cold_mult": args.cold_mult, "test_workers" : args.test_workers, "template_hash": args.template_hash, "template_id": args.template_id, "search_params": query, "launch_args": args.launch_args, "gpu_ram": args.gpu_ram, "endpoint_name": args.endpoint_name, "endpoint_id": args.endpoint_id}
     if (args.explain):
         print("request json: ")
         print(json_blob)


### PR DESCRIPTION
Fix for update command broken due to missing search params. leading to None+str error. This fix checks if the user has the search_params or not other defaults to query instead. 

<img width="1249" height="55" alt="Screenshot from 2025-08-19 09-49-27" src="https://github.com/user-attachments/assets/c57741ea-eacd-4674-877e-ff5c26521717" />
