### PR TITLE
fix create instance raw output

### DIFF
--- a/vastai/cli/commands/instances.py
+++ b/vastai/cli/commands/instances.py
@@ -1176,8 +1176,7 @@ def show__instances_v1(args):
         page       += 1
 
         if args.raw:
-            print(json.dumps(data, indent=1))
-            return
+            return data
 
         if args.quiet:
             for inst in instances:

--- a/vastai/cli/commands/instances.py
+++ b/vastai/cli/commands/instances.py
@@ -288,7 +288,9 @@ _create_instance_args = [
 )
 def create__instance(args):
     """Create an instance from an offer ID."""
-    create_instance_impl(args.id, args)
+    rj = create_instance_impl(args.id, args)
+    if args.raw:
+        return rj
 
 
 @parser.command(


### PR DESCRIPTION
fix for this issue. `--raw` not returning json output for create instance
https://github.com/vast-ai/vast-cli/issues/359

```
(venv) vast-sf /vast-cli$ vastai create instance 33071800 --image pytorch/pytorch --disk 10 --raw
{
 "instance_api_key": "5f6b00960b7c4aebc6841e1d67b9142c946cb84ab7cb14802162ed7a0732c1ad",
 "new_contract": 34935008,
 "success": true
}
```