### PR TITLE
API docs: Update search offers example

### DIFF
--- a/openapi/yaml/combined_api.yaml
+++ b/openapi/yaml/combined_api.yaml
@@ -5541,13 +5541,8 @@ paths:
         | `nin`    | Value is not in a list | `{ "nin": ["TW", "SE"] }`      |
 
 
-        Default filters applied unless --no-default:
-
-        - verified: true
-
-        - rentable: true
-
-        - rented: false
+        Default filters: verified=true, rentable=true, rented=false (unless --no-default
+        is used)
 
 
         CLI Usage: `vastai search offers ''reliability > 0.99 num_gpus>=4'' --order=dph_total`'

--- a/openapi/yaml/search_offers.yaml
+++ b/openapi/yaml/search_offers.yaml
@@ -28,10 +28,7 @@ paths:
         | `in`     | Value is in a list     | `{ "in": ["RTX_3090", "RTX_4090"] }` |
         | `nin`    | Value is not in a list | `{ "nin": ["TW", "SE"] }`      |
 
-        Default filters applied unless --no-default:
-        - verified: true
-        - rentable: true
-        - rented: false
+        Default filters: verified=true, rentable=true, rented=false (unless --no-default is used)
 
         CLI Usage: `vastai search offers 'reliability > 0.99 num_gpus>=4' --order=dph_total`
       requestBody:


### PR DESCRIPTION
- Corrected the 'order' parameter example in the search offers endpoint to use a valid array-of-arrays format (e.g., [["reliability", "desc"]]).
- Removed bearer token auth  