### PR TITLE
tell user which api key used on 401 error, group --help commands

### DIFF
--- a/vastai/cli/commands/auth.py
+++ b/vastai/cli/commands/auth.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from vastai.cli.parser import argument
 from vastai.cli.display import deindent, display_table
 from vastai.api import auth as auth_api
-from vastai.cli.util import SUCCESS, WARN, FAIL
+from vastai.cli.util import SUCCESS, WARN, FAIL, fmt_key_suffix
 
 
 # ---------------------------------------------------------------------------
@@ -215,15 +215,8 @@ def set__api_key(args):
 
     env_key = os.environ.get("VAST_API_KEY")
     if env_key:
-        env_last4 = f"...{env_key[-4:]}" if len(env_key) >= 4 else "(empty)"
-        print(f"\n{WARN} VAST_API_KEY is set in your environment (ends in {env_last4}) and takes precedence over the saved file.")
-        print("The key you just saved will not be used until you unset VAST_API_KEY:")
-        if os.name == "nt":
-            print("  PowerShell:  Remove-Item Env:VAST_API_KEY")
-            print("  cmd.exe:     set VAST_API_KEY=")
-        else:
-            print("  unset VAST_API_KEY")
-        print("If you set it permanently (shell rc file, or `setx` on Windows), you'll also need to remove it from there.")
+        print(f"\n{WARN} VAST_API_KEY is set in your environment (ends in {fmt_key_suffix(env_key)}) and overrides the key you just saved.")
+        print("Unset VAST_API_KEY to use the saved key.")
 
 
 # ---------------------------------------------------------------------------

--- a/vastai/cli/commands/auth.py
+++ b/vastai/cli/commands/auth.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from vastai.cli.parser import argument
 from vastai.cli.display import deindent, display_table
 from vastai.api import auth as auth_api
-from vastai.cli.util import SUCCESS, WARN, FAIL, fmt_key_suffix
+from vastai.cli.util import SUCCESS, WARN, FAIL, format_key_suffix
 
 
 # ---------------------------------------------------------------------------
@@ -215,7 +215,7 @@ def set__api_key(args):
 
     env_key = os.environ.get("VAST_API_KEY")
     if env_key:
-        print(f"\n{WARN} VAST_API_KEY is set in your environment (ends in {fmt_key_suffix(env_key)}) and overrides the key you just saved.")
+        print(f"\n{WARN} VAST_API_KEY is set in your environment (ends in {format_key_suffix(env_key)}) and overrides the key you just saved.")
         print("Unset VAST_API_KEY to use the saved key.")
 
 

--- a/vastai/cli/commands/auth.py
+++ b/vastai/cli/commands/auth.py
@@ -211,7 +211,8 @@ def set__api_key(args):
 
     if os.path.exists(APIKEY_FILE_HOME):
         os.remove(APIKEY_FILE_HOME)
-        print("Your api key has been removed from {}".format(APIKEY_FILE_HOME))
+        if getattr(args, "explain", False):
+            print("Removed legacy api key file at {} (no longer used).".format(APIKEY_FILE_HOME))
 
     env_key = os.environ.get("VAST_API_KEY")
     if env_key:

--- a/vastai/cli/commands/auth.py
+++ b/vastai/cli/commands/auth.py
@@ -223,6 +223,7 @@ def set__api_key(args):
             print("  cmd.exe:     set VAST_API_KEY=")
         else:
             print("  unset VAST_API_KEY")
+        print("If you set it permanently (shell rc file, or `setx` on Windows), you'll also need to remove it from there.")
 
 
 # ---------------------------------------------------------------------------

--- a/vastai/cli/commands/auth.py
+++ b/vastai/cli/commands/auth.py
@@ -213,6 +213,17 @@ def set__api_key(args):
         os.remove(APIKEY_FILE_HOME)
         print("Your api key has been removed from {}".format(APIKEY_FILE_HOME))
 
