### PR TITLE
feat: vastai wait instance — blocking instance status command (CLN-3213)

### DIFF
--- a/openapi/yaml/combined_api.yaml
+++ b/openapi/yaml/combined_api.yaml
@@ -7080,15 +7080,59 @@ paths:
                         actual_status:
                           type: string
                           nullable: true
+                          enum:
+                          - loading
+                          - running
+                          - stopped
+                          - frozen
+                          - exited
+                          - rebooting
+                          - unknown
+                          - offline
+                          description: "Current status of the instance container.\
+                            \ `null` while provisioning.\n\n- `loading` \u2014 Docker\
+                            \ image downloading or container starting up.\n- `running`\
+                            \ \u2014 Container executing. GPU charges apply.\n- `stopped`\
+                            \ \u2014 Container halted. Disk charges continue; no GPU\
+                            \ charges.\n- `frozen` \u2014 Container paused with memory\
+                            \ preserved. GPU charges apply.\n- `exited` \u2014 Container\
+                            \ process exited unexpectedly.\n- `rebooting` \u2014 Container\
+                            \ restarting (transient).\n- `unknown` \u2014 No recent\
+                            \ heartbeat from the host.\n- `offline` \u2014 Host machine\
+                            \ disconnected from Vast servers (computed, not stored).\n"
                           example: running
                         cur_state:
                           type: string
+                          enum:
+                          - running
+                          - stopped
+                          - unloaded
+                          description: "Current state of the machine contract (hardware\
+                            \ allocation).\n\n- `running` \u2014 Allocation active.\n\
+                            - `stopped` \u2014 Allocation paused.\n- `unloaded` \u2014\
+                            \ Allocation released (instance destroyed).\n"
                           example: running
                         next_state:
                           type: string
+                          enum:
+                          - running
+                          - stopped
+                          - unloaded
+                          description: "Target state for the machine contract. The\
+                            \ daemon transitions `cur_state` toward this value.\n\n\
+                            - `running` \u2014 Should be active.\n- `stopped` \u2014\
+                            \ Should be paused.\n- `unloaded` \u2014 Should be released.\n"
                           example: running
                         intended_status:
                           type: string
+                          enum:
+                          - running
+                          - stopped
+                          - frozen
+                          description: "User's desired target state for the container.\n\
+                            \n- `running` \u2014 Should be executing.\n- `stopped`\
+                            \ \u2014 Should be halted.\n- `frozen` \u2014 Should be\
+                            \ paused with memory preserved.\n"
                           example: running
                         label:
                           type: string
@@ -7562,15 +7606,59 @@ paths:
                         actual_status:
                           type: string
                           nullable: true
+                          enum:
+                          - loading
+                          - running
+                          - stopped
+                          - frozen
+                          - exited
+                          - rebooting
+                          - unknown
+                          - offline
+                          description: "Current status of the instance container.\
+                            \ `null` while provisioning.\n\n- `loading` \u2014 Docker\
+                            \ image downloading or container starting up.\n- `running`\
+                            \ \u2014 Container executing. GPU charges apply.\n- `stopped`\
+                            \ \u2014 Container halted. Disk charges continue; no GPU\
+                            \ charges.\n- `frozen` \u2014 Container paused with memory\
+                            \ preserved. GPU charges apply.\n- `exited` \u2014 Container\
+                            \ process exited unexpectedly.\n- `rebooting` \u2014 Container\
+                            \ restarting (transient).\n- `unknown` \u2014 No recent\
+                            \ heartbeat from the host.\n- `offline` \u2014 Host machine\
+                            \ disconnected from Vast servers (computed, not stored).\n"
                           example: running
                         cur_state:
                           type: string
+                          enum:
+                          - running
+                          - stopped
+                          - unloaded
+                          description: "Current state of the machine contract (hardware\
+                            \ allocation).\n\n- `running` \u2014 Allocation active.\n\
+                            - `stopped` \u2014 Allocation paused.\n- `unloaded` \u2014\
+                            \ Allocation released (instance destroyed).\n"
                           example: running
                         next_state:
                           type: string
+                          enum:
+                          - running
+                          - stopped
+                          - unloaded
+                          description: "Target state for the machine contract. The\
+                            \ daemon transitions `cur_state` toward this value.\n\n\
+                            - `running` \u2014 Should be active.\n- `stopped` \u2014\
+                            \ Should be paused.\n- `unloaded` \u2014 Should be released.\n"
                           example: running
                         intended_status:
                           type: string
