### PR TITLE
fix: owner: me query arg

### DIFF
--- a/vastai/api/billing.py
+++ b/vastai/api/billing.py
@@ -250,7 +250,7 @@ def show_user(client):
     Returns:
         dict: User data (with api_key removed).
     """
-    r = client.get("/users/current", query_args={"owner": "me"})
+    r = client.get("/users/current"})
     r.raise_for_status()
     user_blob = r.json()
     user_blob.pop("api_key", None)

--- a/vastai/api/billing.py
+++ b/vastai/api/billing.py
@@ -250,7 +250,7 @@ def show_user(client):
     Returns:
         dict: User data (with api_key removed).
     """
-    r = client.get("/users/current"})
+    r = client.get("/users/current")
     r.raise_for_status()
     user_blob = r.json()
     user_blob.pop("api_key", None)


### PR DESCRIPTION
Resolves issue #382. Our new webserver validation on this endpoint is causing issues with `show user`. The webserver expects there to not be a body in the request, but show_user is adding `owner: me` as a query param. This is an unconsumed parameter by the endpoint, safe to remove.