### PR TITLE
add start/stop deployment commands

### DIFF
--- a/tests/cli/test_deployments_commands.py
+++ b/tests/cli/test_deployments_commands.py
@@ -56,6 +56,50 @@ class TestShowDeployment:
             args.func(args)
 
 
+class TestStopDeployment:
+    def test_stop_deployment(self, parse_argv, patch_get_client, mock_response, capsys):
+        patch_get_client.post.return_value = mock_response(200, {"success": True, "endpoint_state": "stopped"})
+        args = parse_argv(["stop", "deployment", "42"])
+        args.func(args)
+        patch_get_client.post.assert_called_once()
+        call_args = patch_get_client.post.call_args
+        assert "/deployment/42/stop/" in call_args[0][0]
+
+    def test_stop_deployment_raw(self, parse_argv, patch_get_client, mock_response):
+        patch_get_client.post.return_value = mock_response(200, {"success": True, "endpoint_state": "stopped"})
+        args = parse_argv(["stop", "deployment", "42", "--raw"])
+        result = args.func(args)
+        assert result["success"] is True
+
+    def test_stop_deployment_error(self, parse_argv, patch_get_client, mock_response):
+        patch_get_client.post.return_value = mock_response(404, {"error": "not found"})
+        args = parse_argv(["stop", "deployment", "999"])
+        with pytest.raises(HTTPError):
+            args.func(args)
+
+
+class TestStartDeployment:
+    def test_start_deployment(self, parse_argv, patch_get_client, mock_response, capsys):
+        patch_get_client.post.return_value = mock_response(200, {"success": True, "endpoint_state": "active"})
+        args = parse_argv(["start", "deployment", "42"])
+        args.func(args)
+        patch_get_client.post.assert_called_once()
+        call_args = patch_get_client.post.call_args
+        assert "/deployment/42/start/" in call_args[0][0]
+
+    def test_start_deployment_raw(self, parse_argv, patch_get_client, mock_response):
+        patch_get_client.post.return_value = mock_response(200, {"success": True, "endpoint_state": "active"})
+        args = parse_argv(["start", "deployment", "42", "--raw"])
+        result = args.func(args)
+        assert result["success"] is True
+
+    def test_start_deployment_error(self, parse_argv, patch_get_client, mock_response):
+        patch_get_client.post.return_value = mock_response(404, {"error": "not found"})
+        args = parse_argv(["start", "deployment", "999"])
+        with pytest.raises(HTTPError):
+            args.func(args)
+
+
 class TestDeleteDeployment:
     def test_delete_deployment(self, parse_argv, patch_get_client, mock_response):
         patch_get_client.delete.return_value = mock_response(200, {"success": True})

--- a/vastai/api/deployments.py
+++ b/vastai/api/deployments.py
@@ -30,6 +30,18 @@ def delete_deployment(client: VastClient, id: int) -> dict:
     return r.json()
 
 
+def stop_deployment(client: VastClient, id: int) -> dict:
+    r = client.post(f"/deployment/{id}/stop/")
+    r.raise_for_status()
+    return r.json()
+
+
+def start_deployment(client: VastClient, id: int) -> dict:
+    r = client.post(f"/deployment/{id}/start/")
+    r.raise_for_status()
+    return r.json()
+
+
 def delete_deployment_by_name(client: VastClient, name: str, tag: str = None) -> dict:
     json_blob = {"name": name}
     if tag is not None:

--- a/vastai/cli/commands/deployments.py
+++ b/vastai/cli/commands/deployments.py
@@ -122,6 +122,63 @@ def show__deployment_versions(args):
 
 
 # ---------------------------------------------------------------------------
+# stop deployment
+# ---------------------------------------------------------------------------
+
+@parser.command(
+    argument("id", help="id of deployment to stop", type=int),
+    usage="vastai stop deployment ID [OPTIONS]",
+    help="Stop a running deployment",
+    epilog=deindent("""
+        Stops the endpoint associated with a deployment. The deployment is not
+        deleted and can be restarted with 'vastai start deployment'.
+
+        Examples:
+            vastai stop deployment 1234
+            vastai stop deployment 1234 --raw
+    """),
+)
+def stop__deployment(args):
+    """Stop a running deployment."""
+    client = get_client(args)
+    rj = deployments_api.stop_deployment(client, id=args.id)
+    if args.raw:
+        return rj
+    elif rj.get("success"):
+        print(f"Deployment {args.id} stopped.")
+    else:
+        print(rj.get("msg", rj))
+
+
+# ---------------------------------------------------------------------------
+# start deployment
+# ---------------------------------------------------------------------------
+
+@parser.command(
+    argument("id", help="id of deployment to start", type=int),
+    usage="vastai start deployment ID [OPTIONS]",
+    help="Start a stopped deployment",
+    epilog=deindent("""
+        Starts (or restarts) the endpoint associated with a deployment.
+
+        Examples:
+            vastai start deployment 1234
+            vastai start deployment 1234 --raw
+    """),
+)
+def start__deployment(args):
+    """Start a stopped deployment."""
+    client = get_client(args)
+    rj = deployments_api.start_deployment(client, id=args.id)
+    if args.raw:
+        return rj
+    elif rj.get("success"):
+        print(f"Deployment {args.id} started.")
+    else:
+        print(rj.get("msg", rj))
+
+
+# ---------------------------------------------------------------------------
 # delete deployment
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
```
 $ vastai show deployments
    #  ID   Name    Tag      Image                                    Endpoint
    1  644  square  default  vastai/base-image:@vastai-automatic-tag  25121

  $ vastai show deployment 644
    #  ID   Name    Tag      Image                                    Endpoint  State   Workers
    1  644  square  default  vastai/base-image:@vastai-automatic-tag  25121     active  -

  $ vastai stop deployment 644
  Deployment 644 stopped.

  $ vastai show deployment 644
    #  ID   Name    Tag      Image                                    Endpoint  State    Workers
    1  644  square  default  vastai/base-image:@vastai-automatic-tag  25121     stopped  -

  $ vastai start deployment 644
  Deployment 644 started.

  $ vastai show deployment 644
    #  ID   Name    Tag      Image                                    Endpoint  State   Workers
    1  644  square  default  vastai/base-image:@vastai-automatic-tag  25121     active  -
    
 ```
