### PR TITLE
Handle missing instances during self-test cleanup

### DIFF
--- a/tests/cli/test_instances_commands.py
+++ b/tests/cli/test_instances_commands.py
@@ -44,6 +44,24 @@ class TestShowInstance:
         call_args = patch_get_client.get.call_args
         assert "123" in call_args[0][0]
 
+    def test_show_instance_raw_deleted_instance(self, parse_argv, patch_get_client, mock_response):
+        patch_get_client.get.return_value = mock_response(200, {"instances": None})
+        args = parse_argv(["show", "instance", "123", "--raw"])
+
+        result = args.func(args)
+
+        assert result == {"instances": None}
+
+    def test_show_instance_display_deleted_instance(self, parse_argv, patch_get_client, mock_response, capsys):
+        patch_get_client.get.return_value = mock_response(200, {"instances": None})
+        args = parse_argv(["show", "instance", "123"])
+
+        result = args.func(args)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Instance 123 not found or no longer exists." in captured.out
+
 
 class TestDestroyInstance:
     def test_destroy_instance(self, parse_argv, patch_get_client, mock_response, capsys):

--- a/tests/cli/test_instances_commands.py
+++ b/tests/cli/test_instances_commands.py
@@ -20,6 +20,14 @@ class TestShowInstances:
         assert "/instances" in call_args[0][0]
         assert isinstance(result, list)
 
