### PR TITLE
Feature/execution time metrics cli

### DIFF
--- a/tests/serverless/test_pyworker_metrics.py
+++ b/tests/serverless/test_pyworker_metrics.py
@@ -681,8 +681,9 @@ class TestSendDeleteRequestsAndReset:
         assert mock_session.post.call_count == 1
         assert mock_session.post.call_args[0][0] == "http://internal.report/delete_requests/"
         sent = mock_session.post.call_args[1]["json"]
-        assert sent["request_idxs"] == [1]
-        assert sent["success"] is True
+        assert len(sent["requests"]) == 1
+        assert sent["requests"][0]["request_idx"] == 1
+        assert sent["requests"][0]["success"] is True
         assert m.model_metrics.requests_deleting == []
 
     async def test_delete_requests_noop_when_queue_empty(self, make_pyworker_metrics) -> None:
@@ -708,15 +709,15 @@ class TestSendDeleteRequestsAndReset:
         self, make_pyworker_metrics, make_metrics_aiohttp_post, metrics_delete_send_context, make_pyworker_request_metrics
     ) -> None:
         """
-        Verifies failed-only snapshot triggers POST with success=false payload.
+        Verifies failed-only snapshot triggers POST with per-request success=false.
 
         This test verifies by:
         1. Queuing only RequestMetrics with success False
         2. Mocking HTTP success
-        3. Asserting a single POST with success False and request_idxs
+        3. Asserting a single POST with the request's success flag set to False
 
         Assumptions:
-        - sent_success stays True when success_idxs is empty; sent_failed runs post
+        - A single POST is made containing all requests with their individual success flags
         """
         m = make_pyworker_metrics()
         req_bad = make_pyworker_request_metrics(
@@ -734,22 +735,23 @@ class TestSendDeleteRequestsAndReset:
 
         assert mock_session.post.call_count == 1
         sent = mock_session.post.call_args[1]["json"]
-        assert sent["request_idxs"] == [9]
-        assert sent["success"] is False
+        assert len(sent["requests"]) == 1
+        assert sent["requests"][0]["request_idx"] == 9
+        assert sent["requests"][0]["success"] is False
         assert m.model_metrics.requests_deleting == []
 
-    async def test_delete_requests_posts_success_and_failure_batches_separately(
+    async def test_delete_requests_posts_success_and_failure_in_single_batch(
         self, make_pyworker_metrics, make_metrics_aiohttp_post, metrics_delete_send_context, make_pyworker_request_metrics
     ) -> None:
         """
-        Verifies mixed success/failure snapshot results in two POST calls per report host.
+        Verifies mixed success/failure snapshot results in a single POST with per-request success flags.
 
         This test verifies by:
         1. Queuing one succeeded and one failed request
-        2. Asserting two post calls with distinct success flags and idx lists
+        2. Asserting a single POST with both requests and their individual success flags
 
         Assumptions:
-        - Line 210 and 213 both execute when both idx lists are non-empty
+        - All requests are sent in one batch with per-request success/status fields
         """
         m = make_pyworker_metrics()
         req_ok = make_pyworker_request_metrics(
@@ -772,11 +774,12 @@ class TestSendDeleteRequestsAndReset:
         with metrics_delete_send_context(m, mock_session):
             await m._Metrics__send_delete_requests_and_reset()
 
-        assert mock_session.post.call_count == 2
-        first = mock_session.post.call_args_list[0][1]["json"]
-        second = mock_session.post.call_args_list[1][1]["json"]
-        assert first["success"] is True and first["request_idxs"] == [1]
-        assert second["success"] is False and second["request_idxs"] == [2]
+        assert mock_session.post.call_count == 1
+        sent = mock_session.post.call_args[1]["json"]
+        assert len(sent["requests"]) == 2
+        by_idx = {r["request_idx"]: r for r in sent["requests"]}
+        assert by_idx[1]["success"] is True
+        assert by_idx[2]["success"] is False
         assert m.model_metrics.requests_deleting == []
 
     async def test_delete_requests_retries_after_timeout_then_succeeds(

--- a/vastai/serverless/server/lib/backend.py
+++ b/vastai/serverless/server/lib/backend.py
@@ -308,6 +308,7 @@ class Backend:
             workload=auth_data.get("cost"),
             status="SessionActive",
             is_session=True,
+            entered_queue_at=time.time(),
         )
 
         async with self._sessions_lock:
@@ -443,6 +444,7 @@ class Backend:
             reqnum=auth_data.reqnum,
             workload=workload,
             status="Created",
+            entered_queue_at=time.time(),
         )
 
         event = asyncio.Event()
@@ -475,6 +477,7 @@ class Backend:
                         pass
 
         async def make_request() -> Union[web.Response, web.StreamResponse]:
+            request_metrics.work_started_at = time.time()
             try:
                 if handler.remote_function:
                     # Remote dispatch: return JSON directly, bypassing the

--- a/vastai/serverless/server/lib/data_types.py
+++ b/vastai/serverless/server/lib/data_types.py
@@ -217,6 +217,9 @@ class RequestMetrics:
     is_session: bool = False
     session: Session = None
     session_reqnum: Optional[int] = None
+    entered_queue_at: float = 0.0
+    work_started_at: float = 0.0
+    work_completed_at: float = 0.0
 
 
 @dataclass

--- a/vastai/serverless/server/lib/metrics.py
+++ b/vastai/serverless/server/lib/metrics.py
@@ -97,6 +97,7 @@ class Metrics:
         this function is called after a response from model API is received and forwarded.
         """
         log.debug(f"{self._request_id(request)} succeeded")
+        request.work_completed_at = time.time()
         self.model_metrics.workload_served += request.workload
         request.status = "Success"
         request.success = True
@@ -107,6 +108,7 @@ class Metrics:
         this function is called if model API returns an error
         """
         log.error(f"{self._request_id(request)} errored: {message}")
+        request.work_completed_at = time.time()
         self.model_metrics.workload_errored += request.workload
         request.status = "Error"
         request.success = False
@@ -169,15 +171,14 @@ class Metrics:
     #######################################Private#######################################
 
     async def __send_delete_requests_and_reset(self):
-        async def post(report_addr: str, idxs: list[int], success_flag: bool) -> bool:
+        async def post(report_addr: str, requests: list[dict]) -> bool:
             data = {
                 "worker_id": self.id,
                 "mtoken": self.mtoken,
-                "request_idxs": idxs,
-                "success": success_flag,
+                "requests": requests,
             }
             log.debug(
-                f"Deleting requests that {'succeeded' if success_flag else 'failed'}: {data['request_idxs']}"
+                f"Deleting requests: {[r['request_idx'] for r in requests]}"
             )
             full_path = report_addr.rstrip("/") + "/delete_requests/"
             for attempt in range(1, 4):
@@ -198,28 +199,33 @@ class Metrics:
         # Take a snapshot of what we plan to send this tick.
         # New arrivals after this snapshot will remain in the queue for the next tick.
         snapshot = list(self.model_metrics.requests_deleting)
-        success_idxs = [r.request_idx for r in snapshot if r.success is True]
-        failed_idxs  = [r.request_idx for r in snapshot if r.success is False]
 
-        if not success_idxs and not failed_idxs:
+        if not snapshot:
             return  # nothing to do
+
+        requests_payload = [
+            {
+                "request_idx": r.request_idx,
+                "success": r.success,
+                "status": r.status,
+                "entered_queue_at": r.entered_queue_at,
+                "work_started_at": r.work_started_at,
+                "work_completed_at": r.work_completed_at,
+            }
+            for r in snapshot
+        ]
 
         for report_addr in self.report_addr:
             # TODO: Add a Redis subscriber queue for delete_requests
             if report_addr == "https://cloud.vast.ai/api/v0":
                 # Patch: ignore the Redis API report_addr
                 continue
-            sent_success = True
-            sent_failed  = True
 
-            if success_idxs:
-                sent_success = await post(report_addr, success_idxs, True)
-            if failed_idxs:
-                sent_failed = await post(report_addr, failed_idxs, False)
+            sent = await post(report_addr, requests_payload)
 
-            if sent_success and sent_failed:
+            if sent:
                 # Remove only the items we actually sent from the live queue.
-                sent_set = set(success_idxs) | set(failed_idxs)
+                sent_set = {r.request_idx for r in snapshot}
                 self.model_metrics.requests_deleting[:] = [
                     r for r in self.model_metrics.requests_deleting
                     if r.request_idx not in sent_set


### PR DESCRIPTION
Summary

Adds entered_queue_at, work_started_at, and
work_completed_at timestamp fields to RequestMetrics
to track the full lifecycle of each request
Timestamps are recorded when a request enters the
queue, when work begins on it, and when it completes
(success or error)
Refactors the delete_requests reporting to send
per-request metadata (including timing and status)
in a single payload instead of splitting into
separate success/failed batch calls
Test plan

Verify requests report correct entered_queue_at,
work_started_at, and work_completed_at timestamps
Confirm the /delete_requests/ endpoint receives
the new payload format with per-request objects
Ensure session and non-session request paths both
populate timing fields
Check that failed requests also get
work_completed_at set