+                          enum:
+                          - running
+                          - stopped
+                          - frozen
+                          description: "User's desired target state for the container.\n\
+                            \n- `running` \u2014 Should be executing.\n- `stopped`\
+                            \ \u2014 Should be halted.\n- `frozen` \u2014 Should be\
+                            \ paused with memory preserved.\n"
                           example: running
                         label:
                           type: string
@@ -9081,19 +9169,61 @@ components:
         actual_status:
           type: string
           nullable: true
-          description: Current status of the instance container.
+          enum:
+          - loading
+          - running
+          - stopped
+          - frozen
+          - exited
+          - rebooting
+          - unknown
+          - offline
+          description: "Current status of the instance container. `null` while the\
+            \ instance is still being provisioned.\n\n- `loading` \u2014 Docker image\
+            \ is downloading or the container is starting up.\n- `running` \u2014\
+            \ Container is actively executing. GPU charges apply.\n- `stopped` \u2014\
+            \ Container is halted. Disk charges continue; no GPU charges.\n- `frozen`\
+            \ \u2014 Container is paused with memory preserved. GPU charges apply.\n\
+            - `exited` \u2014 Container process exited unexpectedly.\n- `rebooting`\
+            \ \u2014 Container is restarting (transient).\n- `unknown` \u2014 Status\
+            \ cannot be determined; no recent heartbeat from the host.\n- `offline`\
+            \ \u2014 Machine hosting this instance has disconnected from Vast servers.\
+            \ Computed at query time; the underlying `actual_status` value in the\
+            \ database is preserved.\n"
           example: running
         intended_status:
           type: string
-          description: Intended status of the instance container.
+          enum:
+          - running
+          - stopped
+          - frozen
+          description: "The user's desired target state for the container. The system\
+            \ continuously works to reconcile `actual_status` with this value.\n\n\
+            - `running` \u2014 Container should be executing.\n- `stopped` \u2014\
+            \ Container should be halted.\n- `frozen` \u2014 Container should be paused\
+            \ with memory preserved.\n"
           example: running
         cur_state:
           type: string
-          description: Current state of the machine contract.
+          enum:
+          - running
+          - stopped
+          - unloaded
+          description: "Current state of the machine contract (the hardware allocation\
+            \ for this instance).\n\n- `running` \u2014 Allocation is active; hardware\
+            \ is in use.\n- `stopped` \u2014 Allocation is paused.\n- `unloaded` \u2014\
+            \ Allocation has been released (instance is destroyed).\n"
           example: running
         next_state:
           type: string
-          description: Next scheduled state for the machine contract.
+          enum:
+          - running
+          - stopped
+          - unloaded
+          description: "Target state for the machine contract. The daemon transitions\
+            \ `cur_state` toward this value.\n\n- `running` \u2014 Allocation should\
+            \ be active.\n- `stopped` \u2014 Allocation should be paused.\n- `unloaded`\
+            \ \u2014 Allocation should be released (set when destroying an instance).\n"
           example: running
         label:
           type: string

--- a/openapi/yaml/show_instance.yaml
+++ b/openapi/yaml/show_instance.yaml
@@ -91,19 +91,48 @@ components:
         actual_status:
           type: string
           nullable: true
-          description: Current status of the instance container.
+          enum: [loading, running, stopped, frozen, exited, rebooting, unknown, offline]
+          description: |
+            Current status of the instance container. `null` while the instance is still being provisioned.
+
+            - `loading` — Docker image is downloading or the container is starting up.
+            - `running` — Container is actively executing. GPU charges apply.
+            - `stopped` — Container is halted. Disk charges continue; no GPU charges.
+            - `frozen` — Container is paused with memory preserved. GPU charges apply.
+            - `exited` — Container process exited unexpectedly.
+            - `rebooting` — Container is restarting (transient).
+            - `unknown` — Status cannot be determined; no recent heartbeat from the host.
+            - `offline` — Machine hosting this instance has disconnected from Vast servers. Computed at query time; the underlying `actual_status` value in the database is preserved.
           example: running
         intended_status:
           type: string
