### PR TITLE
security audit fix: remove wget install from SKILL.md

### DIFF
--- a/vastai/SKILL.md
+++ b/vastai/SKILL.md
@@ -18,10 +18,6 @@ Manage GPU instances, templates, volumes, serverless endpoints, SSH keys, and bi
 ```bash
 # PyPI (recommended)
 pip install vastai
-
-# Latest from GitHub
-wget https://raw.githubusercontent.com/vast-ai/vast-python/master/vast.py -O vast
-chmod +x vast
 ```
 
 ## Quick start


### PR DESCRIPTION
## Summary

- Removes the `wget https://raw.githubusercontent.com/...vast.py` + `chmod +x` installation block from `vastai/SKILL.md`
- Keeps only `pip install vastai` (PyPI) as the install method

## Context

The [agent-trust-hub security audit](https://skills.sh/vast-ai/vast-cli/vastai/security/agent-trust-hub) rated this skill **HIGH risk** (Apr 23, 2026). One of the four flagged issues was in SKILL.md itself: the `wget` install method instructs agents to fetch and execute a remote script, which the auditor flagged as a high-risk pattern — even though the source is the official repo.

The other three findings (shell=True in storage ops, tarball RCE in serverless deployment, dynamic imports from remote data) are in source code and are out of scope for this PR.

## Test plan

- [ ] Verify `vastai/SKILL.md` install section only contains `pip install vastai`
- [ ] No functional code changes — docs only