### PR TITLE
Fix search offers rentable param

### DIFF
--- a/tests/sdk/test_sdk.py
+++ b/tests/sdk/test_sdk.py
@@ -189,7 +189,6 @@ class TestSearchOffers:
             assert q["verified"] == {"eq": True}
             assert q["rentable"] == {"eq": True}
             assert q["external"] == {"eq": False}
-            assert "rented" not in q
             assert mock.call_args.kwargs["no_default"] is True
 
     def test_field_any_removes_default(self, sdk):

--- a/tests/sdk/test_sdk.py
+++ b/tests/sdk/test_sdk.py
@@ -189,7 +189,7 @@ class TestSearchOffers:
             assert q["verified"] == {"eq": True}
             assert q["rentable"] == {"eq": True}
             assert q["external"] == {"eq": False}
-            assert q["rented"] == {"eq": False}
+            assert "rented" not in q
             assert mock.call_args.kwargs["no_default"] is True
 
     def test_field_any_removes_default(self, sdk):
@@ -201,7 +201,6 @@ class TestSearchOffers:
             assert "verified" not in q
             assert "rentable" not in q
             assert q["external"] == {"eq": False}
-            assert q["rented"] == {"eq": False}
             assert mock.call_args.kwargs["no_default"] is True
 
     def test_no_default_skips_seeding(self, sdk):

--- a/vastai/cli/commands/offers.py
+++ b/vastai/cli/commands/offers.py
@@ -47,8 +47,8 @@ parser = _get_parser()
 
         Examples:
 
-            # search for somewhat reliable single RTX 3090 instances, filter out any duplicates or offers that conflict with our existing stopped instances
-            vastai search offers 'reliability > 0.98 num_gpus=1 gpu_name=RTX_3090 rented=False'
+            # search for somewhat reliable single RTX 3090 instances
+            vastai search offers 'reliability > 0.98 num_gpus=1 gpu_name=RTX_3090'
 
             # search for datacenter gpus with minimal compute_cap and total_flops
             vastai search offers 'compute_cap > 610 total_flops > 5 datacenter=True'
@@ -62,8 +62,8 @@ parser = _get_parser()
             # search for machines with nvidia drivers 535.86.05 or greater (and various other options)
             vastai search offers 'disk_space>146 duration>24 gpu_ram>10 cuda_vers>=12.1 direct_port_count>=2 driver_version >= 535.86.05'
 
-            # search for reliable machines with at least 4 gpus, unverified, order by num_gpus, allow conflicts
-            vastai search offers 'reliability > 0.99  num_gpus>=4 verified=False rented=any' -o 'num_gpus-'
+            # search for reliable machines with at least 4 gpus, unverified, order by num_gpus
+            vastai search offers 'reliability > 0.99  num_gpus>=4 verified=False' -o 'num_gpus-'
 
             # search for arm64 cpu architecture
             vastai search offers 'cpu_arch=arm64'
@@ -114,7 +114,6 @@ parser = _get_parser()
             pcie_bw:                float     PCIE bandwidth (CPU to GPU)
             reliability:            float     machine reliability score (see FAQ for explanation)
             rentable:               bool      is the instance currently rentable
-            rented:                 bool      allow/disallow duplicates and potential conflicts with existing stopped instances
             storage_cost:           float     storage cost in $/GB/month
             static_ip:              bool      is the IP addr static/stable
             total_flops:            float     total TFLOPs from all GPUs
@@ -135,7 +134,7 @@ def search__offers(args):
         if args.no_default:
             query = {}
         else:
-            query = {"verified": {"eq": True}, "external": {"eq": False}, "rentable": {"eq": True}, "rented": {"eq": False}}
+            query = {"verified": {"eq": True}, "external": {"eq": False}, "rentable": {"eq": True}}
 
         if args.query is not None:
             query = parse_query(args.query, query, offers_fields, offers_alias, offers_mult)
@@ -190,25 +189,6 @@ def search__offers(args):
         return
 
     rows = r.json()["offers"]