-          description: Intended status of the instance container.
+          enum: [running, stopped, frozen]
+          description: |
+            The user's desired target state for the container. The system continuously works to reconcile `actual_status` with this value.
+
+            - `running` — Container should be executing.
+            - `stopped` — Container should be halted.
+            - `frozen` — Container should be paused with memory preserved.
           example: running
         cur_state:
           type: string
-          description: Current state of the machine contract.
+          enum: [running, stopped, unloaded]
+          description: |
+            Current state of the machine contract (the hardware allocation for this instance).
+
+            - `running` — Allocation is active; hardware is in use.
+            - `stopped` — Allocation is paused.
+            - `unloaded` — Allocation has been released (instance is destroyed).
           example: running
         next_state:
           type: string
-          description: Next scheduled state for the machine contract.
+          enum: [running, stopped, unloaded]
+          description: |
+            Target state for the machine contract. The daemon transitions `cur_state` toward this value.
+
+            - `running` — Allocation should be active.
+            - `stopped` — Allocation should be paused.
+            - `unloaded` — Allocation should be released (set when destroying an instance).
           example: running
         label:
           type: string

--- a/openapi/yaml/show_instances.yaml
+++ b/openapi/yaml/show_instances.yaml
@@ -44,15 +44,48 @@ paths:
                         actual_status:
                           type: string
                           nullable: true
+                          enum: [loading, running, stopped, frozen, exited, rebooting, unknown, offline]
+                          description: |
+                            Current status of the instance container. `null` while provisioning.
+
+                            - `loading` — Docker image downloading or container starting up.
+                            - `running` — Container executing. GPU charges apply.
+                            - `stopped` — Container halted. Disk charges continue; no GPU charges.
+                            - `frozen` — Container paused with memory preserved. GPU charges apply.
+                            - `exited` — Container process exited unexpectedly.
+                            - `rebooting` — Container restarting (transient).
+                            - `unknown` — No recent heartbeat from the host.
+                            - `offline` — Host machine disconnected from Vast servers (computed, not stored).
                           example: running
                         cur_state:
                           type: string
+                          enum: [running, stopped, unloaded]
+                          description: |
+                            Current state of the machine contract (hardware allocation).
+
+                            - `running` — Allocation active.
+                            - `stopped` — Allocation paused.
+                            - `unloaded` — Allocation released (instance destroyed).
                           example: running
                         next_state:
                           type: string
+                          enum: [running, stopped, unloaded]
+                          description: |
+                            Target state for the machine contract. The daemon transitions `cur_state` toward this value.
+
+                            - `running` — Should be active.
+                            - `stopped` — Should be paused.
+                            - `unloaded` — Should be released.
                           example: running
                         intended_status:
                           type: string
+                          enum: [running, stopped, frozen]
+                          description: |
+                            User's desired target state for the container.
+
+                            - `running` — Should be executing.
+                            - `stopped` — Should be halted.
+                            - `frozen` — Should be paused with memory preserved.
                           example: running
                         label:
                           type: string

--- a/openapi/yaml/show_instances_v1.yaml
+++ b/openapi/yaml/show_instances_v1.yaml
@@ -101,15 +101,48 @@ paths:
                         actual_status:
                           type: string
                           nullable: true
+                          enum: [loading, running, stopped, frozen, exited, rebooting, unknown, offline]
+                          description: |
+                            Current status of the instance container. `null` while provisioning.
+
+                            - `loading` — Docker image downloading or container starting up.
+                            - `running` — Container executing. GPU charges apply.
+                            - `stopped` — Container halted. Disk charges continue; no GPU charges.
+                            - `frozen` — Container paused with memory preserved. GPU charges apply.
+                            - `exited` — Container process exited unexpectedly.
+                            - `rebooting` — Container restarting (transient).
+                            - `unknown` — No recent heartbeat from the host.
+                            - `offline` — Host machine disconnected from Vast servers (computed, not stored).
                           example: running
                         cur_state:
                           type: string
+                          enum: [running, stopped, unloaded]
+                          description: |
+                            Current state of the machine contract (hardware allocation).
+
+                            - `running` — Allocation active.
+                            - `stopped` — Allocation paused.
+                            - `unloaded` — Allocation released (instance destroyed).
                           example: running
                         next_state:
                           type: string