+    env_key = os.environ.get("VAST_API_KEY")
+    if env_key:
+        env_last4 = f"...{env_key[-4:]}" if len(env_key) >= 4 else "(empty)"
+        print(f"\n{WARN} VAST_API_KEY is set in your environment (ends in {env_last4}) and takes precedence over the saved file.")
+        print("The key you just saved will not be used until you unset VAST_API_KEY:")
+        if os.name == "nt":
+            print("  PowerShell:  Remove-Item Env:VAST_API_KEY")
+            print("  cmd.exe:     set VAST_API_KEY=")
+        else:
+            print("  unset VAST_API_KEY")
+
 
 # ---------------------------------------------------------------------------
 # Note: set__user and show__user are in billing.py.

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -33,8 +33,6 @@ def _emit_error(args, status_code, message):
     else:
         print(message, file=sys.stderr)
 
-    # Surface which keys are configured so the user can confirm they're
-    # using the key they expect.
     if status_code == 401:
         env = os.environ.get("VAST_API_KEY")
         file_key = None

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -7,7 +7,7 @@ import requests
 from vastai.cli.parser import apwrap, argument, MyWideHelpFormatter, set_completers
 from vastai.cli.util import (
     APIKEY_FILE, TFAKEY_FILE, VERSION, server_url_default, api_key_guard,
-    fmt_key_suffix,
+    format_key_suffix,
 )
 
 try:
@@ -47,9 +47,9 @@ def _emit_error(args, status_code, message):
         if not env and not file_key:
             return
         if env:
-            print(f"  $VAST_API_KEY is set (ends in {fmt_key_suffix(env)}); env beats file.", file=sys.stderr)
+            print(f"  $VAST_API_KEY is set (ends in {format_key_suffix(env)}); env beats file.", file=sys.stderr)
         if file_key:
-            print(f"  {APIKEY_FILE} contains a key (ends in {fmt_key_suffix(file_key)}).", file=sys.stderr)
+            print(f"  {APIKEY_FILE} contains a key (ends in {format_key_suffix(file_key)}).", file=sys.stderr)
         print("  Compare with the key you expected to use.", file=sys.stderr)
 
 

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -7,6 +7,7 @@ import requests
 from vastai.cli.parser import apwrap, argument, MyWideHelpFormatter, set_completers
 from vastai.cli.util import (
     APIKEY_FILE, TFAKEY_FILE, VERSION, server_url_default, api_key_guard,
+    fmt_key_suffix,
 )
 
 try:
@@ -21,9 +22,6 @@ def _emit_error(args, status_code, message):
     In ``--raw`` mode, prints a JSON error object to stderr so scripts can
     parse it; otherwise prints a human-readable line. Always goes to stderr
     so stdout stays clean for scripting consumers.
-
-    On 401 "Invalid user key" (non-raw mode), also surface which keys are
-    currently configured so the user can spot a stale env var or wrong file.
     """
     if getattr(args, "raw", False):
         payload = {"error": True, "status_code": status_code, "msg": message}
@@ -35,9 +33,9 @@ def _emit_error(args, status_code, message):
     else:
         print(message, file=sys.stderr)
 
-    if status_code == 401 and message == "Invalid user key":
-        def last4(k):
-            return f"...{k[-4:]}" if k and len(k) >= 4 else "(empty)"
+    # Surface which keys are configured so the user can confirm they're
+    # using the key they expect.
+    if status_code == 401:
         env = os.environ.get("VAST_API_KEY")
         file_key = None
         if os.path.exists(APIKEY_FILE):
@@ -49,10 +47,10 @@ def _emit_error(args, status_code, message):
         if not env and not file_key:
             return
         if env:
-            print(f"  $VAST_API_KEY is set (ends in {last4(env)}); env beats file.", file=sys.stderr)
+            print(f"  $VAST_API_KEY is set (ends in {fmt_key_suffix(env)}); env beats file.", file=sys.stderr)
         if file_key:
-            print(f"  {APIKEY_FILE} contains a key (ends in {last4(file_key)}).", file=sys.stderr)
-        print("  Compare the suffix to the key you meant to use; unset or replace whichever is stale.", file=sys.stderr)
+            print(f"  {APIKEY_FILE} contains a key (ends in {fmt_key_suffix(file_key)}).", file=sys.stderr)
+        print("  Compare with the key you expected to use.", file=sys.stderr)
 
 
 # Create the global parser instance

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -54,13 +54,14 @@ def _emit_error(args, status_code, message):
                     file_key = f.read().strip()
             except OSError:
                 pass
-        if not env and not file_key:
-            return
-        if env:
-            print(f"  $VAST_API_KEY is set (ends in {format_key_suffix(env)}); env beats file.", file=sys.stderr)
-        if file_key:
-            print(f"  {APIKEY_FILE} contains a key (ends in {format_key_suffix(file_key)}).", file=sys.stderr)
-        print("  Compare with the key you expected to use.", file=sys.stderr)
+
+        if env and file_key:
+            print(f"  Sent key from $VAST_API_KEY (ends in {format_key_suffix(env)}). Env var overrides the file.", file=sys.stderr)
+            print(f"  Unset the VAST_API_KEY env var to use the saved key in {APIKEY_FILE} (ends in {format_key_suffix(file_key)}) instead.", file=sys.stderr)
+        elif env:
+            print(f"  Sent key from $VAST_API_KEY (ends in {format_key_suffix(env)}). Update the env var with a new key.", file=sys.stderr)
+        elif file_key:
+            print(f"  Sent key from {APIKEY_FILE} (ends in {format_key_suffix(file_key)}). Update with: vastai set api-key <KEY>", file=sys.stderr)
 
 
 # Create the global parser instance

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -21,56 +21,38 @@ def _emit_error(args, status_code, message):
     In ``--raw`` mode, prints a JSON error object to stderr so scripts can
     parse it; otherwise prints a human-readable line. Always goes to stderr
     so stdout stays clean for scripting consumers.
+
+    On 401 "Invalid user key" (non-raw mode), also surface which keys are
+    currently configured so the user can spot a stale env var or wrong file.
     """
     if getattr(args, "raw", False):
         payload = {"error": True, "status_code": status_code, "msg": message}
         print(json.dumps(payload), file=sys.stderr)
