### PR TITLE
self-test: route to cu118/cu128/cu130 images with compute_cap aware fallback

### DIFF
--- a/vast.py
+++ b/vast.py
@@ -8417,15 +8417,15 @@ def self_test__machine(args):
             """
             Map a CUDA version (and optional compute_cap) to (image, reason).
 
-            If compute_cap is below 700 (sm_70 / Volta), the cu118 image is
-            forced regardless of CUDA version. cu128 (torch 2.10) still ships
-            sm_70 kernels so Volta hosts land on cu128 via the version map;
-            cu130 (torch 2.11) and cu128 do not ship sm_50/sm_60 kernels, so
-            Maxwell and Pascal must use cu118.
+            If compute_cap is below 700 (sm_70 / Volta), the cuda-11.8 image
+            is forced regardless of CUDA version. cuda-12.8 (torch 2.10) still
+            ships sm_70 kernels so Volta hosts land on cuda-12.8 via the
+            version map; cuda-13.0 (torch 2.11) and cuda-12.8 do not ship
+            sm_50/sm_60 kernels, so Maxwell and Pascal must use cuda-11.8.
 
             Volta hosts whose operator has installed a CUDA 13 driver get the
             cuda_version clamped down to 12.8 before the version map runs,
-            since cu130 wheels never built sm_70.
+            since cuda-13.0 wheels never built sm_70.
 
             The returned reason is a short human-readable string so callers
             can log why a particular image was chosen.
@@ -8436,16 +8436,16 @@ def self_test__machine(args):
                 cuda_version = str(cuda_version)
             original_cuda = cuda_version
 
-            # Force the cu118 legacy image on pre-Volta hardware (sm_50/sm_60).
+            # Force the cuda-11.8 legacy image on pre-Volta hardware (sm_50/sm_60).
             if compute_cap is not None and compute_cap < 700:
                 return (
-                    f"{docker_repo}:self-test-cu118",
-                    f"compute_cap={compute_cap} below sm_70 → forced cu118",
+                    f"{docker_repo}:self-test-cuda-11.8",
+                    f"compute_cap={compute_cap} below sm_70 → forced cuda-11.8",
                 )
 
-            # Volta sm_70/sm_72: cu128 has sm_70, cu130 doesn't. Cap driver
-            # CUDA at 12.8 so the map below picks cu128 even on a V100 host
-            # with a CUDA 13 driver installed.
+            # Volta sm_70/sm_72: cuda-12.8 has sm_70, cuda-13.0 doesn't. Cap
+            # driver CUDA at 12.8 so the map below picks cuda-12.8 even on a
+            # V100 host with a CUDA 13 driver installed.
             clamped_for_volta = False
             if compute_cap is not None and compute_cap < 750:
                 if float(cuda_version) > 12.8:
@@ -8453,11 +8453,11 @@ def self_test__machine(args):
                     clamped_for_volta = True
 
             # Predefined mapping. Tracks PyTorch releases and the docker
-            # images we currently publish (cu118 / cu128 / cu130).
+            # images we currently publish (cuda-11.8 / cuda-12.8 / cuda-13.0).
             docker_tag_map = {
-                "11.8": "cu118",
-                "12.8": "cu128",
-                "13.0": "cu130",
+                "11.8": "cuda-11.8",
+                "12.8": "cuda-12.8",
+                "13.0": "cuda-13.0",
             }
 
             cap_hint = f"compute_cap={compute_cap}" if compute_cap is not None else "compute_cap=unknown"

--- a/vast.py
+++ b/vast.py
@@ -8413,30 +8413,37 @@ def self_test__machine(args):
                 # If user did pass --ignore-requirements, warn and continue
                 progress_print(args, "Continuing despite unmet requirements because --ignore-requirements is set.")
 
-        def cuda_map_to_image(cuda_version):
+        def cuda_map_to_image(cuda_version, compute_cap=None):
             """
             Maps a CUDA version to a Docker image tag, falling back to the next lower version until failure.