+    def test_show_instances_raw_null_instances(self, parse_argv, patch_get_client, mock_response):
+        patch_get_client.get.return_value = mock_response(200, {"instances": None})
+        args = parse_argv(["show", "instances", "--raw"])
+
+        result = args.func(args)
+
+        assert result == []
+
     def test_show_instances_display(self, parse_argv, patch_get_client, mock_response, capsys):
         patch_get_client.get.return_value = mock_response(200, {
             "instances": [
@@ -60,7 +68,8 @@ class TestShowInstance:
 
         assert result == 1
         captured = capsys.readouterr()
-        assert "Instance 123 not found or no longer exists." in captured.out
+        assert captured.out == ""
+        assert "Instance 123 not found or no longer exists." in captured.err
 
 
 class TestDestroyInstance:

--- a/tests/cli/test_machines_commands.py
+++ b/tests/cli/test_machines_commands.py
@@ -1,5 +1,8 @@
 """Integration tests for machine CLI commands with mocked HTTP."""
 
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
 
 
@@ -73,3 +76,57 @@ class TestListMachineMinChunkDefault:
         args.func(args)
         body = patch_get_client.put.call_args[1]["json_data"]
         assert body["min_chunk"] == 4
+
+
+class TestSelfTestMachineCleanup:
+    def test_successful_destroy_does_not_warn_when_instance_is_already_gone(
+        self, parse_argv, monkeypatch, capsys
+    ):
+        from vastai.cli.commands import machines
+
+        offer = {
+            "id": 777,
+            "cuda_max_good": "13.0",
+            "compute_cap": 860,
+            "dlperf": 1,
+            "reliability": 0.99,
+            "direct_port_count": 4,
+            "pcie_bw": 3.0,
+            "gpu_total_ram": 12288,
+            "inet_down": 500,
+            "inet_up": 500,
+            "gpu_ram": 8,
+            "cpu_ram": 16000,
+            "cpu_cores": 4,
+            "num_gpus": 1,
+        }
+        running_instance = {
+            "id": 123,
+            "actual_status": "running",
+            "intended_status": "running",
+            "public_ipaddr": "127.0.0.1",
+            "ports": {"5000/tcp": [{"HostPort": "5000"}]},
+            "status_msg": "",
+        }
+
+        monkeypatch.setattr(machines.offers_api, "search_offers", Mock(return_value=[offer]))
+        monkeypatch.setattr(machines.instances_api, "create_instance", Mock(return_value={"new_contract": 123}))
+        monkeypatch.setattr(machines.instances_api, "show_instance", Mock(side_effect=[
+            running_instance,
+            running_instance,
+            None,
+        ]))
+        destroy_instance = Mock(return_value={"success": True})
+        monkeypatch.setattr(machines.instances_api, "destroy_instance", destroy_instance)
+        monkeypatch.setattr(machines.requests, "get", lambda *_, **__: SimpleNamespace(status_code=200, text="DONE"))
+        monkeypatch.setattr(machines.time, "sleep", lambda *_: None)
+
+        args = parse_argv(["self-test", "machine", "46368"])
+        with pytest.raises(SystemExit) as exit_info:
+            args.func(args)
+
+        assert exit_info.value.code == 0
+        assert destroy_instance.call_count == 1
+        captured = capsys.readouterr()
+        assert "Instance 123 destroyed successfully on attempt 1." in captured.out
+        assert "WARNING: failed to destroy test instance 123" not in captured.out

--- a/tests/sdk/test_sdk.py
+++ b/tests/sdk/test_sdk.py
@@ -126,6 +126,10 @@ class TestSshUrl:
         with patch("vastai.api.instances.show_instance", return_value={}):
             assert sdk.ssh_url(1) == ""
 
+    def test_empty_when_deleted(self, sdk):
+        with patch("vastai.api.instances.show_instance", return_value=None):
+            assert sdk.ssh_url(1) == ""
+
     def test_unwraps_list_response(self, sdk):
         with patch("vastai.api.instances.show_instance", return_value=[{"ssh_host": "1.2.3.4", "ssh_port": 22}]):
             assert sdk.ssh_url(1) == "ssh://root@1.2.3.4:22"
@@ -142,6 +146,10 @@ class TestScpUrl:
 
     def test_empty_when_missing(self, sdk):
         with patch("vastai.api.instances.show_instance", return_value={}):
+            assert sdk.scp_url(1) == ""
+
+    def test_empty_when_deleted(self, sdk):
+        with patch("vastai.api.instances.show_instance", return_value=None):
             assert sdk.scp_url(1) == ""
 
 

--- a/vast.py
+++ b/vast.py
@@ -5699,6 +5699,13 @@ def show__instance(args):
     r = http_get(args, req_url)
     r.raise_for_status()
     row = r.json()["instances"]
+    if row is None:
+        if getattr(args, "internal", False):
+            return None
+        if args.raw:
+            return {"instances": None}
+        print(f"Instance {args.id} not found or no longer exists.", file=sys.stderr)
+        return 1
     row['duration'] = time.time() - row['start_date']
     row['extra_env'] = {env_var[0]: env_var[1] for env_var in row['extra_env']}
     if args.raw:
@@ -5723,7 +5730,7 @@ def show__instances(args = {}, extra = {}):
     #r = http_get(req_url)
     r = http_get(args, req_url)
     r.raise_for_status()
-    rows = r.json()["instances"]
+    rows = r.json()["instances"] or []
     for row in rows:
         row = {k: strip_strings(v) for k, v in row.items()} 
         row['duration'] = time.time() - row['start_date']
@@ -8646,10 +8653,25 @@ def self_test__machine(args):
         # silently-leaked instance keeps billing the host.
         if instance_id:
             try:
-                if instance_exist(instance_id, api_key, destroy_args):
-                    progress_print(args, f"Destroying test instance {instance_id}...")
-                    destroy_instance_silent(instance_id, destroy_args)
-                    progress_print(args, f"Test instance {instance_id} destroyed.")
+                show_args = argparse.Namespace(
+                    id=instance_id,
+                    api_key=api_key,
+                    url=args.url,
+                    retry=args.retry,
+                    explain=False,
+                    raw=True,
+                    debugging=args.debugging,
+                    internal=True,
+                )
+                info = show__instance(show_args)
+                if not info:
+                    debug_print(args, f"Test instance {instance_id} is already gone.")
+                else:
+                    status = info.get('intended_status') or info.get('actual_status')
+                    if status not in ('destroyed', 'terminated', 'offline'):
+                        progress_print(args, f"Destroying test instance {instance_id} (status: {status})...")
+                        destroy_instance_silent(instance_id, destroy_args)
+                        progress_print(args, f"Test instance {instance_id} destroyed.")
             except KeyboardInterrupt:
                 progress_print(
                     args,
@@ -9177,7 +9199,8 @@ def instance_exist(instance_id, api_key, args):
         retry=args.retry,
         explain=False,
         raw=True,
-        debugging=args.debugging
+        debugging=args.debugging,
+        internal=True,
     )
     try:
         instance_info = show__instance(show_args)
@@ -9254,6 +9277,7 @@ def run_machinetester(ip_address, port, instance_id, machine_id, delay, args, ap
             retry=3,
             raw=True,
             debugging=args.debugging,
+            internal=True,
         )
         try:
             instance_info = show__instance(show_args)
@@ -9575,6 +9599,7 @@ def wait_for_instance(instance_id, api_key, args, destroy_args, timeout=900, int
         url=args.url,
         retry=args.retry,
         debugging=args.debugging,
+        internal=True,
     )
     
     if args.debugging:

--- a/vastai/api/instances.py
+++ b/vastai/api/instances.py
@@ -29,7 +29,7 @@ def _strip_strings(value):
 def show_instances(client: VastClient) -> list:
     r = client.get("/instances", query_args={"owner": "me"})
     r.raise_for_status()
-    rows = r.json()["instances"]
+    rows = r.json()["instances"] or []
     for i, row in enumerate(rows):
         row = {k: _strip_strings(v) for k, v in row.items()}
         row['duration'] = time.time() - row['start_date']

--- a/vastai/api/instances.py
+++ b/vastai/api/instances.py
@@ -1,6 +1,7 @@
 """Instance CRUD operations."""
 import time
 import requests
+from typing import Optional
 from vastai.api.client import VastClient
 
 
@@ -59,10 +60,12 @@ def show_instance_filters(client: VastClient) -> list:
     return r.json().get("filters", [])
 
 
-def show_instance(client: VastClient, id: int) -> dict:
+def show_instance(client: VastClient, id: int) -> Optional[dict]:
     r = client.get(f"/instances/{id}/", query_args={"owner": "me"})
     r.raise_for_status()
     row = r.json()["instances"]
+    if row is None:
+        return None
     row['duration'] = time.time() - row['start_date']
     row['extra_env'] = {env_var[0]: env_var[1] for env_var in row['extra_env']}
     return row

--- a/vastai/cli/commands/instances.py
+++ b/vastai/cli/commands/instances.py
@@ -86,6 +86,12 @@ def show__instance(args):
     """Shows stats for a single instance."""
     client = get_client(args)
     result = instances_api.show_instance(client, id=args.id)
+    if result is None:
+        if args.raw:
+            return {"instances": None}
+        if not args.quiet:
+            print(f"Instance {args.id} not found or no longer exists.")
+        return 1
     if args.raw:
         return result
     if args.quiet:

--- a/vastai/cli/commands/instances.py
+++ b/vastai/cli/commands/instances.py
@@ -90,7 +90,7 @@ def show__instance(args):
         if args.raw:
             return {"instances": None}
         if not args.quiet:
-            print(f"Instance {args.id} not found or no longer exists.")
+            print(f"Instance {args.id} not found or no longer exists.", file=sys.stderr)
         return 1
     if args.raw:
         return result

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -1038,11 +1038,14 @@ def self_test__machine(args):
         if instance_id:
             try:
                 info = instances_api.show_instance(client, id=instance_id)
-                status = (info or {}).get('intended_status') or (info or {}).get('actual_status')
-                if status not in ('destroyed', 'terminated', 'offline'):
-                    progress_print(f"Destroying test instance {instance_id} (status: {status})...")
-                    instances_api.destroy_instance(client, id=instance_id)
-                    progress_print(f"Test instance {instance_id} destroyed.")
+                if not info:
+                    debug_print(f"Test instance {instance_id} is already gone.")
+                else:
+                    status = info.get('intended_status') or info.get('actual_status')
+                    if status not in ('destroyed', 'terminated', 'offline'):
+                        progress_print(f"Destroying test instance {instance_id} (status: {status})...")
+                        instances_api.destroy_instance(client, id=instance_id)
+                        progress_print(f"Test instance {instance_id} destroyed.")
             except KeyboardInterrupt:
                 progress_print(
                     f"\nSecond interrupt during cleanup — instance {instance_id} may still be running.\n"

--- a/vastai/sdk.py
+++ b/vastai/sdk.py
@@ -144,6 +144,8 @@ class VastAI:
         inst = instances.show_instance(self.client, id)
         if isinstance(inst, list):
             inst = inst[0] if inst else {}
+        if not isinstance(inst, dict):
+            return ""
         port = inst.get("ssh_port") or (inst.get("ports") or {}).get("22/tcp", [{}])[0].get("HostPort")
         ip = inst.get("ssh_host") or inst.get("public_ipaddr")
         return f"ssh://root@{ip}:{port}" if port and ip else ""
@@ -153,6 +155,8 @@ class VastAI:
         inst = instances.show_instance(self.client, id)
         if isinstance(inst, list):
             inst = inst[0] if inst else {}
+        if not isinstance(inst, dict):
+            return ""
         port = inst.get("ssh_port") or (inst.get("ports") or {}).get("22/tcp", [{}])[0].get("HostPort")
         ip = inst.get("ssh_host") or inst.get("public_ipaddr")
         return f"scp://root@{ip}:{port}" if port and ip else ""

--- a/vastai/sdk.py
+++ b/vastai/sdk.py
@@ -66,7 +66,7 @@ class VastAI:
         """Return distinct filterable values for instances."""
         return instances.show_instance_filters(self.client)
 
-    def show_instance(self, id: int) -> dict:
+    def show_instance(self, id: int) -> Optional[dict]:
         """Return details of a single instance."""
         return instances.show_instance(self.client, id)
 


### PR DESCRIPTION
## Summary

Fixes the cleanup warning found during CON-1509 self-test dogfooding.

The live stock self-test passed and destroyed its test instance, but the CLI then checked the already-deleted instance again. The API returned `{"instances": null}`, `show_instance()` crashed with `TypeError: 'NoneType' object is not subscriptable`, and self-test printed a false manual-destroy warning even though `show instances` showed zero active instances.

Changes:

- Treat `{"instances": null}` as a missing/deleted instance in `show_instance()`.
- Make `vastai show instance <id>` return clean output for deleted instances instead of traceback.
- Make self-test final cleanup treat a missing instance as already gone, without duplicate destroy warnings.
- Keep SDK `ssh_url` / `scp_url` safe when `show_instance()` returns `None`.
- Add focused CLI and SDK tests.

## Verification

- `uv run pytest tests/cli/test_instances_commands.py tests/cli/test_machines_commands.py tests/sdk/test_sdk.py -q`
- Read-only repro now returns clean raw JSON instead of traceback:
  `vastai --raw show instance 38056189` -> `{ "instances": null }`

## Notes

This PR only addresses the cleanup/deleted-instance bug. It does not change self-test image selection or the private `vast-ai/self-test` image sources.
