### PR TITLE
fix: clean up entered queue at that is no longer needed

### DIFF
--- a/vastai/serverless/server/lib/backend.py
+++ b/vastai/serverless/server/lib/backend.py
@@ -308,7 +308,6 @@ class Backend:
             workload=auth_data.get("cost"),
             status="SessionActive",
             is_session=True,
-            entered_queue_at=time.time(),
         )
 
         async with self._sessions_lock:
@@ -444,7 +443,6 @@ class Backend:
             reqnum=auth_data.reqnum,
             workload=workload,
             status="Created",
-            entered_queue_at=time.time(),
         )
 
         event = asyncio.Event()

--- a/vastai/serverless/server/lib/data_types.py
+++ b/vastai/serverless/server/lib/data_types.py
@@ -217,7 +217,6 @@ class RequestMetrics:
     is_session: bool = False
     session: Session = None
     session_reqnum: Optional[int] = None
-    entered_queue_at: float = 0.0
     work_started_at: float = 0.0
     work_completed_at: float = 0.0
 

--- a/vastai/serverless/server/lib/metrics.py
+++ b/vastai/serverless/server/lib/metrics.py
@@ -208,7 +208,6 @@ class Metrics:
                 "request_idx": r.request_idx,
                 "success": r.success,
                 "status": r.status,
-                "entered_queue_at": r.entered_queue_at,
                 "work_started_at": r.work_started_at,
                 "work_completed_at": r.work_completed_at,
             }


### PR DESCRIPTION
## Summary
- Remove the `entered_queue_at` field from the `RequestMetrics` dataclass
- Stop sending `entered_queue_at` in the delete_requests payload to the autoscaler
- Drop the two `entered_queue_at=time.time()` kwargs in the request constructor calls

The field is no longer read by the autoscaler. Queue time metrics are computed
from `created_at` (set autoscaler-side when the request first arrives) and
`work_started_at`, so `entered_queue_at` was redundant on the wire and unused
downstream.

## Test plan
- [ ] Verify pyworker still serializes delete_requests payloads correctly
- [ ] Verify autoscaler accepts the trimmed payload without errors
- [ ] Confirm queue time metrics in Prometheus continue to populate