+
+            If compute_cap is below 750 (sm_75 / Turing), the cu118 image is
+            forced regardless of CUDA version: cu128/cu130 PyTorch wheels
+            don't ship sm_50/sm_60/sm_70 kernels.
             """
             docker_repo = "vastai/test"
             # Convert float input to string
             if isinstance(cuda_version, float):
                 cuda_version = str(cuda_version)
-            
-            # Predefined mapping. Tracks PyTorch releases
+
+            # Force the cu118 legacy image on pre-Turing hardware.
+            if compute_cap is not None and compute_cap < 750:
+                return f"{docker_repo}:self-test-cu118"
+
+            # Predefined mapping. Tracks PyTorch releases and the docker
+            # images we currently publish (cu118 / cu128 / cu130).
             docker_tag_map = {
                 "11.8": "cu118",
-                "12.1": "cu121",
-                "12.4": "cu124",
-                "12.6": "cu126",
-                "12.8": "cu128"
+                "12.8": "cu128",
+                "13.0": "cu130",
             }
-            
+
             if cuda_version in docker_tag_map:
                 return f"{docker_repo}:self-test-{docker_tag_map[cuda_version]}"
-            
+
             # Try to find the next version down
             cuda_float = float(cuda_version)
-            
+
             # Try to decrement the version by 0.1 until we find a match or run out of options
             next_version = round(cuda_float - 0.1, 1)
             while next_version >= min(float(v) for v in docker_tag_map.keys()):
@@ -8444,7 +8451,7 @@ def self_test__machine(args):
                 if next_version_str in docker_tag_map:
                     return f"{docker_repo}:self-test-{docker_tag_map[next_version_str]}"
                 next_version = round(next_version - 0.1, 1)
-            
+
             raise KeyError(f"No CUDA version found for {cuda_version} or any lower version")
     
 
@@ -8489,7 +8496,8 @@ def self_test__machine(args):
         else:
             ask_contract_id = top_offer["id"]
             cuda_version = top_offer["cuda_max_good"]
-            docker_image = cuda_map_to_image(cuda_version)
+            compute_cap = top_offer.get("compute_cap")
+            docker_image = cuda_map_to_image(cuda_version, compute_cap)
 
             # Prepare arguments for instance creation
             create_args = argparse.Namespace(

--- a/vast.py
+++ b/vast.py
@@ -8430,7 +8430,7 @@ def self_test__machine(args):
             The returned reason is a short human-readable string so callers
             can log why a particular image was chosen.
             """
-            docker_repo = "robatvastai/test"
+            docker_repo = "vastai/test"
             # Convert float input to string
             if isinstance(cuda_version, float):
                 cuda_version = str(cuda_version)

--- a/vast.py
+++ b/vast.py
@@ -8422,8 +8422,12 @@ def self_test__machine(args):
             sm_70 kernels so Volta hosts land on cu128 via the version map;
             cu130 (torch 2.11) and cu128 do not ship sm_50/sm_60 kernels, so
             Maxwell and Pascal must use cu118.
+
+            Volta hosts whose operator has installed a CUDA 13 driver get the
+            cuda_version clamped down to 12.8 before the version map runs,
+            since cu130 wheels never built sm_70.
             """
-            docker_repo = "vastai/test"
+            docker_repo = "robatvastai/test"
             # Convert float input to string
             if isinstance(cuda_version, float):
                 cuda_version = str(cuda_version)
@@ -8431,6 +8435,13 @@ def self_test__machine(args):
             # Force the cu118 legacy image on pre-Volta hardware (sm_50/sm_60).
             if compute_cap is not None and compute_cap < 700:
                 return f"{docker_repo}:self-test-cu118"
+
+            # Volta sm_70/sm_72: cu128 has sm_70, cu130 doesn't. Cap driver
+            # CUDA at 12.8 so the map below picks cu128 even on a V100 host
+            # with a CUDA 13 driver installed.
+            if compute_cap is not None and compute_cap < 750:
+                if float(cuda_version) > 12.8:
+                    cuda_version = "12.8"
 
             # Predefined mapping. Tracks PyTorch releases and the docker
             # images we currently publish (cu118 / cu128 / cu130).

--- a/vast.py
+++ b/vast.py
@@ -8417,17 +8417,19 @@ def self_test__machine(args):
             """
             Maps a CUDA version to a Docker image tag, falling back to the next lower version until failure.
 
