### PR TITLE
CON-1510: Improve self-test diagnostics and runtime errors

### DIFF
--- a/tests/cli/test_machines_commands.py
+++ b/tests/cli/test_machines_commands.py
@@ -201,11 +201,11 @@ class TestSelfTestMachineIgnoreRequirements:
         monkeypatch.setattr(machines.offers_api, "search_offers", Mock(return_value=[]))
 
         args = parse_argv(["--raw", "self-test", "machine", "0", "--ignore-requirements"])
-        with pytest.raises(SystemExit) as exc_info:
-            args.func(args)
+        result = args.func(args)
 
-        assert exc_info.value.code == 0
-        raw = json.loads(capsys.readouterr().out)
+        assert result["success"] is False
+        assert capsys.readouterr().out == ""
+        raw = result
         assert raw["success"] is False
         assert "warning" in raw
         assert "Requirement checks are skipped as a pass/fail gate" in raw["warning"]
@@ -336,7 +336,7 @@ class TestSelfTestMachineDiagnostics:
     def test_preflight_normalizes_api_gpu_ram_units(
         self, parse_argv, patch_get_client, monkeypatch, capsys
     ):
-        bad_offer = _self_test_offer(gpu_ram=6 * 1024)
+        bad_offer = _self_test_offer(gpu_ram=6 * 1024, gpu_total_ram=0)
         search = Mock(return_value=[bad_offer])
         monkeypatch.setattr("vastai.cli.commands.machines.offers_api.search_offers", search)
 
@@ -349,6 +349,50 @@ class TestSelfTestMachineDiagnostics:
         assert "- GPU RAM" in captured.out
         assert "actual: 6.0 GiB" in captured.out
         assert "required: > 7 GiB" in captured.out
+
+    def test_preflight_uses_canonical_vram_for_b300(
+        self, parse_argv, patch_get_client, monkeypatch, capsys
+    ):
+        offer = _self_test_offer(
+            gpu_name="B300",
+            gpu_ram=288,
+            gpu_total_ram=288 * 1024,
+            num_gpus=1,
+            reliability=0.9,
+            cpu_ram=320 * 1024,
+        )
+        search = Mock(return_value=[offer])
+        monkeypatch.setattr("vastai.cli.commands.machines.offers_api.search_offers", search)
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        captured = capsys.readouterr()
+        gpu_ram_check = next(check for check in result["checks"] if check["id"] == "gpu.ram")
+        raw = json.dumps(result)
+        assert result["failure_code"] == "preflight_requirements_failed"
+        assert gpu_ram_check["status"] == "pass"
+        assert gpu_ram_check["actual"] == 288
+        assert "0.28" not in captured.out
+        assert "0.28125" not in captured.out
+        assert "0.28" not in raw
+        assert "0.28125" not in raw
+
+    def test_preflight_uses_canonical_total_ram_per_gpu(self):
+        from vastai.cli.self_test.machine_diagnostics import preflight_requirement_checks
+
+        offer = _self_test_offer(
+            gpu_ram=288,
+            gpu_total_ram=8 * 80 * 1024,
+            num_gpus=8,
+            cpu_ram=700 * 1024,
+            cpu_cores=24,
+        )
+
+        checks = preflight_requirement_checks(offer)
+        gpu_ram_check = next(check for check in checks if check["id"] == "gpu.ram")
+        assert gpu_ram_check["status"] == "pass"
+        assert gpu_ram_check["actual"] == 80
 
     def test_ignore_requirements_includes_failed_checks_and_continues(
         self, parse_argv, patch_get_client, monkeypatch, capsys

--- a/tests/cli/test_machines_commands.py
+++ b/tests/cli/test_machines_commands.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
+import requests
 
 
 class TestShowMachines:
@@ -209,3 +210,306 @@ class TestSelfTestMachineIgnoreRequirements:
         assert "warning" in raw
         assert "Requirement checks are skipped as a pass/fail gate" in raw["warning"]
         assert "does not qualify this machine for verification" in raw["warning"]
+
+
+def _self_test_offer(**overrides):
+    offer = {
+        "id": 1001,
+        "machine_id": "42",
+        "gpu_name": "RTX_4090",
+        "num_gpus": 1,
+        "dph_total": 0.5,
+        "dlperf": 100,
+        "cuda_max_good": 12.8,
+        "compute_cap": 890,
+        "reliability": 0.99,
+        "direct_port_count": 4,
+        "pcie_bw": 3.2,
+        "inet_down": 200,
+        "inet_up": 200,
+        "gpu_ram": 24,
+        "gpu_total_ram": 24 * 1024,
+        "cpu_ram": 32 * 1024,
+        "cpu_cores": 4,
+    }
+    offer.update(overrides)
+    return offer
+
+
+class TestSelfTestMachineDiagnostics:
+    def test_no_offer_raw_returns_structured_failure(
+        self, parse_argv, patch_get_client, monkeypatch, capsys
+    ):
+        search = Mock(side_effect=[[], []])
+        monkeypatch.setattr("vastai.cli.commands.machines.offers_api.search_offers", search)
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert result["success"] is False
+        assert result["reason"] == "No on-demand offer found for machine 42."
+        assert result["failure_code"] == "no_offer"
+        assert result["phase"] == "preflight"
+        assert result["machine_id"] == "42"
+        assert result["checks"][0]["id"] == "offer.available"
+        assert result["failure"]["likely_causes"]
+        assert search.call_count == 2
+
+    def test_no_offer_non_raw_renders_once_without_stale_placeholders(
+        self, parse_argv, patch_get_client, monkeypatch, capsys
+    ):
+        broader_offer = _self_test_offer(rentable=False, rented=True)
+        search = Mock(side_effect=[[], [broader_offer]])
+        monkeypatch.setattr("vastai.cli.commands.machines.offers_api.search_offers", search)
+
+        args = parse_argv(["self-test", "machine", "42"])
+        with pytest.raises(SystemExit) as exc_info:
+            args.func(args)
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code == 1
+        assert captured.out.count("Preflight diagnostics for machine 42 failed:") == 1
+        assert "actual: 0 offers" in captured.out
+        assert "required: >= 1 offers" in captured.out
+        assert "vastai search offers 'machine_id=42 rentable=any rented=any'" in captured.out
+        assert "{machine_id}" not in captured.out
+        assert "--filter" not in captured.out
+
+    def test_preflight_outputs_actual_required_once(
+        self, parse_argv, patch_get_client, monkeypatch, capsys
+    ):
+        bad_offer = _self_test_offer(cuda_max_good=11.7, reliability=0.9)
+        search = Mock(return_value=[bad_offer])
+        monkeypatch.setattr("vastai.cli.commands.machines.offers_api.search_offers", search)
+
+        args = parse_argv(["self-test", "machine", "42"])
+        with pytest.raises(SystemExit) as exc_info:
+            args.func(args)
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code == 1
+        assert captured.out.count("Preflight diagnostics for machine 42 failed:") == 1
+        assert "- CUDA version" in captured.out
+        assert "actual: 11.7 CUDA" in captured.out
+        assert "required: >= 11.8 CUDA" in captured.out
+        assert "{machine_id}" not in captured.out
+        assert "--filter" not in captured.out
+        assert search.call_count == 1
+
+    def test_selected_offer_is_reused_for_rental(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        lower_offer = _self_test_offer(id=1001, dlperf=10)
+        selected_offer = _self_test_offer(id=2002, dlperf=50)
+        search = Mock(return_value=[lower_offer, selected_offer])
+        create = Mock(side_effect=RuntimeError("stop before live rental"))
+        monkeypatch.setattr("vastai.cli.commands.machines.offers_api.search_offers", search)
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.create_instance", create)
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        assert result["failure_code"] == "instance_create_failed"
+        assert search.call_count == 1
+        create.assert_called_once()
+        assert create.call_args.kwargs["id"] == 2002
+
+    def test_preflight_normalizes_api_gpu_ram_units(
+        self, parse_argv, patch_get_client, monkeypatch, capsys
+    ):
+        bad_offer = _self_test_offer(gpu_ram=6 * 1024)
+        search = Mock(return_value=[bad_offer])
+        monkeypatch.setattr("vastai.cli.commands.machines.offers_api.search_offers", search)
+
+        args = parse_argv(["self-test", "machine", "42"])
+        with pytest.raises(SystemExit) as exc_info:
+            args.func(args)
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code == 1
+        assert "- GPU RAM" in captured.out
+        assert "actual: 6.0 GiB" in captured.out
+        assert "required: > 7 GiB" in captured.out
+
+    def test_ignore_requirements_includes_failed_checks_and_continues(
+        self, parse_argv, patch_get_client, monkeypatch, capsys
+    ):
+        bad_offer = _self_test_offer(reliability=0.9)
+        search = Mock(return_value=[bad_offer])
+        create = Mock(side_effect=RuntimeError("stop before live rental"))
+        monkeypatch.setattr("vastai.cli.commands.machines.offers_api.search_offers", search)
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.create_instance", create)
+
+        args = parse_argv(["self-test", "machine", "42", "--ignore-requirements"])
+        with pytest.raises(SystemExit) as exc_info:
+            args.func(args)
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code == 1
+        assert "Continuing despite unmet requirements because --ignore-requirements is set." in captured.out
+        assert "WARNING: --ignore-requirements is set." in captured.out
+        assert "does not qualify this machine for verification" in captured.out
+        create.assert_called_once()
+        assert search.call_count == 1
+
+    def test_test_image_option_overrides_default_mapping(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        offer = _self_test_offer()
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.offers_api.search_offers",
+            Mock(return_value=[offer]),
+        )
+        create = Mock(side_effect=RuntimeError("stop before live rental"))
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.create_instance", create)
+
+        args = parse_argv(["self-test", "machine", "42", "--test-image", "vastai/test:p3-dogfood", "--raw"])
+        result = args.func(args)
+
+        assert result["diagnostics"]["image"]["override"] is True
+        assert create.call_args.kwargs["image"] == "vastai/test:p3-dogfood"
+
+    def test_env_test_image_overrides_default_mapping(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        offer = _self_test_offer()
+        monkeypatch.setenv("VAST_SELF_TEST_IMAGE", "vastai/test:p3-env")
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.offers_api.search_offers",
+            Mock(return_value=[offer]),
+        )
+        create = Mock(side_effect=RuntimeError("stop before live rental"))
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.create_instance", create)
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        assert result["diagnostics"]["image"]["override"] is True
+        assert create.call_args.kwargs["image"] == "vastai/test:p3-env"
+
+    def test_default_cuda_mapping_still_selects_official_image(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        offer = _self_test_offer(cuda_max_good=12.8, compute_cap=890)
+        monkeypatch.delenv("VAST_SELF_TEST_IMAGE", raising=False)
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.offers_api.search_offers",
+            Mock(return_value=[offer]),
+        )
+        create = Mock(side_effect=RuntimeError("stop before live rental"))
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.create_instance", create)
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        assert result["diagnostics"]["image"]["override"] is False
+        assert create.call_args.kwargs["image"] == "vastai/test:self-test-cuda-12.8"
+
+    def test_startup_status_msg_is_classified_in_raw_output(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        offer = _self_test_offer()
+        status_msg = "Error response from daemon: manifest for vastai/test:self-test-cuda-99 not found"
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.offers_api.search_offers",
+            Mock(return_value=[offer]),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.create_instance",
+            Mock(return_value={"new_contract": 123}),
+        )
+        show = Mock(
+            side_effect=[
+                {
+                    "id": 123,
+                    "status_msg": status_msg,
+                    "actual_status": "created",
+                    "intended_status": "running",
+                },
+                {"id": 123, "actual_status": "running", "intended_status": "running"},
+                {"id": 123, "actual_status": "destroyed", "intended_status": "destroyed"},
+            ]
+        )
+        destroy = Mock(return_value={"success": True})
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.show_instance", show)
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.destroy_instance", destroy)
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        assert result["success"] is False
+        assert result["failure_code"] == "docker_pull_failed"
+        assert result["failure"]["underlying_error"] == status_msg
+        assert result["diagnostics"]["runtime_failure"]["code"] == "docker_pull_failed"
+        destroy.assert_called_once()
+
+    def test_cleanup_404_after_destroy_is_not_reported_as_leak(
+        self, parse_argv, patch_get_client, monkeypatch, capsys
+    ):
+        offer = _self_test_offer()
+        status_msg = "Error: container failed to start: OCI runtime create failed"
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.offers_api.search_offers",
+            Mock(return_value=[offer]),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.create_instance",
+            Mock(return_value={"new_contract": 123}),
+        )
+        response = Mock(status_code=404)
+        gone = requests.exceptions.HTTPError("404 Client Error: Not Found for url: https://example.test/?api_key=secret")
+        gone.response = response
+        show = Mock(
+            side_effect=[
+                {
+                    "id": 123,
+                    "status_msg": status_msg,
+                    "actual_status": "created",
+                    "intended_status": "running",
+                },
+                {"id": 123, "actual_status": "running", "intended_status": "running"},
+                gone,
+            ]
+        )
+        destroy = Mock(return_value={"success": True})
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.show_instance", show)
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.destroy_instance", destroy)
+
+        args = parse_argv(["self-test", "machine", "42"])
+        with pytest.raises(SystemExit) as exc_info:
+            args.func(args)
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code == 1
+        assert "Runtime failure diagnostics:" in captured.out
+        assert "- code: daemon_startup_failed" in captured.out
+        assert "- remediation: Inspect docker daemon, OCI runtime, and container startup logs." in captured.out
+        assert "WARNING: failed to destroy test instance" not in captured.out
+        assert "api_key=secret" not in captured.out
+        destroy.assert_called_once()
+
+    def test_create_instance_error_redacts_api_key(
+        self, parse_argv, patch_get_client, monkeypatch, capsys
+    ):
+        offer = _self_test_offer()
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.offers_api.search_offers",
+            Mock(return_value=[offer]),
+        )
+        create = Mock(
+            side_effect=RuntimeError(
+                "404 Client Error: Not Found for url: https://console.vast.ai/api/v0/instances/?api_key=secret"
+            )
+        )
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.create_instance", create)
+
+        args = parse_argv(["self-test", "machine", "42"])
+        with pytest.raises(SystemExit) as exc_info:
+            args.func(args)
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code == 1
+        assert "api_key=secret" not in captured.out
+        assert "api_key=REDACTED" in captured.out

