### PR TITLE
CON-1512: Improve self-test ignore-requirements messaging

### DIFF
--- a/tests/cli/test_machines_commands.py
+++ b/tests/cli/test_machines_commands.py
@@ -1,5 +1,6 @@
 """Integration tests for machine CLI commands with mocked HTTP."""
 
+import json
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -145,3 +146,66 @@ class TestListMachineEpilogDoesNotPromiseEmail:
 
     def test_list_machines_epilog_no_email(self, cli_parser):
         assert "email" not in self._epilog_lower(cli_parser, "list machines")
+
+
+class TestSelfTestMachineIgnoreRequirements:
+    def test_ignore_requirements_warns_on_success(self, parse_argv, monkeypatch, capsys):
+        from vastai.cli.commands import machines
+
+        offer = {
+            "id": 202,
+            "dlperf": 1.0,
+            "cuda_max_good": 13.0,
+            "compute_cap": 1200,
+            "reliability": 0.99,
+            "direct_port_count": 10,
+            "pcie_bw": 4.0,
+            "gpu_total_ram": 32 * 1024,
+            "inet_down": 200.0,
+            "inet_up": 200.0,
+            "gpu_ram": 32,
+            "cpu_ram": 64 * 1024,
+            "cpu_cores": 8,
+            "num_gpus": 1,
+        }
+        instance = {
+            "intended_status": "running",
+            "actual_status": "running",
+            "public_ipaddr": "203.0.113.10",
+            "ports": {"5000/tcp": [{"HostPort": "5000"}]},
+        }
+
+        monkeypatch.setattr(machines.offers_api, "search_offers", Mock(return_value=[offer]))
+        monkeypatch.setattr(machines.instances_api, "create_instance", Mock(return_value={"new_contract": 303}))
+        monkeypatch.setattr(machines.instances_api, "show_instance", Mock(return_value=instance))
+        monkeypatch.setattr(machines.instances_api, "destroy_instance", Mock(return_value={"success": True}))
+        monkeypatch.setattr(machines.requests, "get", lambda *_, **__: SimpleNamespace(status_code=200, text="DONE"))
+        monkeypatch.setattr(machines.time, "sleep", lambda *_: None)
+
+        args = parse_argv(["self-test", "machine", "123", "--ignore-requirements"])
+        with pytest.raises(SystemExit) as exc_info:
+            args.func(args)
+
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "WARNING: --ignore-requirements is set." in out
+        assert "Requirement checks are skipped as a pass/fail gate" in out
+        assert "does not qualify this machine for verification" in out
+        assert out.count("does not qualify this machine for verification") >= 2
+        assert "Test passed." in out
+
+    def test_ignore_requirements_warning_in_raw_summary(self, parse_argv, monkeypatch, capsys):
+        from vastai.cli.commands import machines
+
+        monkeypatch.setattr(machines.offers_api, "search_offers", Mock(return_value=[]))
+
+        args = parse_argv(["--raw", "self-test", "machine", "0", "--ignore-requirements"])
+        with pytest.raises(SystemExit) as exc_info:
+            args.func(args)
+
+        assert exc_info.value.code == 0
+        raw = json.loads(capsys.readouterr().out)
+        assert raw["success"] is False
+        assert "warning" in raw
+        assert "Requirement checks are skipped as a pass/fail gate" in raw["warning"]
+        assert "does not qualify this machine for verification" in raw["warning"]