+        return
+
+    if status_code:
+        print(f"Failed with error {status_code}: {message}", file=sys.stderr)
     else:
-        if status_code:
-            print(f"Failed with error {status_code}: {message}", file=sys.stderr)
-        else:
-            print(message, file=sys.stderr)
+        print(message, file=sys.stderr)
 
-
-def _gather_key_sources(cli_flag_value):
-    """Return all configured API key sources in precedence order.
-
-    Each entry is ``(source_label, key_value)``. The first entry is the one
-    the CLI will actually use; remaining entries exist for diagnostics so a
-    401 message can tell the user which other keys are configured.
-    """
-    sources = []
-    if cli_flag_value is not api_key_guard:
-        sources.append(("--api-key flag", cli_flag_value))
-    env = os.getenv("VAST_API_KEY")
-    if env:
-        sources.append(("VAST_API_KEY env var", env))
-    if os.path.exists(TFAKEY_FILE):
-        try:
-            with open(TFAKEY_FILE) as f:
-                sources.append((f"TFA session file ({TFAKEY_FILE})", f.read().strip()))
-        except OSError:
-            pass
-    if os.path.exists(APIKEY_FILE):
-        try:
-            with open(APIKEY_FILE) as f:
-                sources.append((f"API key file ({APIKEY_FILE})", f.read().strip()))
-        except OSError:
-            pass
-    return sources
-
-
-def _format_key_diagnostic(used_source, used_key, all_sources):
-    def last4(k):
-        return f"...{k[-4:]}" if k and len(k) >= 4 else "(empty)"
-    lines = [f"  Used key from: {used_source} (ends in {last4(used_key)})"]
-    others = [(s, k) for s, k in all_sources if s != used_source]
-    if others:
-        lines.append("  Also configured:")
-        for s, k in others:
-            lines.append(f"    - {s} (ends in {last4(k)})")
-        lines.append("  Tip: env var beats file. Unset VAST_API_KEY or pass --api-key to use a different key.")
-    return "\n".join(lines)
+    if status_code == 401 and message == "Invalid user key":
+        def last4(k):
+            return f"...{k[-4:]}" if k and len(k) >= 4 else "(empty)"
+        env = os.environ.get("VAST_API_KEY")
+        file_key = None
+        if os.path.exists(APIKEY_FILE):
+            try:
+                with open(APIKEY_FILE) as f:
+                    file_key = f.read().strip()
+            except OSError:
+                pass
+        if not env and not file_key:
+            return
+        if env:
+            print(f"  $VAST_API_KEY is set (ends in {last4(env)}); env beats file.", file=sys.stderr)
+        if file_key:
+            print(f"  {APIKEY_FILE} contains a key (ends in {last4(file_key)}).", file=sys.stderr)
+        print("  Compare the suffix to the key you meant to use; unset or replace whichever is stale.", file=sys.stderr)
 
 
 # Create the global parser instance