-            If compute_cap is below 750 (sm_75 / Turing), the cu118 image is
-            forced regardless of CUDA version: cu128/cu130 PyTorch wheels
-            don't ship sm_50/sm_60/sm_70 kernels.
+            If compute_cap is below 700 (sm_70 / Volta), the cu118 image is
+            forced regardless of CUDA version. cu128 (torch 2.10) still ships
+            sm_70 kernels so Volta hosts land on cu128 via the version map;
+            cu130 (torch 2.11) and cu128 do not ship sm_50/sm_60 kernels, so
+            Maxwell and Pascal must use cu118.
             """
             docker_repo = "vastai/test"
             # Convert float input to string
             if isinstance(cuda_version, float):
                 cuda_version = str(cuda_version)
 
-            # Force the cu118 legacy image on pre-Turing hardware.
-            if compute_cap is not None and compute_cap < 750:
+            # Force the cu118 legacy image on pre-Volta hardware (sm_50/sm_60).
+            if compute_cap is not None and compute_cap < 700:
                 return f"{docker_repo}:self-test-cu118"
 
             # Predefined mapping. Tracks PyTorch releases and the docker

--- a/vast.py
+++ b/vast.py
@@ -8631,17 +8631,38 @@ def self_test__machine(args):
                             result["success"] = success
                             result["reason"] = reason
 
+    except KeyboardInterrupt:
+        result["success"] = False
+        result["reason"] = "Interrupted by user (Ctrl+C)"
+        progress_print(args, "\nInterrupted — cleaning up test instance...")
     except Exception as e:
         result["success"] = False
         result["reason"] = str(e)
 
     finally:
-        try:
-            if instance_id and instance_exist(instance_id, api_key, destroy_args):
-                destroy_instance_silent(instance_id, destroy_args)
-        except Exception as e:
-            if args.debugging:
-                debug_print(args, f"Error during cleanup: {e}")
+        # Always attempt to destroy the test instance, including on Ctrl+C.
+        # KeyboardInterrupt is BaseException (not Exception) so it skips the
+        # typed except above and lands here. Surface failures loudly: a
+        # silently-leaked instance keeps billing the host.
+        if instance_id:
+            try:
+                if instance_exist(instance_id, api_key, destroy_args):
+                    progress_print(args, f"Destroying test instance {instance_id}...")
+                    destroy_instance_silent(instance_id, destroy_args)
+                    progress_print(args, f"Test instance {instance_id} destroyed.")
+            except KeyboardInterrupt:
+                progress_print(
+                    args,
+                    f"\nSecond interrupt during cleanup — instance {instance_id} may still be running.\n"
+                    f"  Destroy it manually: vastai destroy instance {instance_id}"
+                )
+                raise
+            except Exception as e:
+                progress_print(
+                    args,
+                    f"WARNING: failed to destroy test instance {instance_id}: {e}\n"
+                    f"  Destroy it manually: vastai destroy instance {instance_id}"
+                )
 
     # Output results
     if args.raw:

--- a/vast.py
+++ b/vast.py
@@ -8415,7 +8415,7 @@ def self_test__machine(args):
 
         def cuda_map_to_image(cuda_version, compute_cap=None):
             """
-            Maps a CUDA version to a Docker image tag, falling back to the next lower version until failure.
+            Map a CUDA version (and optional compute_cap) to (image, reason).
 
             If compute_cap is below 700 (sm_70 / Volta), the cu118 image is
             forced regardless of CUDA version. cu128 (torch 2.10) still ships