-
-    if 'rented' in query:
-        filter_q = query['rented']
-        filter_op = list(filter_q.keys())[0]
-        target = filter_q[filter_op]
-        new_rows = []
-        for row in rows:
-            rented = False
-            if "rented" in row and row["rented"] is not None:
-                rented = row["rented"]
-            if filter_op == "eq" and rented == target:
-                new_rows.append(row)
-            if filter_op == "neq" and rented != target:
-                new_rows.append(row)
-            if filter_op == "in" and rented in target:
-                new_rows.append(row)
-            if filter_op == "notin" and rented not in target:
-                new_rows.append(row)
-        rows = new_rows
 
     if args.raw:
         return rows
@@ -475,7 +455,7 @@ def create__template(args):
         docker_login_repo = None
     default_search_query = {}
     if not args.no_default:
-        default_search_query = {"verified": {"eq": True}, "external": {"eq": False}, "rentable": {"eq": True}, "rented": {"eq": False}}
+        default_search_query = {"verified": {"eq": True}, "external": {"eq": False}, "rentable": {"eq": True}}
 
     extra_filters = parse_query(args.search_params, default_search_query, offers_fields, offers_alias, offers_mult)
 
@@ -543,7 +523,7 @@ def update__template(args):
         docker_login_repo = None
     default_search_query = {}
     if not args.no_default:
-        default_search_query = {"verified": {"eq": True}, "external": {"eq": False}, "rentable": {"eq": True}, "rented": {"eq": False}}
+        default_search_query = {"verified": {"eq": True}, "external": {"eq": False}, "rentable": {"eq": True}}
 
     extra_filters = parse_query(args.search_params, default_search_query, offers_fields, offers_alias, offers_mult)
 

--- a/vastai/sdk.py
+++ b/vastai/sdk.py
@@ -218,7 +218,7 @@ class VastAI:
             georegion_active, chunked, query = preprocess_search_query(query)
             base = {} if no_default else {
                 "verified": {"eq": True}, "external": {"eq": False},
-                "rentable": {"eq": True}, "rented": {"eq": False},
+                "rentable": {"eq": True},
             }
             query = parse_query(query, base, offers_fields, offers_alias, offers_mult)
             defaults_applied = True
@@ -305,7 +305,7 @@ class VastAI:
             georegion_active, chunked, query = preprocess_search_query(query)
             base = {} if no_default else {
                 "verified": {"eq": True}, "external": {"eq": False},
-                "rentable": {"eq": True}, "rented": {"eq": False},
+                "rentable": {"eq": True},
             }
             query = parse_query(query, base, offers_fields, offers_alias, offers_mult)
             defaults_applied = True


### PR DESCRIPTION
 ## Problem                                                                                                                            
                                                                  
  `vastai search offers 'rented=true ...'` silently returns 0 rows even when matching offers exist. Reported in #391.                   
   
  ## Root cause                                                                                                                         
                                                                  
  Two CLI layers misrepresent `rented` as a working filter:                                                                             
  
  1. **Seeded defaults** inject `rented={eq: false}` into every query (`vastai/cli/commands/offers.py:138`), and `--help` / examples /  
  field docs advertise `rented` as a filterable field.            
  2. **A client-side post-filter** (`offers.py:194-211`) drops every row whose response `rented` field doesn't match the user's filter —
   but that response field means "is the *caller* renting this offer" (computed per-request from the caller's active rentals), not "is  
  anyone renting it". For any user without active rentals it's always False, so `rented={eq: true}` matches nothing.
                                                                                                                                        
  The backend has separately ignored the `rented` body filter since 2025-04-18 (popped into an unused variable in `web/views/misc.py`), so the broken CLI post-filter was the only code still acting on it.
                                                                                                                                        
  ## Fix                                                          

  - Drop `rented` from the seeded defaults in `search__offers`, `create__template`, `update__template`.                                 
  - Drop the matching seeded default in `vastai/sdk.py` (and update the SDK test).
  - Remove the broken client-side post-filter.                                                                                          
  - Remove `rented` from the field-doc list and from two example queries.
                                                                                                                                        
  After this, `rented=...` typed by users still passes through to the request body. once the backend implements the filter (separate ticket), the CLI picks up the new behavior with no further changes.
