### PR TITLE
docs: add agent entry points — CLAUDE.md, README, --help, OpenAPI Key Quirks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# vast-ai/vast-cli
+
+CLI and SDK for the Vast.ai GPU cloud marketplace.
+
+## AI Agents
+
+- **Using the CLI in an agent task?** Read [`vastai/SKILL.md`](vastai/SKILL.md) — install, auth, commands, common errors, and API quirks.
+- **Writing Python code with the SDK?** Read [`vastai_sdk/SKILL.md`](vastai_sdk/SKILL.md) — VastAI class, SyncClient, AsyncClient, Serverless.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ Or for a single session:
 eval "$(register-python-argcomplete vastai)"
 ```
 
+## AI Agents
+
+Vast.ai has a skill for AI coding agents (Claude Code, Cursor, Windsurf, Codex, etc.):
+
+```bash
+npx skills add vast-ai/vast-cli
+```
+
+This installs the Vast.ai skill so your agent can search offers, create instances, and manage GPU workflows directly. See [CLI SKILL.md](vastai/SKILL.md) or [SDK SKILL.md](vastai_sdk/SKILL.md) for the full reference.
+
 ## Contributing
 
 This [repository](https://github.com/vast-ai/vast-cli) is open source. If you find a bug, please [open an issue](https://github.com/vast-ai/vast-cli/issues). PRs are welcome.

--- a/openapi/combine_api_yamls.py
+++ b/openapi/combine_api_yamls.py
@@ -53,7 +53,23 @@ def combine_yaml_files(directory):
         'openapi': '3.1.0',
         'info': {
             'title': 'Vast.ai API',
-            'description': 'Welcome to Vast.ai \'s API documentation. Our API allows you to programmatically manage GPU instances, handle machine operations, and automate your AI/ML workflow. Whether you\'re running individual GPU instances or managing a fleet of machines, our API provides comprehensive control over all Vast.ai  platform features.',
+            'description': (
+                "Vast.ai REST API for managing GPU cloud instances, machine operations, and AI/ML workflows.\n\n"
+                "## AI Agent Quick-Start\n\n"
+                "Install the CLI skill for your agent (Claude Code, Cursor, Windsurf, etc.):\n"
+                "  npx skills add vast-ai/vast-cli\n\n"
+                "CLI reference: https://raw.githubusercontent.com/vast-ai/vast-cli/master/vastai/SKILL.md\n"
+                "SDK reference: https://raw.githubusercontent.com/vast-ai/vast-cli/master/vastai_sdk/SKILL.md\n\n"
+                "## Auth\n"
+                "All endpoints require `Authorization: Bearer $VAST_API_KEY`.\n"
+                "Get your key at: https://cloud.vast.ai/manage-keys/\n\n"
+                "## Key Quirks\n"
+                "- `gpu_ram` in CLI = GB; in REST API = MB (CLI auto-converts)\n"
+                "- `GET /api/v0/instances/` returns an object keyed by instance ID, not an array\n"
+                "- `PUT /users/me/` is unsupported -- use `GET /users/current/` to get numeric ID, then `PUT /users/{id}/`\n"
+                "- SSH keys must be registered BEFORE creating an instance (VM: no recovery; Docker: can add post-create)\n"
+                "- `onstart` field is limited to 4048 characters -- gzip+base64 for longer scripts"
+            ),
             'version': '1.0.0',
             'contact': {
                 'name': 'Vast.ai Support',

--- a/openapi/combine_api_yamls.py
+++ b/openapi/combine_api_yamls.py
@@ -65,10 +65,10 @@ def combine_yaml_files(directory):
                 "Get your key at: https://cloud.vast.ai/manage-keys/\n\n"
                 "## Key Quirks\n"
                 "- `gpu_ram` in CLI = GB; in REST API = MB (CLI auto-converts)\n"
-                "- `GET /api/v0/instances/` returns an object keyed by instance ID, not an array\n"
-                "- `PUT /users/me/` is unsupported -- use `GET /users/current/` to get numeric ID, then `PUT /users/{id}/`\n"
                 "- SSH keys must be registered BEFORE creating an instance (VM: no recovery; Docker: can add post-create)\n"
-                "- `onstart` field is limited to 4048 characters -- gzip+base64 for longer scripts"
+                "- `onstart` field is limited to 4048 characters -- gzip+base64 for longer scripts\n"
+                "- `POST /api/v0/asks/{id}/` (create instance) returns `new_contract` as the instance ID, not `id`\n"
+                "- Poll trap: if `actual_status` becomes `exited`, `unknown`, or `offline` it will never reach `running` -- destroy and retry"
             ),
             'version': '1.0.0',
             'contact': {

--- a/openapi/yaml/combined_api.yaml
+++ b/openapi/yaml/combined_api.yaml
@@ -8,12 +8,12 @@ info:
     SDK reference: https://raw.githubusercontent.com/vast-ai/vast-cli/master/vastai_sdk/SKILL.md\n\
     \n## Auth\nAll endpoints require `Authorization: Bearer $VAST_API_KEY`.\nGet your\
     \ key at: https://cloud.vast.ai/manage-keys/\n\n## Key Quirks\n- `gpu_ram` in\
-    \ CLI = GB; in REST API = MB (CLI auto-converts)\n- `GET /api/v0/instances/` returns\
-    \ an object keyed by instance ID, not an array\n- `PUT /users/me/` is unsupported\
-    \ -- use `GET /users/current/` to get numeric ID, then `PUT /users/{id}/`\n- SSH\
-    \ keys must be registered BEFORE creating an instance (VM: no recovery; Docker:\
-    \ can add post-create)\n- `onstart` field is limited to 4048 characters -- gzip+base64\
-    \ for longer scripts"
+    \ CLI = GB; in REST API = MB (CLI auto-converts)\n- SSH keys must be registered\
+    \ BEFORE creating an instance (VM: no recovery; Docker: can add post-create)\n\
+    - `onstart` field is limited to 4048 characters -- gzip+base64 for longer scripts\n\
+    - `POST /api/v0/asks/{id}/` (create instance) returns `new_contract` as the instance\
+    \ ID, not `id`\n- Poll trap: if `actual_status` becomes `exited`, `unknown`, or\
+    \ `offline` it will never reach `running` -- destroy and retry"
   version: 1.0.0
   contact:
     name: Vast.ai Support

--- a/openapi/yaml/combined_api.yaml
+++ b/openapi/yaml/combined_api.yaml
@@ -1,10 +1,19 @@
 openapi: 3.1.0
 info:
   title: Vast.ai API
-  description: Welcome to Vast.ai 's API documentation. Our API allows you to programmatically
-    manage GPU instances, handle machine operations, and automate your AI/ML workflow.
-    Whether you're running individual GPU instances or managing a fleet of machines,
-    our API provides comprehensive control over all Vast.ai  platform features.
+  description: "Vast.ai REST API for managing GPU cloud instances, machine operations,\
+    \ and AI/ML workflows.\n\n## AI Agent Quick-Start\n\nInstall the CLI skill for\
+    \ your agent (Claude Code, Cursor, Windsurf, etc.):\n  npx skills add vast-ai/vast-cli\n\
+    \nCLI reference: https://raw.githubusercontent.com/vast-ai/vast-cli/master/vastai/SKILL.md\n\
+    SDK reference: https://raw.githubusercontent.com/vast-ai/vast-cli/master/vastai_sdk/SKILL.md\n\
+    \n## Auth\nAll endpoints require `Authorization: Bearer $VAST_API_KEY`.\nGet your\
+    \ key at: https://cloud.vast.ai/manage-keys/\n\n## Key Quirks\n- `gpu_ram` in\
+    \ CLI = GB; in REST API = MB (CLI auto-converts)\n- `GET /api/v0/instances/` returns\
+    \ an object keyed by instance ID, not an array\n- `PUT /users/me/` is unsupported\
+    \ -- use `GET /users/current/` to get numeric ID, then `PUT /users/{id}/`\n- SSH\
+    \ keys must be registered BEFORE creating an instance (VM: no recovery; Docker:\
+    \ can add post-create)\n- `onstart` field is limited to 4048 characters -- gzip+base64\
+    \ for longer scripts"
   version: 1.0.0
   contact:
     name: Vast.ai Support

--- a/vast.py
+++ b/vast.py
@@ -552,7 +552,7 @@ class MyWideHelpFormatter(argparse.RawTextHelpFormatter):
 
 
 parser = apwrap(
-    epilog="Use 'vast COMMAND --help' for more info about a command. AI agent? See https://github.com/vast-ai/vast-cli/blob/master/vastai/SKILL.md",
+    epilog="Use 'vast COMMAND --help' for more info about a command. AI agent? See https://raw.githubusercontent.com/vast-ai/vast-cli/master/vastai/SKILL.md",
     formatter_class=MyWideHelpFormatter
 )
 

--- a/vast.py
+++ b/vast.py
@@ -552,7 +552,7 @@ class MyWideHelpFormatter(argparse.RawTextHelpFormatter):
 
 
 parser = apwrap(
-    epilog="Use 'vast COMMAND --help' for more info about a command",
+    epilog="Use 'vast COMMAND --help' for more info about a command. AI agent? See https://github.com/vast-ai/vast-cli/blob/master/vastai/SKILL.md",
     formatter_class=MyWideHelpFormatter
 )
 

--- a/vastai/SKILL.md
+++ b/vastai/SKILL.md
@@ -27,7 +27,7 @@ chmod +x vast
 ## Quick start
 
 ```bash
