### PR TITLE
make serverless code need serverless reviewers, add deprecation notice

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,12 @@
 # All files, default reviewers:
-*       @stackanthony @kristopolous 
+
+# Serverless and related code requires review from the serverless team:
+/vastai/serverless/                 @vast-ai/serverless
+/vastai/api/deployments.py          @vast-ai/serverless
+/vastai/api/endpoints.py            @vast-ai/serverless
+/vastai/data/deployment.py          @vast-ai/serverless
+/vastai/data/endpoint.py            @vast-ai/serverless
+/vastai/data/workergroup.py         @vast-ai/serverless
+/vastai/cli/commands/endpoints.py   @vast-ai/serverless
+/vastai/cli/commands/deployments.py @vast-ai/serverless
+/tests/serverless/                  @vast-ai/serverless

--- a/sdk-wrapper/README.md
+++ b/sdk-wrapper/README.md
@@ -25,9 +25,19 @@ vast = VastAI()
 
 ## SDK Usage
 
+Both of these work identically:
 ```python
 from vastai_sdk import VastAI
+from vastai import VastAI
+```
 
+Both of these also work identically:
+```python
+from vastai import Serverless
+from vastai_sdk.serverless.client.client import Serverless
+```
+
+```python
 vast = VastAI()
 
 vast.search_offers(query='gpu_name=RTX_4090 num_gpus>=4')
@@ -42,7 +52,7 @@ Use `help(vast.search_offers)` to view documentation for any method.
 
 1. Create the client
 ```python
-from vastai_sdk.serverless.client.client import Serverless
+from vastai import Serverless
 serverless = Serverless() # or, Serverless("YOUR_API_KEY")
 ```
 2. Get an endpoint

--- a/sdk-wrapper/README.md
+++ b/sdk-wrapper/README.md
@@ -1,32 +1,72 @@
-# vastai-sdk
+# Vast.ai Python SDK
 
-This package is a thin compatibility wrapper around the [`vastai`](https://pypi.org/project/vastai/) package.
+> **This package is deprecated.** It has been merged into [vast-ai/vast-cli](https://github.com/vast-ai/vast-cli). `pip install vastai` now installs both the SDK and CLI in a single package. `pip install vastai-sdk` still works and installs the same package. For issues and PRs, go to [vast-ai/vast-cli](https://github.com/vast-ai/vast-cli).
 
-All code now lives in the `vastai` package. This wrapper allows existing code that does `import vastai_sdk` or `from vastai_sdk import ...` to continue working without changes.
-
-## Installation
+## Install
 
 ```bash
 pip install vastai-sdk
 ```
 
-This will automatically install the `vastai` package as a dependency.
+## Quickstart
 
-## Usage
+1. Get your API key from [https://cloud.vast.ai/manage-keys/](https://cloud.vast.ai/manage-keys/)
+
+2. Set your API key:
+```python
+from vastai_sdk import VastAI
+vast = VastAI(api_key="YOUR_API_KEY")
+```
+
+Or set the `VAST_API_KEY` environment variable and just use:
+```python
+vast = VastAI()
+```
+
+## SDK Usage
 
 ```python
-# Both of these work identically:
-from vastai import VastAI
 from vastai_sdk import VastAI
 
-# Submodule imports also work:
+vast = VastAI()
+
+vast.search_offers(query='gpu_name=RTX_4090 num_gpus>=4')
+vast.show_instances()
+vast.start_instance(id=12345)
+vast.stop_instance(id=12345)
+```
+
+Use `help(vast.search_offers)` to view documentation for any method.
+
+## Using the Serverless Client
+
+1. Create the client
+```python
 from vastai_sdk.serverless.client.client import Serverless
+serverless = Serverless() # or, Serverless("YOUR_API_KEY")
+```
+2. Get an endpoint
+```python
+endpoint = await serverless.get_endpoint("my-endpoint")
+```
+3. Make a request
+```python
+request_body = {
+    "model": "Qwen/Qwen3-8B",
+    "prompt" : "Who are you?",
+    "max_tokens" : 100,
+    "temperature" : 0.7
+}
+response = await serverless.request("/v1/completions", request_body)
+```
+4. Read the response
+```python
+text = response["response"]["choices"][0]["text"]
+print(text)
 ```
 
-## Migration
+Find more examples in the `examples/` directory.
 
-If you are starting a new project, use `vastai` directly:
+## Contributing
 
-```bash
-pip install vastai
-```
+This repo is deprecated. For issues, PRs, and documentation, go to [vast-ai/vast-cli](https://github.com/vast-ai/vast-cli).

--- a/sdk-wrapper/pyproject.toml
+++ b/sdk-wrapper/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "vastai-sdk"
 version = "0.0.0"
-description = "Vast.ai SDK - installs the vastai package (CLI + SDK + Serverless)"
+description = "DEPRECATED — use 'pip install vastai' instead. This package is a compatibility wrapper that installs vastai."
 readme = "README.md"
 authors = [
   "Chris McKenzie <chris@vast.ai>",


### PR DESCRIPTION
mark vastai-sdk package description and readme as deprecated

updates the vastai-sdk package description and readme to mark it as deprecated. users should now use `pip install vastai` which includes both the cli and sdk.