@@ -111,7 +93,7 @@ def main():
     parser.add_argument("--raw", action="store_true", help="Output machine-readable json")
     parser.add_argument("--full", action="store_true", help="Print full results instead of paging with `less` for commands that support it")
     parser.add_argument("--curl", action="store_true", help="Show a curl equivalency to the call")
-    parser.add_argument("--api-key", help="API key to use. If unset, falls back to $VAST_API_KEY, then {}".format(APIKEY_FILE), type=str, required=False, default=api_key_guard)
+    parser.add_argument("--api-key", help="API Key to use. defaults to using the one stored in {}".format(APIKEY_FILE), type=str, required=False, default=os.getenv("VAST_API_KEY", api_key_guard))
     parser.add_argument("--version", help="Show CLI version", action="version", version=VERSION)
     parser.add_argument("--no-color", action="store_true", help="Disable colored output for commands that support it")
 
@@ -132,16 +114,14 @@ def main():
 
     args = parser.parse_args()
 
-    # API key resolution. Precedence (highest first): --api-key flag,
-    # $VAST_API_KEY, TFA session file, API key file. The source label is
-    # kept around so a 401 can tell the user which key was rejected.
-    original_cli_flag = args.api_key
-    key_sources = _gather_key_sources(original_cli_flag)
-    if key_sources:
-        key_source, args.api_key = key_sources[0]
-    else:
-        key_source = None
-        args.api_key = None
+    # API key resolution
+    if args.api_key is api_key_guard:
+        key_file = TFAKEY_FILE if os.path.exists(TFAKEY_FILE) else APIKEY_FILE
+        if os.path.exists(key_file):
+            with open(key_file, "r") as reader:
+                args.api_key = reader.read().strip()
+        else:
+            args.api_key = None
 
     # Execute command with error handling
     while True:
@@ -164,29 +144,19 @@ def main():
                 else:
                     errmsg = "(no detail message supplied)"
 
-            if e.response.status_code == 401 and errmsg == "Invalid user key":
-                # TFA session rejected -> assume expiry, retry with long-lived key.
-                if key_source and key_source.startswith("TFA session file"):
-                    print(f"Failed with error {e.response.status_code}: Your 2FA session has expired.")
-                    try:
-                        os.remove(TFAKEY_FILE)
-                    except OSError:
-                        pass
-                    if os.path.exists(APIKEY_FILE):
-                        with open(APIKEY_FILE, "r") as reader:
-                            args.api_key = reader.read().strip()
-                        key_source = f"API key file ({APIKEY_FILE})"
-                        key_sources = _gather_key_sources(original_cli_flag)
+            # 2FA session key expired -> retry with long-lived API key
+            if (e.response.status_code == 401 and errmsg == "Invalid user key"
+                    and os.path.exists(TFAKEY_FILE)):
+                print(f"Failed with error {e.response.status_code}: Your 2FA session has expired.")
+                os.remove(TFAKEY_FILE)
+                if os.path.exists(APIKEY_FILE):
+                    with open(APIKEY_FILE, "r") as reader:
+                        args.api_key = reader.read().strip()
                         print(f"Trying again with your normal API Key from {APIKEY_FILE}...")
                         continue
-                    else:
-                        print("Please log in using the `tfa login` command and try again.")
-                        break
-
-                _emit_error(args, e.response.status_code, errmsg)
-                if key_source and not getattr(args, "raw", False):
-                    print(_format_key_diagnostic(key_source, args.api_key, key_sources), file=sys.stderr)
-                break
+                else:
+                    print("Please log in using the `tfa login` command and try again.")
+                    break
 
             _emit_error(args, e.response.status_code, errmsg)
             break

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -34,6 +34,18 @@ def _emit_error(args, status_code, message):
         print(message, file=sys.stderr)
 
     if status_code == 401:
