### PR TITLE
docs: add Interruptible (spot) rentals section to SKILL.md

### DIFF
--- a/vastai/SKILL.md
+++ b/vastai/SKILL.md
@@ -148,6 +148,12 @@ vastai create instance <id> --image vastai/comfy:@vastai-automatic-tag --disk 40
 
 > **Charges:** Storage charges begin at creation. GPU charges begin when status reaches `running`.
 
+### Interruptible (spot) rentals
+
+Interruptible (spot) instances are priced below on-demand instances, but can be interrupted at any time by another user with a lower bid. Note: `search offers --type bid` exposes `min_bid`, but `create instance` defaults to **on-demand at `dph_total`** unless you pass `--bid_price <floor>`. Always pass `--bid_price` after a `--type bid` search, otherwise the instance will be rented as an on-demand instance/price instead of as an interruptible.
+
+When outbid, the instance moves to `stopped` (not destroyed) and storage charges continue. Resume by raising the bid via `update instance --bid_price`.
+
 ### Search
 
 ```bash

--- a/vastai_sdk/SKILL.md
+++ b/vastai_sdk/SKILL.md
@@ -78,6 +78,12 @@ ssh_url = vast.ssh_url(id=12345)   # returns "ssh -p PORT user@host"
 scp_url = vast.scp_url(id=12345)   # returns scp-compatible URL
 ```
 
+### Interruptible (spot) rentals
+
+Interruptible (spot) instances are priced below on-demand instances, but can be interrupted at any time by another user with a lower bid. Note: `vast.search_offers(type='bid', ...)` exposes `min_bid`, but `vast.create_instance(...)` defaults to **on-demand at `dph_total`** unless you pass `bid_price=<floor>`. Always pass `bid_price` after a `type='bid'` search, otherwise the instance will be rented as an on-demand instance/price instead of as an interruptible.
+
+When outbid, the instance moves to `stopped` (not destroyed) and storage charges continue. Resume by raising the bid via `vast.change_bid(id=..., price=...)`.
+
 ### Search
 
 ```python


### PR DESCRIPTION
## Summary

Adds a short **Interruptible (spot) rentals** section to both `vastai/SKILL.md` and `vastai_sdk/SKILL.md` so agents (and humans skimming the skill) get a single canonical explanation of how `--bid_price` / `bid_price=` interacts with `search offers --type bid` / `search_offers(type='bid')`.

## Why

Today the skills mention spot only in three scattered one-liners:
- `--bid_price PRICE — Interruptible (spot) pricing in $/hr`
- `vastai search offers --type bid  # Interruptible (spot) pricing`
- the flag listing in **search offers flags**

There is no single place that tells an agent: "if you searched `--type bid`, you MUST pass `--bid_price` on create, or the API silently provisions on-demand at `dph_total`."

We've seen agent-driven workflows hit this: search returns a spot offer at `min_bid` (e.g. $0.48), the agent omits `--bid_price` on create, and the instance is billed on-demand at `dph_total`. The create response doesn't echo `rental_type` or `bid_price_used`, so the agent has no way to detect the mismatch.

## What's in this PR

Pure docs — zero code changes.

- `vastai/SKILL.md`: new section inserted between the **Charges** callout and the **Search** section.
- `vastai_sdk/SKILL.md`: mirrored section using SDK syntax (`vast.search_offers(type='bid')`, `bid_price=`, `vast.change_bid(id, price)`).

Each section explains:
1. What interruptible/spot means in one sentence.
2. That omitting `--bid_price` after a `--type bid` search rents on-demand at `dph_total`.
3. That outbid instances move to `stopped` (not destroyed), storage charges continue, and how to resume.

## Test plan

- [ ] Verify rendered markdown reads cleanly on GitHub.
- [ ] Re-read both SKILL files top-to-bottom to confirm placement makes sense in context.
- [ ] Confirm the SDK method names referenced (`search_offers(type='bid')`, `create_instance(bid_price=...)`, `change_bid(id, price)`) match the current SDK signatures in `vastai_base.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)