--- a/vast.py
+++ b/vast.py
@@ -8374,10 +8374,17 @@ def self_test__machine(args):
     """
     instance_id = None  # Store instance ID for cleanup if needed
     result = {"success": False, "reason": ""}
+    ignore_requirements_warning = (
+        "WARNING: --ignore-requirements is set. Requirement checks are skipped as a "
+        "pass/fail gate, and passing this self-test does not qualify this machine for verification."
+    )
     
     # Ensure debugging attribute exists in args
     if not hasattr(args, 'debugging'):
         args.debugging = False
+
+    if args.ignore_requirements:
+        result["warning"] = ignore_requirements_warning
     
     try:
         # Load API key
@@ -8417,8 +8424,9 @@ def self_test__machine(args):
             progress_print(args, f"Machine ID {args.machine_id} does not meet the following requirements:")
             for reason in unmet_reasons:
                 progress_print(args, f"- {reason}")
-                # If user did pass --ignore-requirements, warn and continue
-                progress_print(args, "Continuing despite unmet requirements because --ignore-requirements is set.")
+            progress_print(args, "Continuing despite unmet requirements because --ignore-requirements is set.")
+        if args.ignore_requirements:
+            progress_print(args, ignore_requirements_warning)
 
         def cuda_map_to_image(cuda_version, compute_cap=None):
             """
@@ -8691,6 +8699,8 @@ def self_test__machine(args):
         print(json.dumps(result))
         sys.exit(0)
     else:
+        if result.get("warning"):
+            print(result["warning"])
         if result["success"]:
             print("Test completed successfully.")
             sys.exit(0)

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -551,9 +551,16 @@ def self_test__machine(args):
     """
     instance_id = None
     result = {"success": False, "reason": ""}
+    ignore_requirements_warning = (
+        "WARNING: --ignore-requirements is set. Requirement checks are skipped as a "
+        "pass/fail gate, and passing this self-test does not qualify this machine for verification."
+    )
 
     if not hasattr(args, 'debugging'):
         args.debugging = False
+
+    if getattr(args, "ignore_requirements", False):
+        result["warning"] = ignore_requirements_warning
 
     def progress_print(*args_to_print):
         if not args.raw:
@@ -661,6 +668,8 @@ def self_test__machine(args):
             for reason in unmet_reasons:
                 progress_print(f"- {reason}")
             progress_print("Continuing despite unmet requirements because --ignore-requirements is set.")
+        if args.ignore_requirements:
+            progress_print(ignore_requirements_warning)
 
         # ----- CUDA version to docker image mapping -----
         def cuda_map_to_image(cuda_version, compute_cap=None):
@@ -1063,6 +1072,8 @@ def self_test__machine(args):
         print(json.dumps(result))
         sys.exit(0)
     else:
+        if result.get("warning"):
+            print(result["warning"])
         if result["success"]:
             print("Test completed successfully.")
             sys.exit(0)

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -559,7 +559,7 @@ def self_test__machine(args):
     if not hasattr(args, 'debugging'):
         args.debugging = False
 
-    if getattr(args, "ignore_requirements", False):
+    if args.ignore_requirements:
         result["warning"] = ignore_requirements_warning
 
     def progress_print(*args_to_print):


### PR DESCRIPTION
## Summary

Addresses CON-1512: `Self-Test: Improve self-test messaging when run with --ignore-requirements`.

When this flag is used, the CLI now warns that requirement checks are skipped as a pass/fail gate and that passing the self-test does not qualify the machine for verification.

Changes:

- Adds an explicit warning whenever `--ignore-requirements` is set.
- Prints the warning before the live self-test starts.
- Prints the warning again in the final console status output.
- Includes the warning in raw JSON output as `warning`.
- Adds focused tests for successful console output and raw summary output.

## Verification

- `uv run pytest tests/cli/test_machines_commands.py tests/cli/test_util.py -q` -> `58 passed`
- Fresh-clone validation from `jjziets/vast-python:fix/self-test-ignore-requirements-warning` before branch rename also passed: `58 passed`.
- Actual raw/no-rent CLI check from the fresh clone returned a `warning` field:
  ```json
  {
    "success": false,
    "reason": "No valid offers found.",
    "warning": "WARNING: --ignore-requirements is set. Requirement checks are skipped as a pass/fail gate, and passing this self-test does not qualify this machine for verification."
  }
  ```

## Notes

This supersedes closed PR #406, which GitHub closed when the fork branch was renamed to carry the CON-1512 branch name.

This PR is intentionally separate from #405. PR #405 fixes the deleted-instance cleanup warning found during dogfood; this PR only handles `--ignore-requirements` messaging.
