### PR TITLE
Fix search offers any filter

### DIFF
--- a/tests/sdk/test_sdk.py
+++ b/tests/sdk/test_sdk.py
@@ -180,6 +180,54 @@ class TestSearchOffers:
             order = mock.call_args.kwargs["order"]
             assert len(order) == 1
 
+    def test_string_query_seeds_defaults(self, sdk):
+        """String queries should arrive at the helper with defaults pre-merged
+        and no_default=True so defaults are not applied a second time."""
+        with patch("vastai.api.offers.search_offers", return_value=[]) as mock:
+            sdk.search_offers("num_gpus>=1")
+            q = mock.call_args.kwargs["query"]
+            assert q["verified"] == {"eq": True}
+            assert q["rentable"] == {"eq": True}
+            assert q["external"] == {"eq": False}
+            assert q["rented"] == {"eq": False}
+            assert mock.call_args.kwargs["no_default"] is True
+
+    def test_field_any_removes_default(self, sdk):
+        """Regression: explicit `field=any` must clear the default filter
+        (matches CLI behavior). Reported in vast-cli#383."""
+        with patch("vastai.api.offers.search_offers", return_value=[]) as mock:
+            sdk.search_offers("num_gpus>=1 verified=any rentable=any")
+            q = mock.call_args.kwargs["query"]
+            assert "verified" not in q
+            assert "rentable" not in q
+            assert q["external"] == {"eq": False}
+            assert q["rented"] == {"eq": False}
+            assert mock.call_args.kwargs["no_default"] is True
+
+    def test_no_default_skips_seeding(self, sdk):
+        """no_default=True should skip default seeding entirely."""
+        with patch("vastai.api.offers.search_offers", return_value=[]) as mock:
+            sdk.search_offers("num_gpus>=1", no_default=True)
+            q = mock.call_args.kwargs["query"]
+            assert "verified" not in q
+            assert "rentable" not in q
+            assert mock.call_args.kwargs["no_default"] is True
+
+    def test_dict_query_lets_helper_apply_defaults(self, sdk):
+        """Dict queries are not pre-seeded; the helper still applies defaults
+        per no_default. Preserves existing behavior for dict callers."""
+        with patch("vastai.api.offers.search_offers", return_value=[]) as mock:
+            sdk.search_offers({"num_gpus": {"gte": 1}})
+            assert mock.call_args.kwargs["no_default"] is False
+
+    def test_field_any_removes_default_search_offers_new(self, sdk):
+        """Same regression coverage for the search_offers_new path."""
+        with patch("vastai.api.offers.search_offers_new", return_value=[]) as mock:
+            sdk.search_offers_new("num_gpus>=1 verified=any")
+            q = mock.call_args.kwargs["query"]
+            assert "verified" not in q
+            assert mock.call_args.kwargs["no_default"] is True
+
 
 # ---------------------------------------------------------------------------
 # show_env_vars — value masking

--- a/vastai/sdk.py
+++ b/vastai/sdk.py
@@ -208,11 +208,20 @@ class VastAI:
         from vastai.api.query import parse_query, offers_fields, offers_alias, offers_mult
         from vastai.utils import preprocess_search_query, postprocess_search_results
 
-        # Expand georegion/chunked directives before parsing
+        # Expand georegion/chunked directives before parsing.
+        # Seed defaults before parsing so `field=any` correctly removes them,
+        # matching CLI behavior. Pass no_default=True to the helper afterward
+        # so it does not reapply the same defaults.
         georegion_active, chunked = False, False
+        defaults_applied = False
         if isinstance(query, str):
             georegion_active, chunked, query = preprocess_search_query(query)
-            query = parse_query(query, {}, offers_fields, offers_alias, offers_mult)
+            base = {} if no_default else {
+                "verified": {"eq": True}, "external": {"eq": False},
+                "rentable": {"eq": True}, "rented": {"eq": False},
+            }
+            query = parse_query(query, base, offers_fields, offers_alias, offers_mult)
+            defaults_applied = True
 
         # Parse order string into list
         order_list = None
@@ -238,7 +247,8 @@ class VastAI:
 
         results = offers.search_offers(
             self.client, query=query, offer_type=type, order=order_list,
-            limit=limit, storage=storage, no_default=no_default, **kwargs,
+            limit=limit, storage=storage,
+            no_default=(no_default or defaults_applied), **kwargs,
         )
 
         if isinstance(results, list):
@@ -290,9 +300,15 @@ class VastAI:
         from vastai.utils import preprocess_search_query, postprocess_search_results
 
         georegion_active, chunked = False, False
+        defaults_applied = False
         if isinstance(query, str):
             georegion_active, chunked, query = preprocess_search_query(query)
-            query = parse_query(query, {}, offers_fields, offers_alias, offers_mult)
+            base = {} if no_default else {
+                "verified": {"eq": True}, "external": {"eq": False},
+                "rentable": {"eq": True}, "rented": {"eq": False},
+            }
+            query = parse_query(query, base, offers_fields, offers_alias, offers_mult)
+            defaults_applied = True
 
         order_list = None
         if isinstance(order, str):
@@ -317,7 +333,8 @@ class VastAI:
 
         results = offers.search_offers_new(
             self.client, query=query, offer_type=type, order=order_list,
-            limit=limit, storage=storage, no_default=no_default, **kwargs,
+            limit=limit, storage=storage,
+            no_default=(no_default or defaults_applied), **kwargs,
         )
 
         if isinstance(results, list):


### PR DESCRIPTION
See #383 

using  search offers with "any" filter in the SDK is supposed to return all results.
instead its applying the default filters 