-vastai set api-key <YOUR_API_KEY>                   # Authenticate (one-time); Create API Key in account at https://console.vast.ai/cli
+vastai set api-key <YOUR_API_KEY>                   # Authenticate (one-time); Create API Key in account at https://console.vast.ai/manage-keys/
 vastai show user                                    # Verify auth + check balance
 vastai create ssh-key ~/.ssh/id_ed25519.pub         # Register SSH key (do BEFORE create)
 vastai search offers 'gpu_name=RTX_4090 num_gpus=1 verified=true direct_port_count>=1 rentable=true' -o 'dlperf_usd-'
@@ -40,7 +40,7 @@ vastai copy local:./data/ <INSTANCE_ID>:/workspace/ # Upload files
 vastai destroy instance <INSTANCE_ID> -y             # Clean up (stops all billing; -y skips confirmation)
 ```
 
-API key: https://console.vast.ai/cli
+API key: https://console.vast.ai/manage-keys/
 
 ## Global flags
 
@@ -340,7 +340,7 @@ vastai unlist machine <id>                               # Remove from marketpla
 ```
 https://console.vast.ai/instances/   # Your instances
 https://console.vast.ai/create/      # Search GPU offers
-https://console.vast.ai/cli          # Create and manage API keys
+https://console.vast.ai/manage-keys/ # Create and manage API keys
 https://cloud.vast.ai/billing/       # Billing
 ```
 

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -34,7 +34,7 @@ def _emit_error(args, status_code, message):
 
 # Create the global parser instance
 parser = apwrap(
-    epilog="Use 'vast COMMAND --help' for more info about a command",
+    epilog="Use 'vast COMMAND --help' for more info about a command. AI agent? See https://raw.githubusercontent.com/vast-ai/vast-cli/master/vastai/SKILL.md",
     formatter_class=MyWideHelpFormatter
 )
 


### PR DESCRIPTION
## Summary

- `CLAUDE.md` — new file at repo root routing agents to `vastai/SKILL.md` (CLI) and `vastai_sdk/SKILL.md` (SDK)
- `README.md` — adds `## AI Agents` section with `npx skills add vast-ai/vast-cli` install command (also covers PyPI surface)
- `vast.py` — extends root `--help` epilog with a pointer to `vastai/SKILL.md`

## Note

Hold on merge until `npx skills add vast-ai/vast-cli` is verified to correctly resolve `vastai/SKILL.md` and `vastai_sdk/SKILL.md` from subdirectories (not repo root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)