+        if "Two Factor Authentication" in message:
+            print(
+                "\nThis endpoint requires a 2FA session. Authenticate with the method you have set up:\n"
+                "  vastai tfa login --method-type totp -c <CODE>\n"
+                "  vastai tfa login --method-type sms   --secret <SECRET> -c <CODE>\n"
+                "  vastai tfa login --method-type email --secret <SECRET> -c <CODE>\n"
+                "  vastai tfa login --backup-code ABCD-EFGH-IJKL\n"
+                "For SMS or email, first run 'vastai tfa send-sms' or 'vastai tfa send-email' to get <SECRET>.",
+                file=sys.stderr,
+            )
+            return
+
         env = os.environ.get("VAST_API_KEY")
         file_key = None
         if os.path.exists(APIKEY_FILE):

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -32,6 +32,47 @@ def _emit_error(args, status_code, message):
             print(message, file=sys.stderr)
 
 
+def _gather_key_sources(cli_flag_value):
+    """Return all configured API key sources in precedence order.
+
+    Each entry is ``(source_label, key_value)``. The first entry is the one
+    the CLI will actually use; remaining entries exist for diagnostics so a
+    401 message can tell the user which other keys are configured.
+    """
+    sources = []
+    if cli_flag_value is not api_key_guard:
+        sources.append(("--api-key flag", cli_flag_value))
+    env = os.getenv("VAST_API_KEY")
+    if env:
+        sources.append(("VAST_API_KEY env var", env))
+    if os.path.exists(TFAKEY_FILE):
+        try:
+            with open(TFAKEY_FILE) as f:
+                sources.append((f"TFA session file ({TFAKEY_FILE})", f.read().strip()))
+        except OSError:
+            pass
+    if os.path.exists(APIKEY_FILE):
+        try:
+            with open(APIKEY_FILE) as f:
+                sources.append((f"API key file ({APIKEY_FILE})", f.read().strip()))
+        except OSError:
+            pass
+    return sources
+
+
+def _format_key_diagnostic(used_source, used_key, all_sources):
+    def last4(k):
+        return f"...{k[-4:]}" if k and len(k) >= 4 else "(empty)"
+    lines = [f"  Used key from: {used_source} (ends in {last4(used_key)})"]
+    others = [(s, k) for s, k in all_sources if s != used_source]
+    if others:
+        lines.append("  Also configured:")
+        for s, k in others:
+            lines.append(f"    - {s} (ends in {last4(k)})")
+        lines.append("  Tip: env var beats file. Unset VAST_API_KEY or pass --api-key to use a different key.")
+    return "\n".join(lines)
+
+
 # Create the global parser instance
 parser = apwrap(
     epilog="Use 'vast COMMAND --help' for more info about a command. AI agent? See https://raw.githubusercontent.com/vast-ai/vast-cli/master/vastai/SKILL.md",
@@ -70,7 +111,7 @@ def main():
     parser.add_argument("--raw", action="store_true", help="Output machine-readable json")
     parser.add_argument("--full", action="store_true", help="Print full results instead of paging with `less` for commands that support it")
     parser.add_argument("--curl", action="store_true", help="Show a curl equivalency to the call")
-    parser.add_argument("--api-key", help="API Key to use. defaults to using the one stored in {}".format(APIKEY_FILE), type=str, required=False, default=os.getenv("VAST_API_KEY", api_key_guard))
+    parser.add_argument("--api-key", help="API key to use. If unset, falls back to $VAST_API_KEY, then {}".format(APIKEY_FILE), type=str, required=False, default=api_key_guard)
     parser.add_argument("--version", help="Show CLI version", action="version", version=VERSION)
     parser.add_argument("--no-color", action="store_true", help="Disable colored output for commands that support it")
 
@@ -91,14 +132,16 @@ def main():
 
     args = parser.parse_args()
 
-    # API key resolution
-    if args.api_key is api_key_guard:
-        key_file = TFAKEY_FILE if os.path.exists(TFAKEY_FILE) else APIKEY_FILE
-        if os.path.exists(key_file):
-            with open(key_file, "r") as reader:
-                args.api_key = reader.read().strip()
-        else:
-            args.api_key = None
+    # API key resolution. Precedence (highest first): --api-key flag,
+    # $VAST_API_KEY, TFA session file, API key file. The source label is
+    # kept around so a 401 can tell the user which key was rejected.
+    original_cli_flag = args.api_key
+    key_sources = _gather_key_sources(original_cli_flag)
+    if key_sources:
+        key_source, args.api_key = key_sources[0]
+    else:
+        key_source = None
+        args.api_key = None
 
     # Execute command with error handling
     while True:
@@ -121,19 +164,29 @@ def main():
                 else:
                     errmsg = "(no detail message supplied)"
 
-            # 2FA Session Key Expired
             if e.response.status_code == 401 and errmsg == "Invalid user key":
-                if os.path.exists(TFAKEY_FILE):
+                # TFA session rejected -> assume expiry, retry with long-lived key.
+                if key_source and key_source.startswith("TFA session file"):
                     print(f"Failed with error {e.response.status_code}: Your 2FA session has expired.")
-                    os.remove(TFAKEY_FILE)
+                    try:
+                        os.remove(TFAKEY_FILE)
+                    except OSError:
+                        pass
                     if os.path.exists(APIKEY_FILE):
                         with open(APIKEY_FILE, "r") as reader:
                             args.api_key = reader.read().strip()
-                            print(f"Trying again with your normal API Key from {APIKEY_FILE}...")
-                            continue
+                        key_source = f"API key file ({APIKEY_FILE})"
+                        key_sources = _gather_key_sources(original_cli_flag)
+                        print(f"Trying again with your normal API Key from {APIKEY_FILE}...")
+                        continue
                     else:
                         print("Please log in using the `tfa login` command and try again.")
                         break
+
+                _emit_error(args, e.response.status_code, errmsg)
+                if key_source and not getattr(args, "raw", False):
+                    print(_format_key_diagnostic(key_source, args.api_key, key_sources), file=sys.stderr)
+                break
 
             _emit_error(args, e.response.status_code, errmsg)
             break

--- a/vastai/cli/parser.py
+++ b/vastai/cli/parser.py
@@ -82,13 +82,104 @@ class hidden_aliases(object):
         self.l.append(x)
 
 
-# ---------------------------------------------------------------------------
-# Help formatter
-# ---------------------------------------------------------------------------
-
 class MyWideHelpFormatter(argparse.RawTextHelpFormatter):
     def __init__(self, prog):
         super().__init__(prog, width=128, max_help_position=50, indent_increment=1)
+
+
+COMMAND_GROUPS = {
+    'vastai.cli.commands.offers':       'Search',
+    'vastai.cli.commands.instances':    'Instances',
+    'vastai.cli.commands.benchmarks':   'Instances',
+    'vastai.cli.commands.machines':     'Host machines',
+    'vastai.cli.commands.teams':        'Teams',
+    'vastai.cli.commands.keys':         'Auth & keys',
+    'vastai.cli.commands.auth':         'Auth & keys',
+    'vastai.cli.commands.billing':      'Billing & account',
+    'vastai.cli.commands.endpoints':    'Serverless',
+    'vastai.cli.commands.deployments':  'Serverless',
+    'vastai.cli.commands.metrics':      'Metrics',
+    'vastai.cli.commands.storage':      'Storage volumes',
+    'vastai.cli.commands.misc':         'Other',
+}
+
+# Some misc.py commands belong with their target resource section, not Other.
+COMMAND_OVERRIDES = {
+    'execute':       'Instances',
+    'logs':          'Instances',
+    'ssh-url':       'Instances',
+    'scp-url':       'Instances',
+    'take snapshot': 'Instances',
+    'reports':       'Host machines',
+}
+
+GROUP_ORDER = [
+    'Search', 'Instances', 'Host machines', 'Teams', 'Auth & keys',
+    'Billing & account', 'Serverless', 'Metrics', 'Storage volumes', 'Other',
+]
+
+
+class GroupedArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that renders subcommands grouped by registering module."""
+
+    def format_help(self):
+        sub_action = self._subparsers_action()
+        if sub_action is None or not sub_action.choices:
+            return super().format_help()
+
+        formatter = self._get_formatter()
+        formatter.add_usage(self.usage, self._actions, self._mutually_exclusive_groups)
+        formatter.add_text(self.description)
+
+        # Skip the subparsers action; we render commands grouped below.
+        for action_group in self._action_groups:
+            non_sub_actions = [
+                a for a in action_group._group_actions
+                if not isinstance(a, argparse._SubParsersAction)
+            ]
+            if not non_sub_actions:
+                continue
+            formatter.start_section(action_group.title)
+            formatter.add_text(action_group.description)
+            formatter.add_arguments(non_sub_actions)
+            formatter.end_section()
+
+        self._add_grouped_commands(formatter, sub_action)
+        formatter.add_text(self.epilog)
+        return formatter.format_help()
+
+    def _subparsers_action(self):
+        for a in self._actions:
+            if isinstance(a, argparse._SubParsersAction):
+                return a
+        return None
+
+    def _add_grouped_commands(self, formatter, sub_action):
+        grouped = {}
+        for pseudo in sub_action._choices_actions:
+            sp = sub_action.choices.get(pseudo.dest)
+            if sp is None:
+                continue
+            label = COMMAND_OVERRIDES.get(pseudo.dest)
+            if label is None:
+                func = sp.get_default('func')
+                module = getattr(func, '__module__', None)
+                label = COMMAND_GROUPS.get(module, 'Other')
+            grouped.setdefault(label, []).append(pseudo)
+
+        seen = set()
+        for label in GROUP_ORDER:
+            if label in grouped:
+                formatter.start_section(label)
+                formatter.add_arguments(grouped[label])
+                formatter.end_section()
+                seen.add(label)
+        for label, actions in grouped.items():
+            if label in seen:
+                continue
+            formatter.start_section(label)
+            formatter.add_arguments(actions)
+            formatter.end_section()
 
 
 # ---------------------------------------------------------------------------
@@ -102,7 +193,7 @@ class apwrap(object):
     def __init__(self, *args, **kwargs):
         if "formatter_class" not in kwargs:
             kwargs["formatter_class"] = MyWideHelpFormatter
-        self.parser = argparse.ArgumentParser(*args, **kwargs)
+        self.parser = GroupedArgumentParser(*args, **kwargs)
         self.parser.set_defaults(func=self.fail_with_help)
         self.subparsers_ = None
         self.subparser_objs = []

--- a/vastai/cli/util.py
+++ b/vastai/cli/util.py
@@ -158,8 +158,7 @@ if not os.path.exists(APIKEY_FILE) and os.path.exists(APIKEY_FILE_HOME):
 
 
 def format_key_suffix(k):
-    """Format the last 4 chars of an API key for display, e.g. '...a3f9'.
-    Used in diagnostics so users can identify keys without seeing the full secret."""
+    """Format the last 4 chars of an API key for display, e.g. '...a3f9'."""
     if k and len(k) >= 4:
         return f"...{k[-4:]}"
     return "(empty)"

--- a/vastai/cli/util.py
+++ b/vastai/cli/util.py
@@ -157,7 +157,7 @@ if not os.path.exists(APIKEY_FILE) and os.path.exists(APIKEY_FILE_HOME):
     shutil.copyfile(APIKEY_FILE_HOME, APIKEY_FILE)
 
 
-def fmt_key_suffix(k):
+def format_key_suffix(k):
     """Format the last 4 chars of an API key for display, e.g. '...a3f9'.
     Used in diagnostics so users can identify keys without seeing the full secret."""
     if k and len(k) >= 4:

--- a/vastai/cli/util.py
+++ b/vastai/cli/util.py
@@ -157,6 +157,14 @@ if not os.path.exists(APIKEY_FILE) and os.path.exists(APIKEY_FILE_HOME):
     shutil.copyfile(APIKEY_FILE_HOME, APIKEY_FILE)
 
 
+def fmt_key_suffix(k):
+    """Format the last 4 chars of an API key for display, e.g. '...a3f9'.
+    Used in diagnostics so users can identify keys without seeing the full secret."""
+    if k and len(k) >= 4:
+        return f"...{k[-4:]}"
+    return "(empty)"
+
+
 # ---------------------------------------------------------------------------
 # Simple utility class
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
two changes 

1. group commands in --help 

2. if user enables TFA, their api key just stops working. so now wetell the user why it failed and how to 2fa login through the cli

3. api key issue 
## issue 
users hit 401 "invalid user key" even after calling `vastai set api-key`. 

## why
the cli is using their shell key. we give no clue to the user which key is actually sent. 

Key order is
1. --api-key flag
2. $VAST_API_KEY
3. file written by `set api-key`

## fix 
`vastai set api-key` now warns if the $VAST_API_KEY is set in the env. since the saved key wont be used until thats unset 
we also print the keys to the user (only last 4 digits) so they can compare their keys and remove the stale one 