+                          enum: [running, stopped, unloaded]
+                          description: |
+                            Target state for the machine contract. The daemon transitions `cur_state` toward this value.
+
+                            - `running` — Should be active.
+                            - `stopped` — Should be paused.
+                            - `unloaded` — Should be released.
                           example: running
                         intended_status:
                           type: string
+                          enum: [running, stopped, frozen]
+                          description: |
+                            User's desired target state for the container.
+
+                            - `running` — Should be executing.
+                            - `stopped` — Should be halted.
+                            - `frozen` — Should be paused with memory preserved.
                           example: running
                         label:
                           type: string

--- a/vast.py
+++ b/vast.py
@@ -2255,7 +2255,7 @@ def generate_ssh_key(auto_yes=False):
     argument("--cold_mult",   help="[NOTE: this field isn't currently used at the workergroup level]cold/stopped instance capacity target as multiple of hot capacity target (default 2.0)", type=float),
     argument("--cold_workers",   help="min number of workers to keep 'cold' for this workergroup", type=int),
     argument("--auto_instance", help=argparse.SUPPRESS, type=str, default="prod"),
-    usage="vastai workergroup create [OPTIONS]",
+    usage="vastai create workergroup [OPTIONS]",
     help="Create a new autoscale group",
     epilog=deindent("""
         Create a new autoscaling group to manage a pool of worker instances.
@@ -2578,7 +2578,7 @@ def create__subaccount(args):
 @parser.command(
     argument("--team-name", help="name of the team", type=str),
     argument("--transfer-credit", help="amount of personal credit to transfer to the new team", type=float, default=0),
-    usage="vastai create-team --team_name TEAM_NAME",
+    usage="vastai create team [OPTIONS]",
     help="Create a new team",
     epilog=deindent("""
          Creates a new team under your account. 
@@ -5689,7 +5689,30 @@ def create_rich_table_from_rows(rows, headers=None, title='', sort_key=None):
 @parser.command(
     argument("id", help="id of instance to get", type=int),
     usage="vastai show instance [--api-key API_KEY] [--raw]",
-    help="Display user's current instances"
+    help="Display user's current instances",
+    epilog=deindent("""
+        Returns an instance object. Key status fields:
+
+        **actual_status** — current container state:
+
+        | Value | Meaning |
+        |-------|---------|
+        | `null` | Instance is being provisioned |
+        | `loading` | Docker image is downloading or container is starting up |
+        | `running` | Container is actively executing. GPU charges apply. |
+        | `stopped` | Container is halted. Disk charges continue; no GPU charges. |
+        | `frozen` | Container is paused with memory preserved. GPU charges apply. |
+        | `exited` | Container process exited unexpectedly |
+        | `rebooting` | Container is restarting (transient) |
+        | `unknown` | No recent heartbeat from the host |
+        | `offline` | Host machine disconnected from Vast servers (computed, not stored in DB) |
+
+        **intended_status** — user's desired target state: `running`, `stopped`, or `frozen`.
+
+        **cur_state** — machine contract / hardware allocation state: `running`, `stopped`, or `unloaded` (released on destroy).
+
+        **status_msg** — human-readable detail on the current status.
+    """),
 )
 def show__instance(args):
     """
@@ -5717,7 +5740,30 @@ def show__instance(args):
 @parser.command(
     argument("-q", "--quiet", action="store_true", help="only display numeric ids"),
     usage="vastai show instances [OPTIONS] [--api-key API_KEY] [--raw]",
-    help="Display user's current instances"
+    help="Display user's current instances",
+    epilog=deindent("""
+        Returns a list of instance objects. Key status fields per instance:
+
+        **actual_status** — current container state:
+
+        | Value | Meaning |
+        |-------|---------|
+        | `null` | Instance is being provisioned |
+        | `loading` | Docker image is downloading or container is starting up |
+        | `running` | Container is actively executing. GPU charges apply. |
+        | `stopped` | Container is halted. Disk charges continue; no GPU charges. |
+        | `frozen` | Container is paused with memory preserved. GPU charges apply. |
+        | `exited` | Container process exited unexpectedly |
+        | `rebooting` | Container is restarting (transient) |
+        | `unknown` | No recent heartbeat from the host |
+        | `offline` | Host machine disconnected from Vast servers (computed, not stored in DB) |
+
+        **intended_status** — user's desired target state: `running`, `stopped`, or `frozen`.
+
+        **cur_state** — machine contract / hardware allocation state: `running`, `stopped`, or `unloaded` (released on destroy).
+
+        **status_msg** — human-readable detail on the current status.
+    """),
 )
 def show__instances(args = {}, extra = {}):
     """
@@ -6072,6 +6118,28 @@ def _build_filters_panel(filters):
     usage="vastai show instances-v1 [OPTIONS] [--api-key API_KEY] [--raw]",
     help="List your running instances with filtering, sorting, and pagination",
     epilog=deindent("""
+        Returns a paginated list of instance objects. Key status fields per instance:
+
+        **actual_status** — current container state:
+
+        | Value | Meaning |
+        |-------|---------|
+        | `null` | Instance is being provisioned |
+        | `loading` | Docker image is downloading or container is starting up |
+        | `running` | Container is actively executing. GPU charges apply. |
+        | `stopped` | Container is halted. Disk charges continue; no GPU charges. |
+        | `frozen` | Container is paused with memory preserved. GPU charges apply. |
+        | `exited` | Container process exited unexpectedly |
+        | `rebooting` | Container is restarting (transient) |
+        | `unknown` | No recent heartbeat from the host |
+        | `offline` | Host machine disconnected from Vast servers (computed, not stored in DB) |
+
+        **intended_status** — user's desired target state: `running`, `stopped`, or `frozen`.
+
+        **cur_state** — machine contract / hardware allocation state: `running`, `stopped`, or `unloaded` (released on destroy).
+
+        **status_msg** — human-readable detail on the current status.
+
         Displays your instances in a table with auto-sizing columns. Narrow terminals
         drop lower-priority columns automatically; use --cols to override. Sorted by
         id asc by default. Paginated at 25 results; follow the next-page prompt or

--- a/vast.py
+++ b/vast.py
@@ -4022,6 +4022,115 @@ def stop__instances(args):
     exec_with_threads(lambda ids : stop_instance(ids, args), idlist, nt=8)
 
 
+@parser.command(
+    argument("id", help="instance ID to wait on", type=int),
+    argument("--status",
+             default="running",
+             choices=["running", "stopped", "exited", "created", "frozen"],
+             help="target status to wait for (default: running)"),
+    argument("--timeout", type=int, default=1800,
+             help="seconds before giving up with exit 255 (default: 1800)"),
+    argument("--interval", type=int, default=10,
+             help="seconds between polls, minimum 5 (default: 10)"),
+    usage="vastai wait instance ID [--status STATUS] [--timeout SECONDS] [--interval SECONDS]",
+    help="Block until an instance reaches a target status",
+    epilog=deindent("""
+        Polls instance status every INTERVAL seconds until STATUS is reached or
+        TIMEOUT expires. Progress is printed to stderr; stdout is clean for piping.
+
+        Exit codes:
+            0    target status reached
+            1    instance not found, auth failure, or error state
+            255  timeout
+
+        Examples:
+            vastai wait instance 33402620
+            vastai wait instance 33402620 --status exited --timeout 3600
+            vastai wait instance 33402620 --raw | jq .ssh_host
+            vastai create instance 34069587 --disk 100 --ssh --direct && vastai wait instance $ID && vastai ssh-url $ID
+    """),
+)
+def wait__instance(args):
+    if args.interval < 5:
+        print("error: --interval must be >= 5 seconds", file=sys.stderr)
+        sys.exit(1)
+
+    req_url = apiurl(args, f"/instances/{args.id}/", {"owner": "me"})
+
+    start_time = time.time()
+    last_status = "unknown"
+
+    try:
+        while time.time() - start_time < args.timeout:
+            try:
+                r = http_get(args, req_url)
+                r.raise_for_status()
+                rj = r.json()
+                instance_info = rj.get("instances")
+            except requests.exceptions.HTTPError as e:
+                code = e.response.status_code
+                try:
+                    body = e.response.json()
+                    if body.get("error") == "auth_error":
+                        print(f"error: authentication failed — check your API key", file=sys.stderr)
+                        sys.exit(1)
+                except Exception:
+                    pass
+                if code in (401, 403):
+                    print(f"error: authentication failed (HTTP {code}) — check your API key", file=sys.stderr)
+                    sys.exit(1)
+                if code == 404:
+                    print(f"error: instance {args.id} not found", file=sys.stderr)
+                    sys.exit(1)
+                print(f"warning: HTTP {code} polling instance {args.id}, retrying...", file=sys.stderr)
+                time.sleep(args.interval)
+                continue
+            except Exception as e:
+                print(f"warning: error polling instance {args.id}: {e}, retrying...", file=sys.stderr)
+                time.sleep(args.interval)
+                continue
+
+            if instance_info is None:
+                print(f"error: instance {args.id} not found", file=sys.stderr)
+                sys.exit(1)
+
+            actual_status   = instance_info.get("actual_status",  "unknown")
+            intended_status = instance_info.get("intended_status", "unknown")
+            status_msg      = (instance_info.get("status_msg") or "").strip()
+            last_status     = actual_status
+
+            if "Error" in status_msg:
+                print(f"error: instance {args.id} entered error state: {status_msg}", file=sys.stderr)
+                sys.exit(1)
+
+            if actual_status == "offline":
+                print(f"error: instance {args.id} went offline", file=sys.stderr)
+                sys.exit(1)
+
+            if actual_status == args.status and intended_status == args.status:
+                if args.raw:
+                    return instance_info
+                return None
+
+            detail = f" ({status_msg})" if status_msg and actual_status == "loading" else ""
+            print(
+                f"instance {args.id}: {actual_status}{detail} — waiting for '{args.status}'",
+                file=sys.stderr
+            )
+            time.sleep(args.interval)
+
+    except KeyboardInterrupt:
+        print(f"\nwait cancelled for instance {args.id}", file=sys.stderr)
+        sys.exit(1)
+
+    elapsed = int(time.time() - start_time)
+    print(
+        f"error: instance {args.id} did not reach '{args.status}' within {elapsed}s "
+        f"(last status: {last_status}). Check: vastai show instance {args.id}",
+        file=sys.stderr
+    )
+    sys.exit(255)
+
 
 def numeric_version(version_str):
     try:


### PR DESCRIPTION
## Summary

- Adds `vastai wait instance <ID>` — a blocking poll command that waits until an instance reaches a target status
- Modelled on `aws ec2 wait instance-running`, which is widely cited as one of the most useful scripting primitives in the AWS CLI
- No GPU cloud competitor (RunPod, Modal, Lambda, CoreWeave) has an equivalent command

## What it does

```bash
vastai wait instance 33402620                          # blocks until running, exit 0
vastai wait instance 33402620 --status exited          # wait for job completion
vastai wait instance 33402620 --raw | jq .ssh_host     # get connection details on success
vastai create instance $ID ... && vastai wait instance $ID && vastai ssh-url $ID
```

**Exit codes:** `0` = target reached, `1` = error/not-found/auth failure, `255` = timeout

**Defaults:** `--status running`, `--timeout 1800`, `--interval 10`

## Implementation notes

- Makes API call directly (not via `show__instance`) — handles `instances: null` response correctly for non-existent IDs
- Auth failure detection checks response body (`error: auth_error`) since the API returns HTTP 404 rather than 401 for bad keys
- All progress/error output goes to stderr; stdout is reserved for `--raw` JSON — clean for piping
- Does NOT auto-destroy on error (unlike the internal `wait_for_instance()` used by `self-test`)
- `--interval` enforced >= 5 before polling begins
- SIGINT handled gracefully

## Test plan

- [x] `--interval 3` rejects before polling (exit 1)
- [x] `--interval 5` boundary works correctly
- [x] Instance not found → exit 1 immediately, no timeout burn
- [x] Bad API key → exit 1 immediately with auth message
- [x] Stderr isolation — stdout empty on error
- [x] Invalid `--status` value rejected by argparse
- [x] `&&` pipeline short-circuits on failure
- [x] Live: waits through `None → loading → running`, exits 0
- [x] Live: `--raw` outputs JSON with `ssh_host`, `ssh_port`
- [x] Live: `&&` success path executes downstream command
- [x] SIGINT during poll → exit 1, "wait cancelled", clean terminal
- [x] `--timeout 0` → exit 255 immediately
- [x] No ID / non-integer ID → argparse error, exit 2

## Jira

[CLN-3213](https://vastai.atlassian.net/browse/CLN-3213)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)