--- a/tests/cli/test_machines_commands.py
+++ b/tests/cli/test_machines_commands.py
@@ -415,7 +415,7 @@ class TestSelfTestMachineDiagnostics:
         result, create = _run_self_test_until_create(parse_argv, monkeypatch, offer)
 
         assert result["diagnostics"]["image"]["override"] is False
-        assert create.call_args.kwargs["image"] == "vastai/test:self-test-cuda-12.8"
+        assert create.call_args.kwargs["image"] == "vastai/test:self-test-v2-cuda-12.8"
         assert create.call_args.kwargs["runtype"] == "ssh_direc ssh_proxy"
 
     def test_cuda_mapping_selects_cuda_133_exact_match(
@@ -425,7 +425,7 @@ class TestSelfTestMachineDiagnostics:
         result, create = _run_self_test_until_create(parse_argv, monkeypatch, offer)
 
         assert result["diagnostics"]["image"]["override"] is False
-        assert create.call_args.kwargs["image"] == "vastai/test:self-test-cuda-13.3"
+        assert create.call_args.kwargs["image"] == "vastai/test:self-test-v2-cuda-13.3"
         assert "exact match" in result["diagnostics"]["image"]["reason"]
 
     def test_cuda_mapping_steps_down_to_newest_compatible_image(
@@ -435,7 +435,7 @@ class TestSelfTestMachineDiagnostics:
         result, create = _run_self_test_until_create(parse_argv, monkeypatch, offer)
 
         assert result["diagnostics"]["image"]["override"] is False
-        assert create.call_args.kwargs["image"] == "vastai/test:self-test-cuda-13.0"
+        assert create.call_args.kwargs["image"] == "vastai/test:self-test-v2-cuda-13.0"
         assert "selected newest image <= host CUDA (13.0)" in result["diagnostics"]["image"]["reason"]
 
     def test_cuda_mapping_uses_cuda_133_for_newer_cuda_hosts(
@@ -445,7 +445,7 @@ class TestSelfTestMachineDiagnostics:
         result, create = _run_self_test_until_create(parse_argv, monkeypatch, offer)
 
         assert result["diagnostics"]["image"]["override"] is False
-        assert create.call_args.kwargs["image"] == "vastai/test:self-test-cuda-13.3"
+        assert create.call_args.kwargs["image"] == "vastai/test:self-test-v2-cuda-13.3"
         assert "selected newest image <= host CUDA (13.3)" in result["diagnostics"]["image"]["reason"]
 
     def test_cuda_mapping_still_clamps_volta_to_cuda_128(
@@ -455,14 +455,14 @@ class TestSelfTestMachineDiagnostics:
         result, create = _run_self_test_until_create(parse_argv, monkeypatch, offer)
 
         assert result["diagnostics"]["image"]["override"] is False
-        assert create.call_args.kwargs["image"] == "vastai/test:self-test-cuda-12.8"
+        assert create.call_args.kwargs["image"] == "vastai/test:self-test-v2-cuda-12.8"
         assert "clamped to 12.8" in result["diagnostics"]["image"]["reason"]
 
     def test_startup_status_msg_is_classified_in_raw_output(
         self, parse_argv, patch_get_client, monkeypatch
     ):
         offer = _self_test_offer()
-        status_msg = "Error response from daemon: manifest for vastai/test:self-test-cuda-99 not found"
+        status_msg = "Error response from daemon: manifest for vastai/test:self-test-v2-cuda-99 not found"
         monkeypatch.setattr(
             "vastai.cli.commands.machines.offers_api.search_offers",
             Mock(return_value=[offer]),

--- a/tests/cli/test_machines_commands.py
+++ b/tests/cli/test_machines_commands.py
@@ -496,6 +496,40 @@ class TestSelfTestMachineDiagnostics:
         assert result["diagnostics"]["runtime_failure"]["code"] == "docker_pull_failed"
         destroy.assert_called_once()
 
+    def test_stopped_startup_status_is_classified_without_waiting_for_timeout(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        offer = _self_test_offer()
+        status_msg = "docker_build() error writing dockerfile"
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.offers_api.search_offers",
+            Mock(return_value=[offer]),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.create_instance",
+            Mock(return_value={"new_contract": 123}),
+        )
+        stopped_instance = {
+            "id": 123,
+            "status_msg": status_msg,
+            "actual_status": "loading",
+            "intended_status": "stopped",
+        }
+        show = Mock(side_effect=[stopped_instance, stopped_instance, None])
+        destroy = Mock(return_value={"success": True})
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.show_instance", show)
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.destroy_instance", destroy)
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        assert result["success"] is False
+        assert result["failure_code"] == "daemon_startup_failed"
+        assert result["failure"]["underlying_error"] == status_msg
+        assert result["diagnostics"]["runtime_failure"]["code"] == "daemon_startup_failed"
+        assert show.call_count == 3
+        destroy.assert_called_once()
+
     def test_cleanup_404_after_destroy_is_not_reported_as_leak(
         self, parse_argv, patch_get_client, monkeypatch, capsys
     ):

--- a/tests/cli/test_machines_commands.py
+++ b/tests/cli/test_machines_commands.py
@@ -315,6 +315,9 @@ class TestSelfTestMachineDiagnostics:
         assert search.call_count == 1
         create.assert_called_once()
         assert create.call_args.kwargs["id"] == 2002
+        assert create.call_args.kwargs["runtype"] == "ssh_direc ssh_proxy"
+        assert create.call_args.kwargs["jupyter_lab"] is False
+        assert result["diagnostics"]["launch"]["runtype"] == "ssh_direc ssh_proxy"
 
     def test_preflight_normalizes_api_gpu_ram_units(
         self, parse_argv, patch_get_client, monkeypatch, capsys
@@ -370,6 +373,7 @@ class TestSelfTestMachineDiagnostics:
 
         assert result["diagnostics"]["image"]["override"] is True
         assert create.call_args.kwargs["image"] == "vastai/test:p3-dogfood"
+        assert create.call_args.kwargs["runtype"] == "ssh_direc ssh_proxy"
 
     def test_env_test_image_overrides_default_mapping(
         self, parse_argv, patch_get_client, monkeypatch
@@ -388,6 +392,7 @@ class TestSelfTestMachineDiagnostics:
 
         assert result["diagnostics"]["image"]["override"] is True
         assert create.call_args.kwargs["image"] == "vastai/test:p3-env"
+        assert create.call_args.kwargs["runtype"] == "ssh_direc ssh_proxy"
 
     def test_default_cuda_mapping_still_selects_official_image(
         self, parse_argv, patch_get_client, monkeypatch
@@ -406,6 +411,7 @@ class TestSelfTestMachineDiagnostics:
 
         assert result["diagnostics"]["image"]["override"] is False
         assert create.call_args.kwargs["image"] == "vastai/test:self-test-cuda-12.8"
+        assert create.call_args.kwargs["runtype"] == "ssh_direc ssh_proxy"
 
     def test_startup_status_msg_is_classified_in_raw_output(
         self, parse_argv, patch_get_client, monkeypatch

--- a/tests/cli/test_machines_commands.py
+++ b/tests/cli/test_machines_commands.py
@@ -236,6 +236,20 @@ def _self_test_offer(**overrides):
     return offer
 
 
+def _run_self_test_until_create(parse_argv, monkeypatch, offer):
+    monkeypatch.delenv("VAST_SELF_TEST_IMAGE", raising=False)
+    monkeypatch.setattr(
+        "vastai.cli.commands.machines.offers_api.search_offers",
+        Mock(return_value=[offer]),
+    )
+    create = Mock(side_effect=RuntimeError("stop before live rental"))
+    monkeypatch.setattr("vastai.cli.commands.machines.instances_api.create_instance", create)
+
+    args = parse_argv(["self-test", "machine", "42", "--raw"])
+    result = args.func(args)
+    return result, create
+
+
 class TestSelfTestMachineDiagnostics:
     def test_no_offer_raw_returns_structured_failure(
         self, parse_argv, patch_get_client, monkeypatch, capsys
@@ -398,20 +412,51 @@ class TestSelfTestMachineDiagnostics:
         self, parse_argv, patch_get_client, monkeypatch
     ):
         offer = _self_test_offer(cuda_max_good=12.8, compute_cap=890)
-        monkeypatch.delenv("VAST_SELF_TEST_IMAGE", raising=False)
-        monkeypatch.setattr(
-            "vastai.cli.commands.machines.offers_api.search_offers",
-            Mock(return_value=[offer]),
-        )
-        create = Mock(side_effect=RuntimeError("stop before live rental"))
-        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.create_instance", create)
-
-        args = parse_argv(["self-test", "machine", "42", "--raw"])
-        result = args.func(args)
+        result, create = _run_self_test_until_create(parse_argv, monkeypatch, offer)
 
         assert result["diagnostics"]["image"]["override"] is False
         assert create.call_args.kwargs["image"] == "vastai/test:self-test-cuda-12.8"
         assert create.call_args.kwargs["runtype"] == "ssh_direc ssh_proxy"
+
+    def test_cuda_mapping_selects_cuda_133_exact_match(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        offer = _self_test_offer(cuda_max_good=13.3, compute_cap=890)
+        result, create = _run_self_test_until_create(parse_argv, monkeypatch, offer)
+
+        assert result["diagnostics"]["image"]["override"] is False
+        assert create.call_args.kwargs["image"] == "vastai/test:self-test-cuda-13.3"
+        assert "exact match" in result["diagnostics"]["image"]["reason"]
+
+    def test_cuda_mapping_steps_down_to_newest_compatible_image(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        offer = _self_test_offer(cuda_max_good=13.2, compute_cap=890)
+        result, create = _run_self_test_until_create(parse_argv, monkeypatch, offer)
+
+        assert result["diagnostics"]["image"]["override"] is False
+        assert create.call_args.kwargs["image"] == "vastai/test:self-test-cuda-13.0"
+        assert "selected newest image <= host CUDA (13.0)" in result["diagnostics"]["image"]["reason"]
+
+    def test_cuda_mapping_uses_cuda_133_for_newer_cuda_hosts(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        offer = _self_test_offer(cuda_max_good=13.4, compute_cap=890)
+        result, create = _run_self_test_until_create(parse_argv, monkeypatch, offer)
+
+        assert result["diagnostics"]["image"]["override"] is False
+        assert create.call_args.kwargs["image"] == "vastai/test:self-test-cuda-13.3"
+        assert "selected newest image <= host CUDA (13.3)" in result["diagnostics"]["image"]["reason"]
+
+    def test_cuda_mapping_still_clamps_volta_to_cuda_128(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        offer = _self_test_offer(cuda_max_good=13.3, compute_cap=700)
+        result, create = _run_self_test_until_create(parse_argv, monkeypatch, offer)
+
+        assert result["diagnostics"]["image"]["override"] is False
+        assert create.call_args.kwargs["image"] == "vastai/test:self-test-cuda-12.8"
+        assert "clamped to 12.8" in result["diagnostics"]["image"]["reason"]
 
     def test_startup_status_msg_is_classified_in_raw_output(
         self, parse_argv, patch_get_client, monkeypatch

--- a/tests/cli/test_runtime_diagnostics.py
+++ b/tests/cli/test_runtime_diagnostics.py
@@ -1,0 +1,154 @@
+import pytest
+
+from vastai.cli.self_test import runtime_diagnostics as diag
+
+
+def test_failure_catalog_contains_stable_runtime_codes():
+    catalog = diag.failure_catalog()
+
+    assert set(diag.RUNTIME_FAILURE_CODES) == set(catalog)
+    assert catalog[diag.DOCKER_PULL_FAILED]["code"] == diag.DOCKER_PULL_FAILED
+    assert catalog[diag.CLEANUP_FAILED]["suggested_steps"]
+
+
+def test_make_failure_shapes_raw_output_dict():
+    result = diag.make_failure(
+        diag.INSTANCE_STATUS_ERROR,
+        stage=diag.STAGE_STARTUP,
+        error="Error: status failed",
+        underlying_error="backend status_msg",
+    )
+
+    assert result["code"] == diag.INSTANCE_STATUS_ERROR
+    assert result["stage"] == diag.STAGE_STARTUP
+    assert result["summary"]
+    assert result["remediation"]
+    assert result["suggested_steps"]
+    assert result["error"] == "Error: status failed"
+    assert result["underlying_error"] == "backend status_msg"
+
+
+def test_make_failure_rejects_unknown_code():
+    with pytest.raises(ValueError, match="Unknown runtime failure code"):
+        diag.make_failure("not_a_real_failure")
+
+
+def test_legacy_parser_tracks_stage_and_classifies_nccl_error():
+    parser = diag.LegacyProgressParser()
+
+    assert parser.process_line("Running NCCL distributed test...") is None
+    result = parser.process_line("ERROR: NCCL unhandled system error during allreduce")
+
+    assert parser.stage == diag.STAGE_NCCL
+    assert result["code"] == diag.NCCL_FAILED
+    assert result["stage"] == diag.STAGE_NCCL
+    assert result["underlying_error"] == "ERROR: NCCL unhandled system error during allreduce"
+
+
+def test_legacy_parser_classifies_unknown_error_as_legacy_progress_error():
+    result = diag.parse_legacy_progress(
+        "\n".join(
+            [
+                "Running system requirements test...",
+                "ERROR: something unexpected happened",
+            ]
+        )
+    )
+
+    assert len(result) == 1
+    assert result[0]["code"] == diag.LEGACY_PROGRESS_ERROR
+    assert result[0]["stage"] == diag.STAGE_SYSTEM_REQUIREMENTS
+
+
+def test_legacy_parser_classifies_nvml_and_nvidia_smi_error():
+    result = diag.parse_legacy_progress(
+        "\n".join(
+            [
+                "Running system requirements test...",
+                "ERROR: nvidia-smi failed: Failed to initialize NVML",
+            ]
+        )
+    )
+
+    assert result[0]["code"] == diag.NVML_FAILED
+    assert result[0]["stage"] == diag.STAGE_SYSTEM_REQUIREMENTS
+
+
+def test_legacy_parser_classifies_resnet_torch_oom():
+    result = diag.parse_legacy_progress(
+        "\n".join(
+            [
+                "Running ResNet50/ResNet18 test...",
+                "ERROR: torch RuntimeError: CUDA out of memory",
+            ]
+        )
+    )
+
+    assert result[0]["code"] == diag.RESNET_FAILED
+    assert result[0]["stage"] == diag.STAGE_RESNET
+
+
+def test_legacy_parser_classifies_ecc_error():
+    result = diag.parse_legacy_progress(
+        "\n".join(
+            [
+                "Running ECC test...",
+                "ERROR: ECC double bit error detected",
+            ]
+        )
+    )
+
+    assert result[0]["code"] == diag.ECC_FAILED
+    assert result[0]["stage"] == diag.STAGE_ECC
+
+
+def test_legacy_parser_classifies_stress_gpu_burn_xid_error():
+    result = diag.parse_legacy_progress(
+        "\n".join(
+            [
+                "Running stress-ng and gpu-burn...",
+                "ERROR: gpu-burn failed after kernel Xid 79",
+            ]
+        )
+    )
+
+    assert result[0]["code"] == diag.STRESS_GPU_BURN_FAILED
+    assert result[0]["stage"] == diag.STAGE_STRESS_GPU_BURN
+
+
+@pytest.mark.parametrize(
+    "status_msg",
+    [
+        "Error response from daemon: manifest for vastai/test:self-test-cuda-99 not found",
+        "pull access denied for private/image, repository does not exist or may require authorization",
+        "unauthorized: authentication required",
+    ],
+)
+def test_status_msg_classifies_docker_pull_failures(status_msg):
+    result = diag.classify_status_msg(status_msg)
+
+    assert result["code"] == diag.DOCKER_PULL_FAILED
+    assert result["stage"] == diag.STAGE_STARTUP
+    assert result["underlying_error"] == status_msg
+
+
+def test_status_msg_classifies_generic_daemon_startup_failure():
+    status_msg = "Error: container failed to start: OCI runtime create failed"
+
+    result = diag.classify_status_msg(status_msg)
+
+    assert result["code"] == diag.DAEMON_STARTUP_FAILED
+    assert result["stage"] == diag.STAGE_STARTUP
+    assert result["underlying_error"] == status_msg
+
+
+def test_status_msg_classifies_other_errors_as_status_error():
+    result = diag.classify_status_msg("Error: host reported an unknown fault")
+
+    assert result["code"] == diag.INSTANCE_STATUS_ERROR
+    assert result["stage"] == diag.STAGE_STARTUP
+
+
+def test_status_msg_ignores_empty_values():
+    assert diag.classify_status_msg(None) is None
+    assert diag.classify_status_msg("  ") is None

--- a/vastai/cli/commands/instances.py
+++ b/vastai/cli/commands/instances.py
@@ -93,7 +93,10 @@ def show__instance(args):
             print(f"Instance {args.id} not found or no longer exists.", file=sys.stderr)
         return 1
     if args.raw:
-        return result
+        return result if result is not None else {"instances": None}
+    if result is None:
+        print(f"Instance {args.id} not found or no longer exists.")
+        return 1
     if args.quiet:
         print(result.get("id", ""))
     else:

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -714,6 +714,11 @@ def self_test__machine(args):
         def cuda_map_to_image(cuda_version, compute_cap=None):
             """Return (image, reason). Reason explains why this image was picked."""
             docker_repo = "vastai/test"
+            image_tag_prefix = "self-test-v2-cuda"
+
+            def image_for(version):
+                return f"{docker_repo}:{image_tag_prefix}-{version}"
+
             if isinstance(cuda_version, float):
                 cuda_version = str(cuda_version)
             original_cuda = cuda_version
@@ -724,8 +729,8 @@ def self_test__machine(args):
             # legacy image.
             if compute_cap is not None and compute_cap < 700:
                 return (
-                    f"{docker_repo}:self-test-cuda-11.8",
-                    f"compute_cap={compute_cap} below sm_70 → forced cuda-11.8",
+                    image_for("11.8"),
+                    f"compute_cap={compute_cap} below sm_70 → forced {image_tag_prefix}-11.8",
                 )
 
             # Volta sm_70/sm_72 hosts: cuda-12.8 wheels include sm_70 but
@@ -739,10 +744,10 @@ def self_test__machine(args):
                     clamped_for_volta = True
 
             docker_tag_map = {
-                "11.8": "cuda-11.8",
-                "12.8": "cuda-12.8",
-                "13.0": "cuda-13.0",
-                "13.3": "cuda-13.3",
+                "11.8": image_for("11.8"),
+                "12.8": image_for("12.8"),
+                "13.0": image_for("13.0"),
+                "13.3": image_for("13.3"),
             }
 
             cap_hint = f"compute_cap={compute_cap}" if compute_cap is not None else "compute_cap=unknown"
@@ -756,17 +761,17 @@ def self_test__machine(args):
 
             if selected_version is not None:
                 selected_version_str = f"{selected_version:.1f}"
-                tag = docker_tag_map[selected_version_str]
+                image = docker_tag_map[selected_version_str]
                 if clamped_for_volta:
-                    reason = f"{cap_hint} (Volta) + cuda_max_good={original_cuda} → clamped to {cuda_version} → {tag}"
+                    reason = f"{cap_hint} (Volta) + cuda_max_good={original_cuda} → clamped to {cuda_version} → {image}"
                 elif selected_version_str == cuda_version:
-                    reason = f"{cap_hint}, cuda_max_good={cuda_version} → exact match → {tag}"
+                    reason = f"{cap_hint}, cuda_max_good={cuda_version} → exact match → {image}"
                 else:
                     reason = (
                         f"{cap_hint}, cuda_max_good={original_cuda} → "
-                        f"selected newest image <= host CUDA ({selected_version_str}) → {tag}"
+                        f"selected newest image <= host CUDA ({selected_version_str}) → {image}"
                     )
-                return f"{docker_repo}:self-test-{tag}", reason
+                return image, reason
 
             raise KeyError(f"No CUDA version found for {cuda_version} or any lower version")
 

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -912,14 +912,28 @@ def self_test__machine(args):
                                 continue
 
                             status_msg = instance_info.get('status_msg', '')
-                            if status_msg and 'Error' in status_msg:
-                                diagnostic = classify_status_msg(status_msg) or make_failure(
+                            status_msg_clean = status_msg.strip() if isinstance(status_msg, str) else ""
+                            status_msg_lower = status_msg_clean.lower()
+                            status_msg_is_error = any(
+                                token in status_msg_lower
+                                for token in (
+                                    "error",
+                                    "failed",
+                                    "failure",
+                                    "exception",
+                                    "traceback",
+                                    "oci runtime",
+                                    "permission denied",
+                                )
+                            )
+                            if status_msg_clean and status_msg_is_error:
+                                diagnostic = classify_status_msg(status_msg_clean) or make_failure(
                                     DAEMON_STARTUP_FAILED,
                                     stage="startup",
-                                    error=status_msg.strip(),
-                                    underlying_error=status_msg.strip(),
+                                    error=status_msg_clean,
+                                    underlying_error=status_msg_clean,
                                 )
-                                reason = f"Instance {inst_id} encountered an error: {status_msg.strip()}"
+                                reason = f"Instance {inst_id} encountered an error: {status_msg_clean}"
                                 progress_print(reason)
                                 if instance_exist(inst_id):
                                     destroy_instance_silent(inst_id)
@@ -929,6 +943,7 @@ def self_test__machine(args):
                                 return False, reason, diagnostic
 
                             actual_status = instance_info.get('actual_status', 'unknown')
+                            intended_status = instance_info.get('intended_status', 'unknown')
                             if actual_status == 'offline':
                                 reason = "Instance offline during testing"
                                 diagnostic = make_failure(INSTANCE_OFFLINE_BEFORE_TEST, stage="startup")
@@ -940,7 +955,29 @@ def self_test__machine(args):
                                     progress_print(f"Instance {inst_id} could not be destroyed or does not exist.")
                                 return False, reason, diagnostic
 
-                            if instance_info.get('intended_status') == 'running' and actual_status == 'running':
+                            if intended_status in ('stopped', 'exited') or actual_status in ('stopped', 'exited'):
+                                reason = f"Instance {inst_id} stopped before reaching running status"
+                                if status_msg_clean:
+                                    reason = f"{reason}: {status_msg_clean}"
+                                diagnostic = classify_status_msg(status_msg_clean) if status_msg_clean else None
+                                if diagnostic is None:
+                                    diagnostic = make_failure(
+                                        DAEMON_STARTUP_FAILED,
+                                        stage="startup",
+                                        summary="Instance stopped before the self-test runtime started.",
+                                        details=reason,
+                                        error=status_msg_clean or None,
+                                        underlying_error=status_msg_clean or None,
+                                    )
+                                progress_print(reason)
+                                if instance_exist(inst_id):
+                                    destroy_instance_silent(inst_id)
+                                    progress_print(f"Instance {inst_id} has been destroyed due to startup failure.")
+                                else:
+                                    progress_print(f"Instance {inst_id} could not be destroyed or does not exist.")
+                                return False, reason, diagnostic
+
+                            if intended_status == 'running' and actual_status == 'running':
                                 debug_print(f"Instance {inst_id} is now running.")
                                 return instance_info, None, None
 

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -795,6 +795,12 @@ def self_test__machine(args):
                 result["stage"] = "create_instance"
                 from vastai.cli.util import parse_env
                 env = parse_env("-e TZ=PDT -e XNAME=XX4 -p 5000:5000 -p 1234:1234")
+                runtype = "ssh_direc ssh_proxy"
+                result["diagnostics"]["launch"] = {
+                    "runtype": runtype,
+                    "jupyter_lab": False,
+                    "ports": ["5000/tcp", "1234/tcp"],
+                }
 
                 progress_print(f"Starting test with {docker_image} ({image_reason})")
                 rj = instances_api.create_instance(
@@ -816,7 +822,7 @@ def self_test__machine(args):
                     cancel_unavail=False,
                     template_hash=None,
                     user=None,
-                    runtype="jupyter_direc ssh_direc ssh_proxy",
+                    runtype=runtype,
                     args=None,
                 )
                 debug_print("Captured instance_info from create_instance:", rj)

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -742,30 +742,31 @@ def self_test__machine(args):
                 "11.8": "cuda-11.8",
                 "12.8": "cuda-12.8",
                 "13.0": "cuda-13.0",
+                "13.3": "cuda-13.3",
             }
 
             cap_hint = f"compute_cap={compute_cap}" if compute_cap is not None else "compute_cap=unknown"
 
-            if cuda_version in docker_tag_map:
-                tag = docker_tag_map[cuda_version]
+            cuda_float = float(cuda_version)
+            compatible_versions = sorted(float(version) for version in docker_tag_map)
+            selected_version = max(
+                (version for version in compatible_versions if version <= cuda_float),
+                default=None,
+            )
+
+            if selected_version is not None:
+                selected_version_str = f"{selected_version:.1f}"
+                tag = docker_tag_map[selected_version_str]
                 if clamped_for_volta:
                     reason = f"{cap_hint} (Volta) + cuda_max_good={original_cuda} → clamped to {cuda_version} → {tag}"
-                else:
+                elif selected_version_str == cuda_version:
                     reason = f"{cap_hint}, cuda_max_good={cuda_version} → exact match → {tag}"
-                return f"{docker_repo}:self-test-{tag}", reason
-
-            cuda_float = float(cuda_version)
-            next_version = round(cuda_float - 0.1, 1)
-            while next_version >= min(float(v) for v in docker_tag_map.keys()):
-                next_version_str = str(next_version)
-                if next_version_str in docker_tag_map:
-                    tag = docker_tag_map[next_version_str]
+                else:
                     reason = (
                         f"{cap_hint}, cuda_max_good={original_cuda} → "
-                        f"stepped down to {next_version_str} → {tag}"
+                        f"selected newest image <= host CUDA ({selected_version_str}) → {tag}"
                     )
-                    return f"{docker_repo}:self-test-{tag}", reason
-                next_version = round(next_version - 0.1, 1)
+                return f"{docker_repo}:self-test-{tag}", reason
 
             raise KeyError(f"No CUDA version found for {cuda_version} or any lower version")
 

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import sys
 import time
 import warnings
@@ -23,7 +24,31 @@ from vastai.api import storage as storage_api
 
 
 from vastai.cli.utils import get_parser as _get_parser, get_client  # noqa: F401
-from vastai.cli.util import required_inet_mbps
+from vastai.cli.self_test.machine_diagnostics import (
+    base_result,
+    compact_offer_metadata,
+    failed_checks,
+    no_offer_failure,
+    preflight_requirement_checks,
+    render_preflight_failure,
+    requirement_failure,
+)
+from vastai.cli.self_test.runtime_diagnostics import (
+    DAEMON_STARTUP_FAILED,
+    INSTANCE_CREATE_FAILED,
+    INSTANCE_CREATE_MISSING_CONTRACT,
+    INSTANCE_OFFLINE_BEFORE_TEST,
+    INSTANCE_START_TIMEOUT,
+    INTERRUPTED,
+    LegacyProgressParser,
+    MISSING_PUBLIC_IP,
+    PROGRESS_ENDPOINT_LOST,
+    PROGRESS_ENDPOINT_UNREACHABLE,
+    PROGRESS_PORT_NOT_MAPPED,
+    RUNTIME_TEST_TIMEOUT,
+    classify_status_msg,
+    make_failure,
+)
 
 
 parser = _get_parser()
@@ -533,7 +558,8 @@ def add__network_disk(args):
     argument("machine_id", help="Machine ID", type=str),
     argument("--debugging", action="store_true", help="Enable debugging output"),
     argument("--ignore-requirements", action="store_true", help="Ignore the minimum system requirements and run the self test regardless"),
-    usage="vastai self-test machine <machine_id> [--debugging] [--ignore-requirements]",
+    argument("--test-image", help="Use a custom self-test image for testing custom self-test images. Overrides VAST_SELF_TEST_IMAGE and CUDA mapping.", type=str),
+    usage="vastai self-test machine <machine_id> [--debugging] [--ignore-requirements] [--test-image IMAGE]",
     help="[Host] Perform a self-test on the specified machine",
     epilog=deindent("""
         This command tests if a machine meets specific requirements and
@@ -550,7 +576,7 @@ def self_test__machine(args):
     required specifications and functionality.
     """
     instance_id = None
-    result = {"success": False, "reason": ""}
+    result = base_result(args.machine_id)
     ignore_requirements_warning = (
         "WARNING: --ignore-requirements is set. Requirement checks are skipped as a "
         "pass/fail gate, and passing this self-test does not qualify this machine for verification."
@@ -558,8 +584,9 @@ def self_test__machine(args):
 
     if not hasattr(args, 'debugging'):
         args.debugging = False
-
-    if args.ignore_requirements:
+    if not hasattr(args, 'test_image'):
+        args.test_image = None
+    if getattr(args, "ignore_requirements", False):
         result["warning"] = ignore_requirements_warning
 
     def progress_print(*args_to_print):
@@ -570,104 +597,116 @@ def self_test__machine(args):
         if args.debugging and not args.raw:
             print(*args_to_print)
 
-    def safe_float(value):
-        if value is None:
-            return 0
-        try:
-            return float(value)
-        except (ValueError, TypeError):
-            return 0
+    def finish_failure():
+        if args.raw:
+            return result
+        if result.get("warning"):
+            print(result["warning"])
+        render_runtime_failure()
+        print(f"Test failed: {result['reason']}")
+        sys.exit(1)
+
+    def set_runtime_failure(diagnostic, fallback_reason=None):
+        result["failure"] = diagnostic
+        result["failure_code"] = diagnostic["code"]
+        result["stage"] = diagnostic.get("stage") or result.get("stage")
+        result["reason"] = fallback_reason or diagnostic.get("summary") or ""
+        result["diagnostics"]["runtime_failure"] = diagnostic
+
+    def safe_error(error):
+        return re.sub(r"([?&]api_key=)[^&\s]+", r"\1REDACTED", str(error))
+
+    def render_runtime_failure():
+        diagnostic = result.get("diagnostics", {}).get("runtime_failure")
+        if not diagnostic:
+            return
+        print("Runtime failure diagnostics:")
+        print(f"- code: {diagnostic.get('code')}")
+        if diagnostic.get("summary"):
+            print(f"- summary: {diagnostic['summary']}")
+        if diagnostic.get("underlying_error"):
+            print(f"- underlying error: {diagnostic['underlying_error']}")
+        if diagnostic.get("remediation"):
+            print(f"- remediation: {diagnostic['remediation']}")
+        steps = diagnostic.get("suggested_steps") or []
+        if steps:
+            print("- suggested steps:")
+            for step in steps:
+                print(f"  - {step}")
 
     client = get_client(args)
 
     try:
-        # ----- check requirements -----
-        def check_requirements(machine_id):
-            unmet_reasons = []
-            query = {
+        def selected_offer_for_self_test(machine_id):
+            strict_query = {
                 "machine_id": {"eq": machine_id},
                 "verified": {"eq": "any"},
                 "rentable": {"eq": True},
                 "rented": {"eq": "any"},
             }
-            try:
-                offers = offers_api.search_offers(
-                    client, query=query, offer_type="on-demand",
-                    order=[["score", "desc"]], storage=5.0, no_default=True,
-                )
-                debug_print("Captured offers from search_offers:", offers)
+            strict_offers = offers_api.search_offers(
+                client, query=strict_query, offer_type="on-demand",
+                order=[["score", "desc"]], storage=5.0, no_default=True,
+            )
+            debug_print("Captured strict offers from search_offers:", strict_offers)
+            diagnostics = {
+                "strict_offer_count": len(strict_offers or []),
+                "broader_offer_count": None,
+                "broader_offers": [],
+            }
+            if strict_offers:
+                sorted_offers = sorted(strict_offers, key=lambda x: x.get("dlperf", 0), reverse=True)
+                selected = dict(sorted_offers[0])
+                selected["machine_id"] = selected.get("machine_id") or machine_id
+                debug_print("Selected offer found:", selected)
+                return selected, None, diagnostics
 
-                if not offers:
-                    msg = f"Machine ID {machine_id} not found or not rentable."
-                    unmet_reasons.append(msg)
-                    progress_print(msg)
-                    progress_print("Possible reasons:")
-                    progress_print("  1. Machine is already rented — try: vastai show machines --filter 'machine_id={machine_id} rented=true'")
-                    progress_print("  2. Machine is offline — try: vastai show machines")
-                    progress_print("  3. No active offer for this machine — try: vastai search offers --filter 'machine_id={machine_id} rentable=any'")
-                    progress_print("  4. Bid price may be too low — compare prices with: vastai search offers --filter 'machine_id={machine_id} rentable=any'")
-                    return False, unmet_reasons
+            broader_query = {
+                "machine_id": {"eq": machine_id},
+                "verified": {"eq": "any"},
+                "rentable": {"eq": "any"},
+                "rented": {"eq": "any"},
+            }
+            broader_offers = offers_api.search_offers(
+                client, query=broader_query, offer_type="on-demand",
+                order=[["score", "desc"]], storage=5.0, no_default=True,
+            )
+            diagnostics["broader_offer_count"] = len(broader_offers or [])
+            diagnostics["broader_offers"] = [
+                compact_offer_metadata(dict(offer, machine_id=offer.get("machine_id", machine_id)))
+                for offer in (broader_offers or [])[:5]
+            ]
+            check, failure = no_offer_failure(machine_id, broader_offers)
+            return None, (check, failure), diagnostics
 
-                sorted_offers = sorted(offers, key=lambda x: x.get('dlperf', 0), reverse=True)
-                top_offer = sorted_offers[0]
-                debug_print("Top offer found:", top_offer)
+        selected_offer, offer_failure, offer_diagnostics = selected_offer_for_self_test(args.machine_id)
+        result["diagnostics"]["offer_search"] = offer_diagnostics
+        if offer_failure:
+            check, failure = offer_failure
+            result["checks"] = [check]
+            result["failure"] = failure
+            result["failure_code"] = failure["code"]
+            result["stage"] = "select_offer"
+            result["reason"] = failure["summary"]
+            render_preflight_failure(args.machine_id, result["checks"], failure, progress_print)
+            return finish_failure()
 
-                if safe_float(top_offer.get('cuda_max_good')) < 11.8:
-                    unmet_reasons.append("CUDA version < 11.8")
-                if safe_float(top_offer.get('reliability')) <= 0.90:
-                    unmet_reasons.append("Reliability <= 0.90")
-                if safe_float(top_offer.get('direct_port_count')) <= 3:
-                    unmet_reasons.append("Direct port count <= 3")
-                if safe_float(top_offer.get('pcie_bw')) <= 2.85:
-                    unmet_reasons.append("PCIe bandwidth <= 2.85")
-                gpu_total_ram = safe_float(top_offer.get('gpu_total_ram'))
-                required_mbps = required_inet_mbps(gpu_total_ram)
-                if safe_float(top_offer.get('inet_down')) < required_mbps:
-                    unmet_reasons.append(f"Download speed < {required_mbps:.0f} Mb/s")
-                if safe_float(top_offer.get('inet_up')) < required_mbps:
-                    unmet_reasons.append(f"Upload speed < {required_mbps:.0f} Mb/s")
-                if safe_float(top_offer.get('gpu_ram')) <= 7:
-                    unmet_reasons.append("GPU RAM <= 7 GB")
-
-                cpu_ram = safe_float(top_offer.get('cpu_ram'))
-                if cpu_ram < 0.95 * gpu_total_ram:
-                    unmet_reasons.append("System RAM is less than total VRAM.")
-                debug_print(f"CPU RAM: {cpu_ram} MB")
-                debug_print(f"Total GPU RAM: {gpu_total_ram} MB")
-
-                cpu_cores = int(safe_float(top_offer.get('cpu_cores')))
-                num_gpus = int(safe_float(top_offer.get('num_gpus')))
-                if cpu_cores < 2 * num_gpus:
-                    unmet_reasons.append("Number of CPU cores is less than twice the number of GPUs.")
-                debug_print(f"CPU Cores: {cpu_cores}")
-                debug_print(f"Number of GPUs: {num_gpus}")
-
-                if unmet_reasons:
-                    progress_print(f"Machine ID {machine_id} does not meet the requirements:")
-                    for reason in unmet_reasons:
-                        progress_print(f"- {reason}")
-                    return False, unmet_reasons
-                else:
-                    progress_print(f"Machine ID {machine_id} meets all the requirements.")
-                    return True, []
-
-            except Exception as e:
-                progress_print(f"An unexpected error occurred: {str(e)}")
-                debug_print(f"Exception details: {e}")
-                return False, [f"Unexpected error: {str(e)}"]
-
-        meets_requirements, unmet_reasons = check_requirements(args.machine_id)
-        if not meets_requirements and not args.ignore_requirements:
-            progress_print(f"Machine ID {args.machine_id} does not meet the following requirements:")
-            for reason in unmet_reasons:
-                progress_print(f"- {reason}")
-            result["reason"] = "; ".join(unmet_reasons)
-            return result
-        if not meets_requirements and args.ignore_requirements:
-            progress_print(f"Machine ID {args.machine_id} does not meet the following requirements:")
-            for reason in unmet_reasons:
-                progress_print(f"- {reason}")
+        result["offer"] = compact_offer_metadata(selected_offer)
+        checks = preflight_requirement_checks(selected_offer)
+        result["checks"] = checks
+        unmet_checks = failed_checks(checks)
+        if unmet_checks:
+            failure = requirement_failure(checks)
+            result["failure"] = failure
+            result["failure_code"] = failure["code"]
+            result["stage"] = "preflight_requirements"
+            result["reason"] = failure["summary"]
+            render_preflight_failure(args.machine_id, checks, failure, progress_print)
+            if not args.ignore_requirements:
+                return finish_failure()
             progress_print("Continuing despite unmet requirements because --ignore-requirements is set.")
+        else:
+            progress_print(f"Machine ID {args.machine_id} meets all the requirements.")
         if args.ignore_requirements:
             progress_print(ignore_requirements_warning)
 
@@ -730,30 +769,7 @@ def self_test__machine(args):
 
             raise KeyError(f"No CUDA version found for {cuda_version} or any lower version")
 
-        # ----- search offers and get top -----
-        def search_offers_and_get_top(machine_id):
-            query = {
-                "machine_id": {"eq": machine_id},
-                "verified": {"eq": "any"},
-                "rentable": {"eq": True},
-                "rented": {"eq": "any"},
-            }
-            offers = offers_api.search_offers(
-                client, query=query, offer_type="on-demand",
-                order=[["score", "desc"]], storage=5.0, no_default=True,
-            )
-            if not offers:
-                progress_print(f"Machine ID {machine_id} not found or not rentable.")
-                progress_print("Possible reasons:")
-                progress_print(f"  1. Machine is already rented — try: vastai show machines --filter 'machine_id={machine_id} rented=true'")
-                progress_print("  2. Machine is offline — try: vastai show machines")
-                progress_print(f"  3. No active offer for this machine — try: vastai search offers --filter 'machine_id={machine_id} rentable=any'")
-                progress_print(f"  4. Bid price may be too low — compare prices with: vastai search offers --filter 'machine_id={machine_id} rentable=any'")
-                return None
-            sorted_offers = sorted(offers, key=lambda x: x.get("dlperf", 0), reverse=True)
-            return sorted_offers[0] if sorted_offers else None
-
-        top_offer = search_offers_and_get_top(args.machine_id)
+        top_offer = selected_offer
         if not top_offer:
             progress_print(f"No valid offers found for Machine ID {args.machine_id}")
             result["reason"] = "No valid offers found."
@@ -761,10 +777,22 @@ def self_test__machine(args):
             ask_contract_id = top_offer["id"]
             cuda_version = top_offer["cuda_max_good"]
             compute_cap = top_offer.get("compute_cap")
-            docker_image, image_reason = cuda_map_to_image(cuda_version, compute_cap)
+            image_override = args.test_image or os.environ.get("VAST_SELF_TEST_IMAGE")
+            if image_override:
+                docker_image = image_override
+                image_reason = "custom self-test image override"
+            else:
+                docker_image, image_reason = cuda_map_to_image(cuda_version, compute_cap)
+            result["diagnostics"]["image"] = {
+                "image": docker_image,
+                "reason": image_reason,
+                "override": bool(image_override),
+            }
 
             # ----- create the test instance -----
             try:
+                result["phase"] = "rental"
+                result["stage"] = "create_instance"
                 from vastai.cli.util import parse_env
                 env = parse_env("-e TZ=PDT -e XNAME=XX4 -p 5000:5000 -p 1234:1234")
 
@@ -793,14 +821,31 @@ def self_test__machine(args):
                 )
                 debug_print("Captured instance_info from create_instance:", rj)
             except Exception as e:
-                progress_print(f"Error creating instance: {e}")
-                result["reason"] = "Failed to create instance. Check the docker configuration. Use the self-test machine function in vast cli"
-                return result
+                error = safe_error(e)
+                progress_print(f"Error creating instance: {error}")
+                set_runtime_failure(
+                    make_failure(
+                        INSTANCE_CREATE_FAILED,
+                        stage="create_instance",
+                        summary="Failed to create instance. Check the docker configuration.",
+                        error=error,
+                        underlying_error=error,
+                    )
+                )
+                result["error"] = error
+                return finish_failure()
 
             instance_id = rj.get("new_contract")
             if not instance_id:
                 progress_print("Instance creation response did not contain 'new_contract'.")
-                result["reason"] = "Instance creation failed."
+                set_runtime_failure(
+                    make_failure(
+                        INSTANCE_CREATE_MISSING_CONTRACT,
+                        stage="create_instance",
+                        details=f"Create-instance response: {rj}",
+                    ),
+                    "Instance creation failed.",
+                )
             else:
                 # ----- helper: check if instance exists -----
                 def instance_exist(inst_id):
@@ -815,10 +860,10 @@ def self_test__machine(args):
                     except requests.exceptions.HTTPError as e:
                         if e.response.status_code == 404:
                             return False
-                        debug_print(f"HTTPError when checking instance existence: {e}")
+                        debug_print(f"HTTPError when checking instance existence: {safe_error(e)}")
                         return False
                     except Exception as e:
-                        debug_print(f"No instance found or Unexpected error checking instance existence: {e}")
+                        debug_print(f"No instance found or Unexpected error checking instance existence: {safe_error(e)}")
                         return False
 
                 # ----- helper: destroy instance silently with retries -----
@@ -836,7 +881,7 @@ def self_test__machine(args):
                             return {"success": True}
                         except Exception as e:
                             if not args.raw:
-                                print(f"Error destroying instance {inst_id}: {e}")
+                                print(f"Error destroying instance {inst_id}: {safe_error(e)}")
                         if attempt < max_retries:
                             if not args.raw:
                                 print(f"Retrying in 10 seconds... (Attempt {attempt}/{max_retries})")
@@ -861,6 +906,12 @@ def self_test__machine(args):
 
                             status_msg = instance_info.get('status_msg', '')
                             if status_msg and 'Error' in status_msg:
+                                diagnostic = classify_status_msg(status_msg) or make_failure(
+                                    DAEMON_STARTUP_FAILED,
+                                    stage="startup",
+                                    error=status_msg.strip(),
+                                    underlying_error=status_msg.strip(),
+                                )
                                 reason = f"Instance {inst_id} encountered an error: {status_msg.strip()}"
                                 progress_print(reason)
                                 if instance_exist(inst_id):
@@ -868,40 +919,47 @@ def self_test__machine(args):
                                     progress_print(f"Instance {inst_id} has been destroyed due to error.")
                                 else:
                                     progress_print(f"Instance {inst_id} could not be destroyed or does not exist.")
-                                return False, reason
+                                return False, reason, diagnostic
 
                             actual_status = instance_info.get('actual_status', 'unknown')
                             if actual_status == 'offline':
                                 reason = "Instance offline during testing"
+                                diagnostic = make_failure(INSTANCE_OFFLINE_BEFORE_TEST, stage="startup")
                                 progress_print(reason)
                                 if instance_exist(inst_id):
                                     destroy_instance_silent(inst_id)
                                     progress_print(f"Instance {inst_id} has been destroyed due to being offline.")
                                 else:
                                     progress_print(f"Instance {inst_id} could not be destroyed or does not exist.")
-                                return False, reason
+                                return False, reason, diagnostic
 
                             if instance_info.get('intended_status') == 'running' and actual_status == 'running':
                                 debug_print(f"Instance {inst_id} is now running.")
-                                return instance_info, None
+                                return instance_info, None, None
 
                             progress_print(f"Instance {inst_id} status: {actual_status}... waiting for 'running' status.")
                             time.sleep(interval)
 
                         except Exception as e:
-                            progress_print(f"Error retrieving instance info for {inst_id}: {e}. Retrying...")
-                            debug_print(f"Exception details: {str(e)}")
+                            error = safe_error(e)
+                            progress_print(f"Error retrieving instance info for {inst_id}: {error}. Retrying...")
+                            debug_print(f"Exception details: {error}")
                             time.sleep(interval)
 
                     reason = f"Instance did not become running within {timeout} seconds. Verify network configuration. Use the self-test machine function in vast cli"
                     progress_print(reason)
-                    return False, reason
+                    return False, reason, make_failure(
+                        INSTANCE_START_TIMEOUT,
+                        stage="startup",
+                        details=reason,
+                    )
 
                 # ----- run machine tester -----
                 def run_machinetester(ip_address, port, inst_id, machine_id, delay):
                     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
                     delay = int(delay)
                     message = ''
+                    legacy_parser = LegacyProgressParser()
 
                     def is_instance(iid):
                         try:
@@ -913,7 +971,7 @@ def self_test__machine(args):
                             actual_status = info.get('actual_status', 'unknown')
                             return actual_status if actual_status in ['running', 'offline', 'exited', 'created'] else 'unknown'
                         except Exception as e:
-                            debug_print(f"is_instance(): Error: {e}")
+                            debug_print(f"is_instance(): Error: {safe_error(e)}")
                             return 'unknown'
 
                     if delay > 0:
@@ -935,7 +993,7 @@ def self_test__machine(args):
                                 progress_print(f"Instance {inst_id} went offline. {reason}")
                                 destroy_instance_silent(inst_id)
                                 instance_destroyed = True
-                                return False, reason
+                                return False, reason, make_failure(INSTANCE_OFFLINE_BEFORE_TEST, stage="runtime")
 
                             try:
                                 debug_print(f"Sending GET request to https://{ip_address}:{port}/progress")
@@ -948,25 +1006,26 @@ def self_test__machine(args):
                                 message = response.text.strip()
                                 debug_print(f"Received message: '{message}'")
                             except requests.exceptions.RequestException as e:
-                                debug_print(f"Error making HTTPS request: {e}")
+                                debug_print(f"Error making HTTPS request: {safe_error(e)}")
                                 message = ''
 
                             if message:
                                 lines = message.split('\n')
                                 new_lines = [line for line in lines if line not in printed_lines]
                                 for line in new_lines:
+                                    diagnostic = legacy_parser.process_line(line)
                                     if line == 'DONE':
                                         progress_print("Test completed successfully.")
                                         progress_print("Test passed.")
                                         destroy_instance_silent(inst_id)
                                         instance_destroyed = True
-                                        return True, ""
+                                        return True, "", None
                                     elif line.startswith('ERROR'):
                                         progress_print(line)
                                         progress_print(f"Test failed with error: {line}.")
                                         destroy_instance_silent(inst_id)
                                         instance_destroyed = True
-                                        return False, line
+                                        return False, line, diagnostic
                                     else:
                                         progress_print(line)
                                     printed_lines.add(line)
@@ -981,8 +1040,13 @@ def self_test__machine(args):
                                     progress_print("Possible causes:")
                                     progress_print("  1. Port not accessible from outside — check firewall and direct_port_count")
                                     progress_print("  2. Container crashed on startup — check docker logs")
-                                    progress_print(f"  3. direct_port_count too low — check with: vastai search offers --filter 'machine_id={machine_id}'")
+                                    progress_print(f"  3. direct_port_count too low - check with: vastai search offers 'machine_id={machine_id} rentable=any rented=any'")
                                     return_reason = "Port never reachable within 120 seconds"
+                                    diagnostic = make_failure(
+                                        PROGRESS_ENDPOINT_UNREACHABLE,
+                                        stage="runtime_connect",
+                                        details=return_reason,
+                                    )
                                 else:
                                     progress_print("Connection lost after initial success — instance may have crashed.")
                                     progress_print("Possible causes:")
@@ -990,15 +1054,23 @@ def self_test__machine(args):
                                     progress_print("  2. GPU errors — check dmesg for Xid errors")
                                     progress_print("  3. Try running individual tests to isolate the failure")
                                     return_reason = "Connection lost after 120 seconds — possible crash during stress test"
+                                    diagnostic = make_failure(
+                                        PROGRESS_ENDPOINT_LOST,
+                                        stage="runtime_connect",
+                                        details=return_reason,
+                                    )
                                 destroy_instance_silent(inst_id)
                                 instance_destroyed = True
-                                return False, return_reason
+                                return False, return_reason, diagnostic
 
                             debug_print("Waiting for 20 seconds before the next check.")
                             time.sleep(20)
 
                         debug_print(f"Time limit reached. Destroying instance {inst_id}.")
-                        return False, "Test did not complete within the time limit"
+                        return False, "Test did not complete within the time limit", make_failure(
+                            RUNTIME_TEST_TIMEOUT,
+                            stage="runtime",
+                        )
                     finally:
                         if not instance_destroyed and inst_id and instance_exist(inst_id):
                             destroy_instance_silent(inst_id)
@@ -1006,13 +1078,18 @@ def self_test__machine(args):
                         warnings.simplefilter('default')
 
                 # ----- main orchestration: wait then test -----
-                instance_info, wait_reason = wait_for_instance(instance_id)
+                result["phase"] = "wait"
+                result["stage"] = "wait_for_instance"
+                instance_info, wait_reason, wait_diagnostic = wait_for_instance(instance_id)
                 if not instance_info:
-                    result["reason"] = wait_reason
+                    set_runtime_failure(wait_diagnostic, wait_reason)
                 else:
                     ip_address = instance_info.get("public_ipaddr")
                     if not ip_address:
-                        result["reason"] = "Failed to retrieve public IP address."
+                        set_runtime_failure(
+                            make_failure(MISSING_PUBLIC_IP, stage="instance_network"),
+                            "Failed to retrieve public IP address.",
+                        )
                     else:
                         all_ports = instance_info.get("ports", {})
                         port_mappings = all_ports.get("5000/tcp", [])
@@ -1021,24 +1098,50 @@ def self_test__machine(args):
                             progress_print(f"Port 5000/tcp not found in mapped ports. Available ports: {list(all_ports.keys())}")
                             progress_print("Possible causes:")
                             progress_print("  1. Firewall blocking the port")
-                            progress_print(f"  2. direct_port_count too low — check with: vastai search offers --filter 'machine_id={args.machine_id}'")
+                            progress_print(f"  2. direct_port_count too low - check with: vastai search offers 'machine_id={args.machine_id} rentable=any rented=any'")
                             progress_print("  3. Container is not exposing port 5000")
-                            result["reason"] = "Failed to retrieve mapped port."
+                            set_runtime_failure(
+                                make_failure(
+                                    PROGRESS_PORT_NOT_MAPPED,
+                                    stage="instance_network",
+                                    details=f"Available ports: {list(all_ports.keys())}",
+                                ),
+                                "Failed to retrieve mapped port.",
+                            )
                         else:
                             delay = "15"
-                            success, reason = run_machinetester(
+                            result["phase"] = "test"
+                            result["stage"] = "run_machinetester"
+                            success, reason, runtime_diagnostic = run_machinetester(
                                 ip_address, port, instance_id, args.machine_id, delay,
                             )
                             result["success"] = success
                             result["reason"] = reason
+                            if success:
+                                result["phase"] = "complete"
+                                result["stage"] = "complete"
+                            else:
+                                set_runtime_failure(runtime_diagnostic, reason)
 
     except KeyboardInterrupt:
         result["success"] = False
-        result["reason"] = "Interrupted by user (Ctrl+C)"
+        set_runtime_failure(
+            make_failure(INTERRUPTED, stage=result.get("stage")),
+            "Interrupted by user (Ctrl+C)",
+        )
+        result["error"] = result["reason"]
         progress_print("\nInterrupted — cleaning up test instance...")
     except Exception as e:
+        error = safe_error(e)
         result["success"] = False
-        result["reason"] = str(e)
+        result["reason"] = error
+        result["failure_code"] = "unexpected_error"
+        result["failure"] = {
+            "code": "unexpected_error",
+            "summary": error,
+            "remediation": "Retry with --debugging and inspect the error details.",
+        }
+        result["error"] = error
 
     finally:
         # Always attempt to destroy the test instance, including on Ctrl+C.
@@ -1049,28 +1152,35 @@ def self_test__machine(args):
             try:
                 info = instances_api.show_instance(client, id=instance_id)
                 if not info:
-                    debug_print(f"Test instance {instance_id} is already gone.")
-                else:
-                    status = info.get('intended_status') or info.get('actual_status')
-                    if status not in ('destroyed', 'terminated', 'offline'):
-                        progress_print(f"Destroying test instance {instance_id} (status: {status})...")
-                        instances_api.destroy_instance(client, id=instance_id)
-                        progress_print(f"Test instance {instance_id} destroyed.")
+                    debug_print(f"Test instance {instance_id} already gone during cleanup.")
+                    info = {}
+                status = (info or {}).get('intended_status') or (info or {}).get('actual_status')
+                if info and status not in ('destroyed', 'terminated', 'offline'):
+                    progress_print(f"Destroying test instance {instance_id} (status: {status})...")
+                    instances_api.destroy_instance(client, id=instance_id)
+                    progress_print(f"Test instance {instance_id} destroyed.")
             except KeyboardInterrupt:
                 progress_print(
                     f"\nSecond interrupt during cleanup — instance {instance_id} may still be running.\n"
                     f"  Destroy it manually: vastai destroy instance {instance_id}"
                 )
                 raise
+            except requests.exceptions.HTTPError as e:
+                if e.response is not None and e.response.status_code == 404:
+                    debug_print(f"Test instance {instance_id} already gone during cleanup.")
+                else:
+                    progress_print(
+                        f"WARNING: failed to destroy test instance {instance_id}: {safe_error(e)}\n"
+                        f"  Destroy it manually: vastai destroy instance {instance_id}"
+                    )
             except Exception as e:
                 progress_print(
-                    f"WARNING: failed to destroy test instance {instance_id}: {e}\n"
+                    f"WARNING: failed to destroy test instance {instance_id}: {safe_error(e)}\n"
                     f"  Destroy it manually: vastai destroy instance {instance_id}"
                 )
 
     if args.raw:
-        print(json.dumps(result))
-        sys.exit(0)
+        return result
     else:
         if result.get("warning"):
             print(result["warning"])
@@ -1078,5 +1188,6 @@ def self_test__machine(args):
             print("Test completed successfully.")
             sys.exit(0)
         else:
+            render_runtime_failure()
             print(f"Test failed: {result['reason']}")
             sys.exit(1)

--- a/vastai/cli/self_test/__init__.py
+++ b/vastai/cli/self_test/__init__.py
@@ -1,0 +1,2 @@
+"""Helpers for CLI self-test diagnostics."""
+

--- a/vastai/cli/self_test/machine_diagnostics.py
+++ b/vastai/cli/self_test/machine_diagnostics.py
@@ -1,0 +1,287 @@
+"""Structured diagnostics for ``vastai self-test machine``."""
+
+from vastai.cli.util import required_inet_mbps
+
+
+DIAGNOSTICS_VERSION = "1"
+
+
+def safe_float(value):
+    if value is None:
+        return 0.0
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def gpu_ram_gib(value):
+    """Normalize API GPU RAM values for display.
+
+    Search offer output historically displays `gpu_ram` after dividing by
+    1000, while tests and some call paths use a direct GiB-style value. Treat
+    large values as MiB so host-facing self-test output does not print
+    impossible values such as `32768 GB`.
+    """
+    raw = safe_float(value)
+    if raw > 256:
+        return raw / 1024
+    return raw
+
+
+def compact_offer_metadata(offer):
+    if not offer:
+        return None
+    fields = (
+        "id",
+        "machine_id",
+        "gpu_name",
+        "num_gpus",
+        "dph_total",
+        "dlperf",
+        "cuda_max_good",
+        "compute_cap",
+        "reliability",
+        "direct_port_count",
+        "pcie_bw",
+        "inet_down",
+        "inet_up",
+        "gpu_ram",
+        "gpu_total_ram",
+        "cpu_ram",
+        "cpu_cores",
+        "rentable",
+        "rented",
+    )
+    return {field: offer.get(field) for field in fields if field in offer}
+
+
+def base_result(machine_id):
+    return {
+        "success": False,
+        "reason": "",
+        "warning": None,
+        "phase": "preflight",
+        "diagnostics_version": DIAGNOSTICS_VERSION,
+        "machine_id": machine_id,
+        "offer": None,
+        "checks": [],
+        "failure": None,
+        "failure_code": None,
+        "stage": None,
+        "error": None,
+        "diagnostics": {},
+    }
+
+
+def _check(
+    check_id,
+    title,
+    actual,
+    required,
+    operator,
+    unit,
+    passed,
+    purpose,
+    remediation,
+):
+    status = "pass" if passed else "fail"
+    return {
+        "id": check_id,
+        "title": title,
+        "status": status,
+        "actual": actual,
+        "required": required,
+        "operator": operator,
+        "unit": unit,
+        "summary": f"{title}: actual {actual} {unit}, required {operator} {required} {unit}",
+        "purpose": purpose,
+        "remediation": remediation,
+    }
+
+
+def preflight_requirement_checks(offer):
+    gpu_total_ram = safe_float(offer.get("gpu_total_ram"))
+    per_gpu_ram_gib = gpu_ram_gib(offer.get("gpu_ram"))
+    required_mbps = required_inet_mbps(gpu_total_ram)
+    cpu_ram = safe_float(offer.get("cpu_ram"))
+    cpu_cores = int(safe_float(offer.get("cpu_cores")))
+    num_gpus = int(safe_float(offer.get("num_gpus")))
+    required_cpu_ram = 0.95 * gpu_total_ram
+    required_cpu_cores = 2 * num_gpus
+
+    return [
+        _check(
+            "cuda.version",
+            "CUDA version",
+            safe_float(offer.get("cuda_max_good")),
+            11.8,
+            ">=",
+            "CUDA",
+            safe_float(offer.get("cuda_max_good")) >= 11.8,
+            "The self-test image needs a host driver stack compatible with CUDA 11.8 or newer.",
+            "Update the NVIDIA driver/CUDA stack, then confirm with: vastai search offers "
+            f"'machine_id={offer.get('machine_id') or 'unknown'} rentable=any rented=any'",
+        ),
+        _check(
+            "reliability",
+            "Reliability",
+            safe_float(offer.get("reliability")),
+            0.90,
+            ">",
+            "ratio",
+            safe_float(offer.get("reliability")) > 0.90,
+            "Self-test uses reliability as a guardrail before launching a temporary instance.",
+            "Let the host stabilize and resolve recent failures before retrying the self-test.",
+        ),
+        _check(
+            "network.direct_ports",
+            "Direct port count",
+            safe_float(offer.get("direct_port_count")),
+            3,
+            ">",
+            "ports",
+            safe_float(offer.get("direct_port_count")) > 3,
+            "The tester needs enough directly mapped ports for remote progress and SSH checks.",
+            "Open additional direct ports or adjust host firewall/NAT settings, then rerun verification.",
+        ),
+        _check(
+            "pcie.bandwidth",
+            "PCIe bandwidth",
+            safe_float(offer.get("pcie_bw")),
+            2.85,
+            ">",
+            "GB/s",
+            safe_float(offer.get("pcie_bw")) > 2.85,
+            "Low PCIe bandwidth can make GPU stress and transfer checks fail or time out.",
+            "Check BIOS PCIe generation/lane settings and confirm GPUs are seated in full-speed slots.",
+        ),
+        _check(
+            "network.download",
+            "Download speed",
+            safe_float(offer.get("inet_down")),
+            round(required_mbps, 2),
+            ">=",
+            "Mb/s",
+            safe_float(offer.get("inet_down")) >= required_mbps,
+            "The bandwidth floor scales with total VRAM so large GPU hosts can complete data movement tests.",
+            "Improve host download bandwidth or reduce contention, then rerun the Vast host verification.",
+        ),
+        _check(
+            "network.upload",
+            "Upload speed",
+            safe_float(offer.get("inet_up")),
+            round(required_mbps, 2),
+            ">=",
+            "Mb/s",
+            safe_float(offer.get("inet_up")) >= required_mbps,
+            "The tester needs enough upload bandwidth to report progress and complete network checks.",
+            "Improve host upload bandwidth or reduce contention, then rerun the Vast host verification.",
+        ),
+        _check(
+            "gpu.ram",
+            "GPU RAM",
+            round(per_gpu_ram_gib, 2),
+            7,
+            ">",
+            "GiB",
+            per_gpu_ram_gib > 7,
+            "The verification workload requires more than 7 GB of VRAM per GPU.",
+            "Use a GPU with more VRAM for this self-test.",
+        ),
+        _check(
+            "system.ram",
+            "System RAM",
+            cpu_ram,
+            round(required_cpu_ram, 2),
+            ">=",
+            "MiB",
+            cpu_ram >= required_cpu_ram,
+            "System RAM must be close to total VRAM so CPU-side staging does not starve the tests.",
+            "Add system RAM or reduce the listed GPU set so system RAM is at least 95% of total VRAM.",
+        ),
+        _check(
+            "cpu.cores",
+            "CPU cores",
+            cpu_cores,
+            required_cpu_cores,
+            ">=",
+            "cores",
+            cpu_cores >= required_cpu_cores,
+            "The tester expects at least two CPU cores per GPU for stable orchestration.",
+            "Expose more CPU cores to the host or reduce the GPU count for this offer.",
+        ),
+    ]
+
+
+def failed_checks(checks):
+    return [check for check in checks if check.get("status") == "fail"]
+
+
+def no_offer_failure(machine_id, broader_offers):
+    broad_count = len(broader_offers or [])
+    if broad_count:
+        summary = f"No currently rentable on-demand offer found for machine {machine_id}."
+        causes = [
+            "The machine may be listed but not rentable right now.",
+            "The offer may be unavailable to new rentals because host state, verification, or pricing changed.",
+            "The machine may already be occupied or temporarily unavailable.",
+        ]
+        code = "no_rentable_offer"
+    else:
+        summary = f"No on-demand offer found for machine {machine_id}."
+        causes = [
+            "The machine may be offline.",
+            "The machine may not have an active listed offer.",
+            "The machine ID may be incorrect or not visible to this account.",
+        ]
+        code = "no_offer"
+
+    remediation = (
+        "Check host state with: vastai show machines. Then inspect offers with: "
+        f"vastai search offers 'machine_id={machine_id} rentable=any rented=any'."
+    )
+    check = {
+        "id": "offer.available",
+        "title": "Rentable offer available",
+        "status": "fail",
+        "actual": 0,
+        "required": 1,
+        "operator": ">=",
+        "unit": "offers",
+        "summary": summary,
+        "purpose": "The self-test needs a selected offer so it can rent one temporary diagnostic instance.",
+        "remediation": remediation,
+    }
+    failure = {
+        "code": code,
+        "summary": summary,
+        "likely_causes": causes,
+        "remediation": remediation,
+    }
+    return check, failure
+
+
+def requirement_failure(checks):
+    failures = failed_checks(checks)
+    summary = f"{len(failures)} preflight requirement check(s) failed."
+    return {
+        "code": "preflight_requirements_failed",
+        "summary": summary,
+        "failed_check_ids": [check["id"] for check in failures],
+        "remediation": "Resolve the failed checks below, or rerun with --ignore-requirements to dogfood anyway.",
+    }
+
+
+def render_preflight_failure(machine_id, checks, failure=None, print_fn=print):
+    print_fn(f"Preflight diagnostics for machine {machine_id} failed:")
+    for check in failed_checks(checks):
+        print_fn(f"- {check['title']}")
+        print_fn(f"  actual: {check['actual']} {check['unit']}")
+        print_fn(f"  required: {check['operator']} {check['required']} {check['unit']}")
+        print_fn(f"  purpose: {check['purpose']}")
+        print_fn(f"  remediation: {check['remediation']}")
+    if failure and failure.get("likely_causes"):
+        print_fn("Likely causes:")
+        for cause in failure["likely_causes"]:
+            print_fn(f"- {cause}")

--- a/vastai/cli/self_test/machine_diagnostics.py
+++ b/vastai/cli/self_test/machine_diagnostics.py
@@ -15,18 +15,17 @@ def safe_float(value):
         return 0.0
 
 
-def gpu_ram_gib(value):
-    """Normalize API GPU RAM values for display.
+def per_gpu_vram_gib(offer):
+    """Return per-GPU VRAM in GiB from canonical offer fields when possible."""
+    gpu_total_ram = safe_float(offer.get("gpu_total_ram"))
+    num_gpus = safe_float(offer.get("num_gpus"))
+    if gpu_total_ram > 0 and num_gpus > 0:
+        return gpu_total_ram / num_gpus / 1024
 
-    Search offer output historically displays `gpu_ram` after dividing by
-    1000, while tests and some call paths use a direct GiB-style value. Treat
-    large values as MiB so host-facing self-test output does not print
-    impossible values such as `32768 GB`.
-    """
-    raw = safe_float(value)
-    if raw > 256:
-        return raw / 1024
-    return raw
+    gpu_ram = safe_float(offer.get("gpu_ram"))
+    if gpu_ram >= 1024:
+        return gpu_ram / 1024
+    return gpu_ram
 
 
 def compact_offer_metadata(offer):
@@ -102,7 +101,7 @@ def _check(
 
 def preflight_requirement_checks(offer):
     gpu_total_ram = safe_float(offer.get("gpu_total_ram"))
-    per_gpu_ram_gib = gpu_ram_gib(offer.get("gpu_ram"))
+    per_gpu_ram_gib = per_gpu_vram_gib(offer)
     required_mbps = required_inet_mbps(gpu_total_ram)
     cpu_ram = safe_float(offer.get("cpu_ram"))
     cpu_cores = int(safe_float(offer.get("cpu_cores")))

--- a/vastai/cli/self_test/runtime_diagnostics.py
+++ b/vastai/cli/self_test/runtime_diagnostics.py
@@ -1,0 +1,430 @@
+"""Runtime diagnostic helpers for CLI self-test machine flows.
+
+The functions in this module are intentionally pure so the CLI can use them for
+raw output shaping without coupling parser/classifier behavior to live Vast API
+calls or the existing self-test orchestration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Iterable
+
+
+INSTANCE_CREATE_FAILED = "instance_create_failed"
+INSTANCE_CREATE_MISSING_CONTRACT = "instance_create_missing_contract"
+INSTANCE_STATUS_ERROR = "instance_status_error"
+INSTANCE_STATUS_POLL_FAILED = "instance_status_poll_failed"
+INSTANCE_START_TIMEOUT = "instance_start_timeout"
+INSTANCE_OFFLINE_BEFORE_TEST = "instance_offline_before_test"
+MISSING_PUBLIC_IP = "missing_public_ip"
+PROGRESS_PORT_NOT_MAPPED = "progress_port_not_mapped"
+PROGRESS_ENDPOINT_UNREACHABLE = "progress_endpoint_unreachable"
+PROGRESS_ENDPOINT_LOST = "progress_endpoint_lost"
+PROGRESS_EMPTY_TIMEOUT = "progress_empty_timeout"
+RUNTIME_TEST_TIMEOUT = "runtime_test_timeout"
+LEGACY_PROGRESS_ERROR = "legacy_progress_error"
+DOCKER_PULL_FAILED = "docker_pull_failed"
+DAEMON_STARTUP_FAILED = "daemon_startup_failed"
+NVML_FAILED = "nvml_failed"
+RESNET_FAILED = "resnet_failed"
+ECC_FAILED = "ecc_failed"
+NCCL_FAILED = "nccl_failed"
+STRESS_GPU_BURN_FAILED = "stress_gpu_burn_failed"
+INTERRUPTED = "interrupted"
+CLEANUP_FAILED = "cleanup_failed"
+
+
+RUNTIME_FAILURE_CODES = (
+    INSTANCE_CREATE_FAILED,
+    INSTANCE_CREATE_MISSING_CONTRACT,
+    INSTANCE_STATUS_ERROR,
+    INSTANCE_STATUS_POLL_FAILED,
+    INSTANCE_START_TIMEOUT,
+    INSTANCE_OFFLINE_BEFORE_TEST,
+    MISSING_PUBLIC_IP,
+    PROGRESS_PORT_NOT_MAPPED,
+    PROGRESS_ENDPOINT_UNREACHABLE,
+    PROGRESS_ENDPOINT_LOST,
+    PROGRESS_EMPTY_TIMEOUT,
+    RUNTIME_TEST_TIMEOUT,
+    LEGACY_PROGRESS_ERROR,
+    DOCKER_PULL_FAILED,
+    DAEMON_STARTUP_FAILED,
+    NVML_FAILED,
+    RESNET_FAILED,
+    ECC_FAILED,
+    NCCL_FAILED,
+    STRESS_GPU_BURN_FAILED,
+    INTERRUPTED,
+    CLEANUP_FAILED,
+)
+
+
+@dataclass(frozen=True)
+class FailureCatalogEntry:
+    code: str
+    summary: str
+    remediation: str
+    suggested_steps: tuple[str, ...]
+
+
+FAILURE_CATALOG: dict[str, FailureCatalogEntry] = {
+    INSTANCE_CREATE_FAILED: FailureCatalogEntry(
+        INSTANCE_CREATE_FAILED,
+        "Failed to create the runtime test instance.",
+        "Check the offer, docker image, and instance creation response.",
+        ("Retry with --debugging enabled.", "Inspect the create-instance API error."),
+    ),
+    INSTANCE_CREATE_MISSING_CONTRACT: FailureCatalogEntry(
+        INSTANCE_CREATE_MISSING_CONTRACT,
+        "Instance creation did not return a new contract id.",
+        "Treat the create response as malformed or incomplete.",
+        ("Inspect the raw create-instance response.", "Retry after confirming the offer is still rentable."),
+    ),
+    INSTANCE_STATUS_ERROR: FailureCatalogEntry(
+        INSTANCE_STATUS_ERROR,
+        "The instance reported an error while starting.",
+        "Inspect the instance status message and host/container logs.",
+        ("Run show instance for the contract.", "Check docker logs on the host if available."),
+    ),
+    INSTANCE_STATUS_POLL_FAILED: FailureCatalogEntry(
+        INSTANCE_STATUS_POLL_FAILED,
+        "Failed to poll instance status.",
+        "Confirm API connectivity and retry the status check.",
+        ("Retry the CLI command.", "Check network/API errors from the status request."),
+    ),
+    INSTANCE_START_TIMEOUT: FailureCatalogEntry(
+        INSTANCE_START_TIMEOUT,
+        "The instance did not reach running state before timeout.",
+        "Check host capacity, docker startup, and network configuration.",
+        ("Inspect instance status_msg.", "Try the test again after confirming the host is healthy."),
+    ),
+    INSTANCE_OFFLINE_BEFORE_TEST: FailureCatalogEntry(
+        INSTANCE_OFFLINE_BEFORE_TEST,
+        "The instance went offline before the runtime test could run.",
+        "Investigate host availability and instance lifecycle events.",
+        ("Check machine status.", "Review host daemon and container logs."),
+    ),
+    MISSING_PUBLIC_IP: FailureCatalogEntry(
+        MISSING_PUBLIC_IP,
+        "The running instance did not expose a public IP address.",
+        "Confirm the instance network configuration and public IP assignment.",
+        ("Inspect show instance output.", "Retry on a machine with public networking available."),
+    ),
+    PROGRESS_PORT_NOT_MAPPED: FailureCatalogEntry(
+        PROGRESS_PORT_NOT_MAPPED,
+        "The runtime progress port was not mapped.",
+        "Confirm port 5000/tcp is exposed and direct ports are available.",
+        ("Check instance port mappings.", "Verify the machine has enough direct ports."),
+    ),
+    PROGRESS_ENDPOINT_UNREACHABLE: FailureCatalogEntry(
+        PROGRESS_ENDPOINT_UNREACHABLE,
+        "The runtime progress endpoint was never reachable.",
+        "Check firewall, direct port mapping, and container startup.",
+        ("Confirm port 5000/tcp is mapped.", "Inspect docker logs for startup failures."),
+    ),
+    PROGRESS_ENDPOINT_LOST: FailureCatalogEntry(
+        PROGRESS_ENDPOINT_LOST,
+        "The runtime progress endpoint became unreachable after connecting.",
+        "Look for container crashes, OOM, GPU errors, or host instability.",
+        ("Inspect docker logs.", "Check dmesg for Xid or GPU reset messages."),
+    ),
+    PROGRESS_EMPTY_TIMEOUT: FailureCatalogEntry(
+        PROGRESS_EMPTY_TIMEOUT,
+        "The progress endpoint returned no new output before timeout.",
+        "Check whether the runtime script stalled or stopped writing progress.",
+        ("Inspect runtime logs.", "Retry with debugging enabled."),
+    ),
+    RUNTIME_TEST_TIMEOUT: FailureCatalogEntry(
+        RUNTIME_TEST_TIMEOUT,
+        "The runtime test did not complete before timeout.",
+        "Investigate long-running or stalled test stages.",
+        ("Check the last reported progress stage.", "Run individual tests to isolate the stall."),
+    ),
+    LEGACY_PROGRESS_ERROR: FailureCatalogEntry(
+        LEGACY_PROGRESS_ERROR,
+        "The legacy runtime progress stream reported an unclassified error.",
+        "Use the raw error text and active stage to decide the next action.",
+        ("Inspect the original ERROR line.", "Retry with debugging enabled if the cause is unclear."),
+    ),
+    DOCKER_PULL_FAILED: FailureCatalogEntry(
+        DOCKER_PULL_FAILED,
+        "The test image could not be pulled.",
+        "Check image name, tag availability, registry access, and credentials.",
+        ("Verify the docker image tag exists.", "Check for registry unauthorized or denied errors."),
+    ),
+    DAEMON_STARTUP_FAILED: FailureCatalogEntry(
+        DAEMON_STARTUP_FAILED,
+        "The container or daemon failed during startup.",
+        "Inspect docker daemon, OCI runtime, and container startup logs.",
+        ("Check docker logs.", "Verify NVIDIA container runtime and host daemon health."),
+    ),
+    NVML_FAILED: FailureCatalogEntry(
+        NVML_FAILED,
+        "NVML or nvidia-smi failed during system checks.",
+        "Check NVIDIA driver, NVML, and GPU visibility on the host.",
+        ("Run nvidia-smi on the host.", "Check driver/library mismatch or GPU reset errors."),
+    ),
+    RESNET_FAILED: FailureCatalogEntry(
+        RESNET_FAILED,
+        "The ResNet runtime test failed.",
+        "Check PyTorch/CUDA health, available VRAM, and GPU compute stability.",
+        ("Look for CUDA OOM, cuDNN, or torch runtime errors.", "Run a smaller isolated torch workload."),
+    ),
+    ECC_FAILED: FailureCatalogEntry(
+        ECC_FAILED,
+        "The ECC runtime test failed.",
+        "Check GPU ECC counters and hardware health.",
+        ("Inspect ECC error counters.", "Review dmesg and nvidia-smi health output."),
+    ),
+    NCCL_FAILED: FailureCatalogEntry(
+        NCCL_FAILED,
+        "The NCCL distributed runtime test failed.",
+        "Check multi-GPU connectivity, NCCL transport, and network fabric.",
+        ("Inspect NCCL error output.", "Verify peer-to-peer and multi-GPU communication."),
+    ),
+    STRESS_GPU_BURN_FAILED: FailureCatalogEntry(
+        STRESS_GPU_BURN_FAILED,
+        "The stress-ng or gpu-burn runtime test failed.",
+        "Check thermals, power stability, GPU Xid errors, and host stress logs.",
+        ("Inspect dmesg for Xid errors.", "Review gpu-burn and stress-ng output."),
+    ),
+    INTERRUPTED: FailureCatalogEntry(
+        INTERRUPTED,
+        "The runtime test was interrupted.",
+        "Ensure cleanup completed or destroy the test instance manually.",
+        ("Check whether the test instance still exists.", "Destroy leaked instances if needed."),
+    ),
+    CLEANUP_FAILED: FailureCatalogEntry(
+        CLEANUP_FAILED,
+        "Runtime test cleanup failed.",
+        "Destroy the temporary test instance manually to avoid continued billing.",
+        ("Run destroy instance for the temporary contract.", "Retry cleanup after checking API connectivity."),
+    ),
+}
+
+
+STAGE_SYSTEM_REQUIREMENTS = "system_requirements"
+STAGE_RESNET = "resnet"
+STAGE_ECC = "ecc"
+STAGE_NCCL = "nccl"
+STAGE_STRESS_GPU_BURN = "stress_gpu_burn"
+STAGE_STARTUP = "startup"
+
+
+_STAGE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^\s*Running system requirements test\.\.\.\s*$", re.IGNORECASE), STAGE_SYSTEM_REQUIREMENTS),
+    (re.compile(r"^\s*Running ResNet50/ResNet18 test\.\.\.\s*$", re.IGNORECASE), STAGE_RESNET),
+    (re.compile(r"^\s*Running ECC test\.\.\.\s*$", re.IGNORECASE), STAGE_ECC),
+    (re.compile(r"^\s*Running NCCL distributed test\.\.\.\s*$", re.IGNORECASE), STAGE_NCCL),
+    (re.compile(r"^\s*Running stress-ng and gpu-burn\.\.\.\s*$", re.IGNORECASE), STAGE_STRESS_GPU_BURN),
+)
+
+_NVML_RE = re.compile(
+    r"nvml|nvidia-smi|driver/library version mismatch|failed to initialize.*nvidia",
+    re.IGNORECASE,
+)
+_RESNET_RE = re.compile(
+    r"resnet|torch|pytorch|cuda out of memory|outofmemory|cudnn|cublas|cuda error|runtimeerror",
+    re.IGNORECASE,
+)
+_ECC_RE = re.compile(r"\becc\b|volatile double bit|aggregate single bit", re.IGNORECASE)
+_NCCL_RE = re.compile(r"\bnccl\b|unhandled system error|connection timed out|allreduce|peer access", re.IGNORECASE)
+_STRESS_RE = re.compile(r"stress-ng|gpu-burn|xid|thermal|power limit|burn-in|hardware error", re.IGNORECASE)
+
+_DOCKER_PULL_RE = re.compile(
+    r"pull|manifest|not found|unauthorized|denied|repository does not exist|no such image|"
+    r"pull access denied|requested access to the resource is denied",
+    re.IGNORECASE,
+)
+_STARTUP_RE = re.compile(
+    r"daemon|container|startup|start container|failed to start|oci runtime|runc|nvidia-container|"
+    r"docker|exited|exec format error|permission denied|mount|entrypoint",
+    re.IGNORECASE,
+)
+
+
+def failure_catalog() -> dict[str, dict[str, object]]:
+    """Return a JSON-serializable copy of the runtime failure catalog."""
+    return {
+        code: {
+            "code": entry.code,
+            "summary": entry.summary,
+            "remediation": entry.remediation,
+            "suggested_steps": list(entry.suggested_steps),
+        }
+        for code, entry in FAILURE_CATALOG.items()
+    }
+
+
+def get_failure_entry(code: str) -> FailureCatalogEntry:
+    """Return the catalog entry for a stable runtime failure code."""
+    try:
+        return FAILURE_CATALOG[code]
+    except KeyError as exc:
+        raise ValueError(f"Unknown runtime failure code: {code}") from exc
+
+
+def make_failure(
+    code: str,
+    *,
+    stage: str | None = None,
+    summary: str | None = None,
+    details: str | None = None,
+    error: str | None = None,
+    remediation: str | None = None,
+    suggested_steps: Iterable[str] | None = None,
+    underlying_error: str | None = None,
+) -> dict[str, object]:
+    """Build a raw-output-friendly diagnostic dictionary."""
+    entry = get_failure_entry(code)
+    diagnostic: dict[str, object] = {
+        "code": code,
+        "stage": stage,
+        "summary": summary or entry.summary,
+        "remediation": remediation or entry.remediation,
+        "suggested_steps": list(suggested_steps) if suggested_steps is not None else list(entry.suggested_steps),
+    }
+    if details:
+        diagnostic["details"] = details
+    if error:
+        diagnostic["error"] = error
+    if underlying_error:
+        diagnostic["underlying_error"] = underlying_error
+    return diagnostic
+
+
+def stage_from_progress_line(line: str) -> str | None:
+    """Return the legacy runtime stage introduced by a progress line."""
+    for pattern, stage in _STAGE_PATTERNS:
+        if pattern.search(line):
+            return stage
+    return None
+
+
+def classify_legacy_error_line(line: str, stage: str | None = None) -> dict[str, object]:
+    """Classify a legacy progress ``ERROR`` line into a runtime diagnostic."""
+    stripped = line.strip()
+    lowered_stage = stage.lower() if stage else None
+
+    code = LEGACY_PROGRESS_ERROR
+    if _NVML_RE.search(stripped):
+        code = NVML_FAILED
+    elif _NCCL_RE.search(stripped) or lowered_stage == STAGE_NCCL:
+        code = NCCL_FAILED
+    elif _ECC_RE.search(stripped) or lowered_stage == STAGE_ECC:
+        code = ECC_FAILED
+    elif _STRESS_RE.search(stripped) or lowered_stage == STAGE_STRESS_GPU_BURN:
+        code = STRESS_GPU_BURN_FAILED
+    elif _RESNET_RE.search(stripped) or lowered_stage == STAGE_RESNET:
+        code = RESNET_FAILED
+
+    return make_failure(
+        code,
+        stage=stage,
+        error=stripped,
+        details=f"Legacy progress stream reported: {stripped}",
+        underlying_error=stripped,
+    )
+
+
+class LegacyProgressParser:
+    """Stateful parser for the legacy runtime progress text stream."""
+
+    def __init__(self) -> None:
+        self.stage: str | None = None
+
+    def process_line(self, line: str) -> dict[str, object] | None:
+        """Update parser state and return a diagnostic for ``ERROR`` lines."""
+        stage = stage_from_progress_line(line)
+        if stage:
+            self.stage = stage
+            return None
+
+        if line.strip().upper().startswith("ERROR"):
+            return classify_legacy_error_line(line, self.stage)
+
+        return None
+
+    def parse(self, text: str) -> list[dict[str, object]]:
+        """Parse progress text and return diagnostics for any ``ERROR`` lines."""
+        diagnostics: list[dict[str, object]] = []
+        for line in text.splitlines():
+            diagnostic = self.process_line(line)
+            if diagnostic is not None:
+                diagnostics.append(diagnostic)
+        return diagnostics
+
+
+def parse_legacy_progress(text: str) -> list[dict[str, object]]:
+    """Parse a legacy progress payload with a fresh parser instance."""
+    return LegacyProgressParser().parse(text)
+
+
+def classify_status_msg(status_msg: str | None) -> dict[str, object] | None:
+    """Classify startup/status messages reported while the instance starts."""
+    if not status_msg:
+        return None
+
+    msg = status_msg.strip()
+    if not msg:
+        return None
+
+    code = INSTANCE_STATUS_ERROR
+    if _DOCKER_PULL_RE.search(msg):
+        code = DOCKER_PULL_FAILED
+    elif _STARTUP_RE.search(msg):
+        code = DAEMON_STARTUP_FAILED
+
+    return make_failure(
+        code,
+        stage=STAGE_STARTUP,
+        error=msg,
+        details=f"Instance status message reported: {msg}",
+        underlying_error=msg,
+    )
+
+
+__all__ = [
+    "CLEANUP_FAILED",
+    "DAEMON_STARTUP_FAILED",
+    "DOCKER_PULL_FAILED",
+    "ECC_FAILED",
+    "FAILURE_CATALOG",
+    "FailureCatalogEntry",
+    "INSTANCE_CREATE_FAILED",
+    "INSTANCE_CREATE_MISSING_CONTRACT",
+    "INSTANCE_OFFLINE_BEFORE_TEST",
+    "INSTANCE_START_TIMEOUT",
+    "INSTANCE_STATUS_ERROR",
+    "INSTANCE_STATUS_POLL_FAILED",
+    "INTERRUPTED",
+    "LEGACY_PROGRESS_ERROR",
+    "LegacyProgressParser",
+    "MISSING_PUBLIC_IP",
+    "NCCL_FAILED",
+    "NVML_FAILED",
+    "PROGRESS_EMPTY_TIMEOUT",
+    "PROGRESS_ENDPOINT_LOST",
+    "PROGRESS_ENDPOINT_UNREACHABLE",
+    "PROGRESS_PORT_NOT_MAPPED",
+    "RESNET_FAILED",
+    "RUNTIME_FAILURE_CODES",
+    "RUNTIME_TEST_TIMEOUT",
+    "STAGE_ECC",
+    "STAGE_NCCL",
+    "STAGE_RESNET",
+    "STAGE_STARTUP",
+    "STAGE_STRESS_GPU_BURN",
+    "STAGE_SYSTEM_REQUIREMENTS",
+    "STRESS_GPU_BURN_FAILED",
+    "classify_legacy_error_line",
+    "classify_status_msg",
+    "failure_catalog",
+    "get_failure_entry",
+    "make_failure",
+    "parse_legacy_progress",
+    "stage_from_progress_line",
+]


### PR DESCRIPTION
## Summary

This draft implements the CLI-side CON-1510 self-test diagnostics work:

- add structured preflight diagnostics with actual values, thresholds, purpose, and remediation;
- render preflight failures once instead of duplicating the block;
- replace stale/literal remediation commands with current `search offers` syntax;
- preserve `--raw` compatibility while adding `diagnostics_version`, `checks`, `failure`, `failure_code`, `stage`, `error`, and offer metadata;
- reuse one selected offer for preflight and rental;
- add `--test-image` and `VAST_SELF_TEST_IMAGE` so rebuilt self-test images can be dogfooded before official tags are changed;
- add runtime failure codes and a legacy progress text parser for current images;
- classify create/start/progress/daemon failures with host-visible underlying errors and remediation;
- redact API keys from host-visible exception output;
- avoid the unnecessary Jupyter runtime path for self-test instances by launching with `ssh_direc ssh_proxy`.

This branch currently includes the deleted/missing-instance cleanup handling from PR #405 because CON-1510 cleanup diagnostics rely on the same behavior. Happy to rebase once #405 lands.

## Validation

Focused tests:

```text
uv run --with pytest --with pycryptodome python -m pytest tests/cli/test_machines_commands.py tests/cli/test_runtime_diagnostics.py tests/cli/test_instances_commands.py tests/sdk/test_sdk.py -q
110 passed, 1 warning
```

Earlier broader focused run after integration:

```text
160 passed, 1 warning
```

No-rent/preflight live validation:

- `vastai --raw self-test machine 0`: structured `no_offer`, no rental.
- `vastai --raw self-test machine 54894`: direct ports, download, and upload failures show actual values, thresholds, purpose, and remediation; no rental.
- `vastai --raw self-test machine 16689`: GPU RAM failure shows `5.99 GiB`, required `> 7 GiB`; no rental.
- `vastai --raw self-test machine 68277`: PCIe/system RAM/CPU failures show actual values and thresholds; no rental.

Paid runtime red validation:

- Machine `19028`, dogfood image `jjziets/vast-self-test:con1510-cuda-13.0-amd64`, instance `38084614`: failed before runtime start with OCI/CDI GPU injection error; destroyed.
- Machine `23973`, same dogfood image, instance `38085349`: reproduced OCI/CDI startup failure; destroyed.
- Machine `19028`, official image `vastai/test:self-test-cuda-13.0`, instance `38094685`: reproduced the same OCI/CDI failure and the CLI classified it as `daemon_startup_failed`; destroyed.

Paid green validation with structured self-test image:

- Machine `55752`, instance `38090857`: strict one-GPU pass; `/summary.json` confirmed `gpu_count: 1`; all stages passed; destroyed.
- Machine `46001`, instance `38092686`: strict one-GPU pass after removing `jupyter_direc`; instance used `/ssh`, `5000/tcp` stayed mapped, `/summary.json` confirmed `gpu_count: 1`; all stages passed; destroyed.
- Machine `21044`, instance `38089696`: all stages passed, but selected a 2-GPU offer from the machine despite starting from a 1-GPU candidate search. This exposed the existing machine-level offer-selection caveat.

Every paid run ended with a final `show instances` audit returning zero active instances.

## Related Work

- `vast-ai/self-test#1` restores the missing self-test runtime source files (`remote.py`, `remote.sh`) and validates the current published image family.
- P3 structured image progress is implemented on `jjziets/self-test`, branch `CON-1510-structured-self-test-progress`, and was dogfooded via `jjziets/vast-self-test:con1510-cuda-13.0-amd64`.
- P4 docs/UI extraction is intentionally deferred until the diagnostic schema stabilizes.