@@ -8426,22 +8426,31 @@ def self_test__machine(args):
             Volta hosts whose operator has installed a CUDA 13 driver get the
             cuda_version clamped down to 12.8 before the version map runs,
             since cu130 wheels never built sm_70.
+
+            The returned reason is a short human-readable string so callers
+            can log why a particular image was chosen.
             """
             docker_repo = "robatvastai/test"
             # Convert float input to string
             if isinstance(cuda_version, float):
                 cuda_version = str(cuda_version)
+            original_cuda = cuda_version
 
             # Force the cu118 legacy image on pre-Volta hardware (sm_50/sm_60).
             if compute_cap is not None and compute_cap < 700:
-                return f"{docker_repo}:self-test-cu118"
+                return (
+                    f"{docker_repo}:self-test-cu118",
+                    f"compute_cap={compute_cap} below sm_70 → forced cu118",
+                )
 
             # Volta sm_70/sm_72: cu128 has sm_70, cu130 doesn't. Cap driver
             # CUDA at 12.8 so the map below picks cu128 even on a V100 host
             # with a CUDA 13 driver installed.
+            clamped_for_volta = False
             if compute_cap is not None and compute_cap < 750:
                 if float(cuda_version) > 12.8:
                     cuda_version = "12.8"
+                    clamped_for_volta = True
 
             # Predefined mapping. Tracks PyTorch releases and the docker
             # images we currently publish (cu118 / cu128 / cu130).
@@ -8451,8 +8460,15 @@ def self_test__machine(args):
                 "13.0": "cu130",
             }
 
+            cap_hint = f"compute_cap={compute_cap}" if compute_cap is not None else "compute_cap=unknown"
+
             if cuda_version in docker_tag_map:
-                return f"{docker_repo}:self-test-{docker_tag_map[cuda_version]}"
+                tag = docker_tag_map[cuda_version]
+                if clamped_for_volta:
+                    reason = f"{cap_hint} (Volta) + cuda_max_good={original_cuda} → clamped to {cuda_version} → {tag}"
+                else:
+                    reason = f"{cap_hint}, cuda_max_good={cuda_version} → exact match → {tag}"
+                return f"{docker_repo}:self-test-{tag}", reason
 
             # Try to find the next version down
             cuda_float = float(cuda_version)
@@ -8462,7 +8478,12 @@ def self_test__machine(args):
             while next_version >= min(float(v) for v in docker_tag_map.keys()):
                 next_version_str = str(next_version)
                 if next_version_str in docker_tag_map:
-                    return f"{docker_repo}:self-test-{docker_tag_map[next_version_str]}"
+                    tag = docker_tag_map[next_version_str]
+                    reason = (
+                        f"{cap_hint}, cuda_max_good={original_cuda} → "
+                        f"stepped down to {next_version_str} → {tag}"
+                    )
+                    return f"{docker_repo}:self-test-{tag}", reason
                 next_version = round(next_version - 0.1, 1)
 
             raise KeyError(f"No CUDA version found for {cuda_version} or any lower version")
@@ -8510,7 +8531,7 @@ def self_test__machine(args):
             ask_contract_id = top_offer["id"]
             cuda_version = top_offer["cuda_max_good"]
             compute_cap = top_offer.get("compute_cap")
-            docker_image = cuda_map_to_image(cuda_version, compute_cap)
+            docker_image, image_reason = cuda_map_to_image(cuda_version, compute_cap)
 
             # Prepare arguments for instance creation
             create_args = argparse.Namespace(
@@ -8550,7 +8571,7 @@ def self_test__machine(args):
 
             # Create instance
             try:
-                progress_print(args, f"Starting test with {docker_image}")
+                progress_print(args, f"Starting test with {docker_image} ({image_reason})")
                 response = create__instance(create_args)
                 if isinstance(response, requests.Response):  # Check if it's an HTTP response
                     if response.status_code == 200:

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -660,17 +660,21 @@ def self_test__machine(args):
             progress_print("Continuing despite unmet requirements because --ignore-requirements is set.")
 
         # ----- CUDA version to docker image mapping -----
-        def cuda_map_to_image(cuda_version):
+        def cuda_map_to_image(cuda_version, compute_cap=None):
             docker_repo = "vastai/test"
             if isinstance(cuda_version, float):
                 cuda_version = str(cuda_version)
 
+            # cu128 and cu130 PyTorch wheels don't ship sm_50/sm_60/sm_70
+            # kernels. Anything below Turing (sm_75 == compute_cap 750)
+            # must use the cu118 legacy image regardless of driver CUDA.
+            if compute_cap is not None and compute_cap < 750:
+                return f"{docker_repo}:self-test-cu118"
+
             docker_tag_map = {
                 "11.8": "cu118",
-                "12.1": "cu121",
-                "12.4": "cu124",
-                "12.6": "cu126",
                 "12.8": "cu128",
+                "13.0": "cu130",
             }
 
             if cuda_version in docker_tag_map:
@@ -716,7 +720,8 @@ def self_test__machine(args):
         else:
             ask_contract_id = top_offer["id"]
             cuda_version = top_offer["cuda_max_good"]
-            docker_image = cuda_map_to_image(cuda_version)
+            compute_cap = top_offer.get("compute_cap")
+            docker_image = cuda_map_to_image(cuda_version, compute_cap)
 
             # ----- create the test instance -----
             try:

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -665,10 +665,11 @@ def self_test__machine(args):
             if isinstance(cuda_version, float):
                 cuda_version = str(cuda_version)
 
-            # cu128 and cu130 PyTorch wheels don't ship sm_50/sm_60/sm_70
-            # kernels. Anything below Turing (sm_75 == compute_cap 750)
-            # must use the cu118 legacy image regardless of driver CUDA.
-            if compute_cap is not None and compute_cap < 750:
+            # cu128 (torch 2.10) still ships sm_70 (Volta); cu130 (torch 2.11)
+            # never did. Neither builds sm_50/sm_60 kernels. Anything pre-Volta
+            # (compute_cap < 700) must use the cu118 legacy image; Volta itself
+            # lands on cu128 via the version mapping below.
+            if compute_cap is not None and compute_cap < 700:
                 return f"{docker_repo}:self-test-cu118"
 
             docker_tag_map = {

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -667,10 +667,17 @@ def self_test__machine(args):
 
             # cu128 (torch 2.10) still ships sm_70 (Volta); cu130 (torch 2.11)
             # never did. Neither builds sm_50/sm_60 kernels. Anything pre-Volta
-            # (compute_cap < 700) must use the cu118 legacy image; Volta itself
-            # lands on cu128 via the version mapping below.
+            # (compute_cap < 700) must use the cu118 legacy image.
             if compute_cap is not None and compute_cap < 700:
                 return f"{docker_repo}:self-test-cu118"
+
+            # Volta sm_70/sm_72 hosts: cu128 wheels include sm_70 but cu130
+            # wheels never did. Cap the driver-reported CUDA version at 12.8
+            # so the map below resolves to cu128 even if the operator has
+            # installed a CUDA 13 driver on a V100.
+            if compute_cap is not None and compute_cap < 750:
+                if float(cuda_version) > 12.8:
+                    cuda_version = "12.8"
 
             docker_tag_map = {
                 "11.8": "cu118",

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -667,19 +667,20 @@ def self_test__machine(args):
                 cuda_version = str(cuda_version)
             original_cuda = cuda_version
 
-            # cu128 (torch 2.10) still ships sm_70 (Volta); cu130 (torch 2.11)
-            # never did. Neither builds sm_50/sm_60 kernels. Anything pre-Volta
-            # (compute_cap < 700) must use the cu118 legacy image.
+            # cuda-12.8 (torch 2.10) still ships sm_70 (Volta); cuda-13.0
+            # (torch 2.11) never did. Neither builds sm_50/sm_60 kernels.
+            # Anything pre-Volta (compute_cap < 700) must use the cuda-11.8
+            # legacy image.
             if compute_cap is not None and compute_cap < 700:
                 return (
-                    f"{docker_repo}:self-test-cu118",
-                    f"compute_cap={compute_cap} below sm_70 → forced cu118",
+                    f"{docker_repo}:self-test-cuda-11.8",
+                    f"compute_cap={compute_cap} below sm_70 → forced cuda-11.8",
                 )
 
-            # Volta sm_70/sm_72 hosts: cu128 wheels include sm_70 but cu130
-            # wheels never did. Cap the driver-reported CUDA version at 12.8
-            # so the map below resolves to cu128 even if the operator has
-            # installed a CUDA 13 driver on a V100.
+            # Volta sm_70/sm_72 hosts: cuda-12.8 wheels include sm_70 but
+            # cuda-13.0 wheels never did. Cap the driver-reported CUDA version
+            # at 12.8 so the map below resolves to cuda-12.8 even if the
+            # operator has installed a CUDA 13 driver on a V100.
             clamped_for_volta = False
             if compute_cap is not None and compute_cap < 750:
                 if float(cuda_version) > 12.8:
@@ -687,9 +688,9 @@ def self_test__machine(args):
                     clamped_for_volta = True
 
             docker_tag_map = {
-                "11.8": "cu118",
-                "12.8": "cu128",
-                "13.0": "cu130",
+                "11.8": "cuda-11.8",
+                "12.8": "cuda-12.8",
+                "13.0": "cuda-13.0",
             }
 
             cap_hint = f"compute_cap={compute_cap}" if compute_cap is not None else "compute_cap=unknown"

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -661,23 +661,30 @@ def self_test__machine(args):
 
         # ----- CUDA version to docker image mapping -----
         def cuda_map_to_image(cuda_version, compute_cap=None):
+            """Return (image, reason). Reason explains why this image was picked."""
             docker_repo = "vastai/test"
             if isinstance(cuda_version, float):
                 cuda_version = str(cuda_version)
+            original_cuda = cuda_version
 
             # cu128 (torch 2.10) still ships sm_70 (Volta); cu130 (torch 2.11)
             # never did. Neither builds sm_50/sm_60 kernels. Anything pre-Volta
             # (compute_cap < 700) must use the cu118 legacy image.
             if compute_cap is not None and compute_cap < 700:
-                return f"{docker_repo}:self-test-cu118"
+                return (
+                    f"{docker_repo}:self-test-cu118",
+                    f"compute_cap={compute_cap} below sm_70 → forced cu118",
+                )
 
             # Volta sm_70/sm_72 hosts: cu128 wheels include sm_70 but cu130
             # wheels never did. Cap the driver-reported CUDA version at 12.8
             # so the map below resolves to cu128 even if the operator has
             # installed a CUDA 13 driver on a V100.
+            clamped_for_volta = False
             if compute_cap is not None and compute_cap < 750:
                 if float(cuda_version) > 12.8:
                     cuda_version = "12.8"
+                    clamped_for_volta = True
 
             docker_tag_map = {
                 "11.8": "cu118",
@@ -685,15 +692,27 @@ def self_test__machine(args):
                 "13.0": "cu130",
             }
 
+            cap_hint = f"compute_cap={compute_cap}" if compute_cap is not None else "compute_cap=unknown"
+
             if cuda_version in docker_tag_map:
-                return f"{docker_repo}:self-test-{docker_tag_map[cuda_version]}"
+                tag = docker_tag_map[cuda_version]
+                if clamped_for_volta:
+                    reason = f"{cap_hint} (Volta) + cuda_max_good={original_cuda} → clamped to {cuda_version} → {tag}"
+                else:
+                    reason = f"{cap_hint}, cuda_max_good={cuda_version} → exact match → {tag}"
+                return f"{docker_repo}:self-test-{tag}", reason
 
             cuda_float = float(cuda_version)
             next_version = round(cuda_float - 0.1, 1)
             while next_version >= min(float(v) for v in docker_tag_map.keys()):
                 next_version_str = str(next_version)
                 if next_version_str in docker_tag_map:
-                    return f"{docker_repo}:self-test-{docker_tag_map[next_version_str]}"
+                    tag = docker_tag_map[next_version_str]
+                    reason = (
+                        f"{cap_hint}, cuda_max_good={original_cuda} → "
+                        f"stepped down to {next_version_str} → {tag}"
+                    )
+                    return f"{docker_repo}:self-test-{tag}", reason
                 next_version = round(next_version - 0.1, 1)
 
             raise KeyError(f"No CUDA version found for {cuda_version} or any lower version")
@@ -729,14 +748,14 @@ def self_test__machine(args):
             ask_contract_id = top_offer["id"]
             cuda_version = top_offer["cuda_max_good"]
             compute_cap = top_offer.get("compute_cap")
-            docker_image = cuda_map_to_image(cuda_version, compute_cap)
+            docker_image, image_reason = cuda_map_to_image(cuda_version, compute_cap)
 
             # ----- create the test instance -----
             try:
                 from vastai.cli.util import parse_env
                 env = parse_env("-e TZ=PDT -e XNAME=XX4 -p 5000:5000 -p 1234:1234")
 
-                progress_print(f"Starting test with {docker_image}")
+                progress_print(f"Starting test with {docker_image} ({image_reason})")
                 rj = instances_api.create_instance(
                     client,
                     id=ask_contract_id,

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -1019,25 +1019,38 @@ def self_test__machine(args):
                             result["success"] = success
                             result["reason"] = reason
 
+    except KeyboardInterrupt:
+        result["success"] = False
+        result["reason"] = "Interrupted by user (Ctrl+C)"
+        progress_print("\nInterrupted — cleaning up test instance...")
     except Exception as e:
         result["success"] = False
         result["reason"] = str(e)
 
     finally:
-        try:
-            if instance_id:
-                # Helper might not be defined if we failed early, so use API directly
-                try:
-                    info = instances_api.show_instance(client, id=instance_id)
-                    if info:
-                        status = info.get('intended_status') or info.get('actual_status')
-                        if status not in ['destroyed', 'terminated', 'offline']:
-                            instances_api.destroy_instance(client, id=instance_id)
-                except Exception:
-                    pass
-        except Exception as e:
-            if args.debugging:
-                print(f"Error during cleanup: {e}")
+        # Always attempt to destroy the test instance, including on Ctrl+C.
+        # KeyboardInterrupt is BaseException (not Exception) so it skips the
+        # typed except above and lands here. Surface failures loudly: a
+        # silently-leaked instance keeps billing the host.
+        if instance_id:
+            try:
+                info = instances_api.show_instance(client, id=instance_id)
+                status = (info or {}).get('intended_status') or (info or {}).get('actual_status')
+                if status not in ('destroyed', 'terminated', 'offline'):
+                    progress_print(f"Destroying test instance {instance_id} (status: {status})...")
+                    instances_api.destroy_instance(client, id=instance_id)
+                    progress_print(f"Test instance {instance_id} destroyed.")
+            except KeyboardInterrupt:
+                progress_print(
+                    f"\nSecond interrupt during cleanup — instance {instance_id} may still be running.\n"
+                    f"  Destroy it manually: vastai destroy instance {instance_id}"
+                )
+                raise
+            except Exception as e:
+                progress_print(
+                    f"WARNING: failed to destroy test instance {instance_id}: {e}\n"
+                    f"  Destroy it manually: vastai destroy instance {instance_id}"
+                )
 
     if args.raw:
         print(json.dumps(result))


### PR DESCRIPTION
## Summary

Update `self_test__machine`'s docker image selection to match the new three-image lineup (`vastai/test:self-test-cuda-11.8|12.8|13.0`) and add a compute-capability rule so older GPUs land on a wheel that actually has kernels for them. Also fixes the test-instance cleanup so it actually runs on Ctrl+C.

## Image selection

`docker_tag_map` is trimmed to `cuda-11.8 / cuda-12.8 / cuda-13.0` (drops the now-unpublished `cu121 / cu124 / cu126` entries). The existing decrement-by-0.1 fallback still resolves intermediate CUDA versions to the nearest lower tag — e.g. a host on CUDA 12.4 steps down to `cuda-11.8`, since the host driver can't load `cuda-12.8` wheels.

Two `compute_cap` branches added on top:

1. **`compute_cap < 700` → force `cuda-11.8`.** `cuda-12.8` (torch 2.10) and `cuda-13.0` (torch 2.11) wheels don't compile `sm_50`/`sm_60` kernels, so Maxwell and Pascal must use the legacy image regardless of CUDA version.
2. **`compute_cap < 750` (Volta) + `cuda_max_good > 12.8` → clamp `cuda_version` to `12.8`.** `cuda-12.8` (pinned to torch 2.10) still ships `sm_70` kernels, but `cuda-13.0` wheels never did. Without the clamp, a V100 with a CUDA 13 driver installed would resolve to `cuda-13.0` and fail with "no kernel image available." Cap and let the version map pick `cuda-12.8`.

Sample decisions (now logged with the reason):

| Host | Image | Reason |
|---|---|---|
| V100 + CUDA 13 driver | `cuda-12.8` | `compute_cap=700 (Volta) + cuda_max_good=13.0 → clamped to 12.8 → cuda-12.8` |
| V100 + CUDA 12.8 | `cuda-12.8` | `compute_cap=700, cuda_max_good=12.8 → exact match → cuda-12.8` |
| P100 (Pascal) | `cuda-11.8` | `compute_cap=600 below sm_70 → forced cuda-11.8` |
| H100 + CUDA 12.9 | `cuda-12.8` | `compute_cap=900, cuda_max_good=12.9 → stepped down to 12.8 → cuda-12.8` |
| B200 + CUDA 13 | `cuda-13.0` | `compute_cap=1000, cuda_max_good=13.0 → exact match → cuda-13.0` |

`cuda_map_to_image` now returns `(image, reason)` and the `Starting test with …` progress line prints both, so operator logs say *why* a particular image was chosen.

## Ctrl+C cleanup

`KeyboardInterrupt` inherits from `BaseException`, not `Exception`, so the outer `except Exception` was letting it through and the cleanup block's `except Exception: pass` silently ate any resulting destroy failure. Hitting Ctrl+C during the wait/poll phase could leak the test instance.

- Added an explicit `except KeyboardInterrupt` branch above `except Exception` that sets the result reason and prints a cleanup message. The `finally` still runs to do the destroy.
- Dropped the `except Exception: pass` in the cleanup. If the destroy call fails for any reason — auth, network, transient API — a `WARNING:` line now names the instance id and prints the `vastai destroy instance <id>` recovery command.
- The cleanup also catches its own `KeyboardInterrupt` (a second Ctrl+C during the destroy API call) and prints the same manual-cleanup hint before re-raising.

Identical changes applied to the monolithic `vast.py` (`self_test__machine`) and the modular `vastai/cli/commands/machines.py`.

## Test plan

- [ ] `vastai self-test machine <id>` on a Turing+ host with CUDA 12.8 driver — expect `cuda-12.8`, exact match line.
- [ ] `vastai self-test machine <id>` on a V100 with CUDA 13 driver — expect `cuda-12.8`, clamped line.
- [ ] `vastai self-test machine <id>` on a Pascal host — expect `cuda-11.8`, forced line.
- [ ] During an in-progress self-test, hit Ctrl+C. Confirm the test instance is destroyed and no leaked instance shows up in `vastai show instances`.
- [ ] Run with the destroy intentionally broken (e.g. revoked API key) and confirm the new WARNING surfaces the instance id and the manual cleanup command.
