### PR TITLE
CON-1514: Disambiguate self-test common failures

### DIFF
--- a/tests/cli/test_machines_commands.py
+++ b/tests/cli/test_machines_commands.py
@@ -940,6 +940,7 @@ class TestSelfTestMachineDiagnostics:
         endpoint = result["diagnostics"]["progress_endpoint"]
         assert result["failure_code"] == "progress_port_not_mapped"
         assert endpoint["container_port"] == "5000/tcp"
+        assert endpoint["external_port"] is None
         assert endpoint["host_port"] is None
         assert endpoint["mapped_ports"] == ["22/tcp"]
         assert result["diagnostics"]["runtime_failure"]["progress_endpoint"] == endpoint
@@ -984,6 +985,7 @@ class TestSelfTestMachineDiagnostics:
         assert result["failure_code"] == "progress_endpoint_unreachable"
         assert endpoint["url"] == "https://127.0.0.1:45000/progress"
         assert endpoint["public_ip"] == "127.0.0.1"
+        assert endpoint["external_port"] == "45000"
         assert endpoint["host_port"] == "45000"
         assert endpoint["attempt_count"] >= 6
         assert endpoint["first_connection_established"] is False
@@ -993,6 +995,50 @@ class TestSelfTestMachineDiagnostics:
         assert endpoint["mapped_ports"] == ["22/tcp", "5000/tcp"]
         assert result["diagnostics"]["runtime_failure"]["progress_endpoint"] == endpoint
         assert destroy.call_count >= 1
+
+    def test_progress_endpoint_failure_prints_external_port(
+        self, parse_argv, patch_get_client, monkeypatch, capsys
+    ):
+        offer = _self_test_offer()
+        running_instance = {
+            "id": 123,
+            "actual_status": "running",
+            "intended_status": "running",
+            "public_ipaddr": "127.0.0.1",
+            "ports": {"5000/tcp": [{"HostPort": "45000"}], "22/tcp": [{"HostPort": "40022"}]},
+            "status_msg": "",
+        }
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.offers_api.search_offers",
+            Mock(return_value=[offer]),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.create_instance",
+            Mock(return_value={"new_contract": 123}),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.show_instance",
+            Mock(return_value=running_instance),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.destroy_instance",
+            Mock(return_value={"success": True}),
+        )
+        monkeypatch.setattr("vastai.cli.commands.machines.time.sleep", lambda *_: None)
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.requests.get",
+            Mock(side_effect=requests.exceptions.ConnectTimeout("timed out")),
+        )
+
+        args = parse_argv(["self-test", "machine", "42"])
+        with pytest.raises(SystemExit) as exc_info:
+            args.func(args)
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code == 1
+        assert "External port tested: 45000" in captured.out
+        assert "- external port tested: 45000" in captured.out
+        assert "- mapped container ports: 22/tcp, 5000/tcp" in captured.out
 
     def test_progress_endpoint_lost_after_success_records_different_failure(
         self, parse_argv, patch_get_client, monkeypatch

--- a/tests/cli/test_machines_commands.py
+++ b/tests/cli/test_machines_commands.py
@@ -336,6 +336,31 @@ class TestSelfTestMachineDiagnostics:
         assert result["failure"]["root_state"] == "api_permission_failed"
         assert result["diagnostics"]["offer_search"]["machine_lookup"]["status_code"] == 403
 
+    def test_machine_lookup_transport_error_is_recorded_without_aborting(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        search = Mock(side_effect=[[], []])
+        monkeypatch.setattr("vastai.cli.commands.machines.offers_api.search_offers", search)
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.machines_api.show_machine",
+            Mock(
+                side_effect=requests.exceptions.Timeout(
+                    "timeout for url: https://console.vast.ai/api/v0/machines/42/?api_key=secret"
+                )
+            ),
+        )
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        lookup = result["diagnostics"]["offer_search"]["machine_lookup"]
+        assert result["failure_code"] == "no_offer"
+        assert result["failure"]["root_state"] == "offline_or_not_listed"
+        assert lookup["status"] == "lookup_error"
+        assert lookup["status_code"] is None
+        assert "api_key=REDACTED" in lookup["error"]
+        assert "api_key=secret" not in str(result)
+
     def test_no_rentable_offer_reports_currently_rented_state(
         self, parse_argv, patch_get_client, monkeypatch
     ):
@@ -533,6 +558,29 @@ class TestSelfTestMachineDiagnostics:
         assert "64 ports per listed GPU" in advisory["purpose"]
         assert advisory not in failed_checks(checks)
 
+    def test_preflight_direct_port_minimum_scales_by_gpu_count(self):
+        from vastai.cli.self_test.machine_diagnostics import preflight_requirement_checks
+
+        offer = _self_test_offer(
+            num_gpus=8,
+            gpu_ram=24 * 1024,
+            gpu_total_ram=8 * 24 * 1024,
+            cpu_ram=256 * 1024,
+            cpu_cores=32,
+            direct_port_count=20,
+            inet_down=600,
+            inet_up=600,
+        )
+
+        checks = preflight_requirement_checks(offer)
+        direct_ports = next(check for check in checks if check["id"] == "network.direct_ports")
+
+        assert direct_ports["status"] == "fail"
+        assert direct_ports["actual"] == 20
+        assert direct_ports["required"] == 24
+        assert direct_ports["operator"] == ">="
+        assert "3 directly mapped ports per listed GPU" in direct_ports["purpose"]
+
     def test_preflight_direct_port_overage_renders_advisory(
         self, parse_argv, patch_get_client, monkeypatch, capsys
     ):
@@ -724,6 +772,8 @@ class TestSelfTestMachineDiagnostics:
         assert result["diagnostics"]["image"]["override"] is False
         assert create.call_args.kwargs["image"] == "vastai/test:self-test-v2-cuda-12.8"
         assert create.call_args.kwargs["runtype"] == "ssh_direc ssh_proxy"
+        assert create.call_args.kwargs["label"] == "vast-self-test-machine-42"
+        assert result["diagnostics"]["launch"]["label"] == "vast-self-test-machine-42"
 
     def test_cuda_mapping_selects_cuda_133_exact_match(
         self, parse_argv, patch_get_client, monkeypatch

--- a/tests/cli/test_machines_commands.py
+++ b/tests/cli/test_machines_commands.py
@@ -236,6 +236,15 @@ def _self_test_offer(**overrides):
     return offer
 
 
+def _http_error(status_code, message=None):
+    response = Mock(status_code=status_code)
+    error = requests.exceptions.HTTPError(
+        message or f"{status_code} Client Error for url: https://console.vast.ai/api/v0/bundles/?api_key=secret"
+    )
+    error.response = response
+    return error
+
+
 def _run_self_test_until_create(parse_argv, monkeypatch, offer):
     monkeypatch.delenv("VAST_SELF_TEST_IMAGE", raising=False)
     monkeypatch.setattr(
@@ -269,7 +278,101 @@ class TestSelfTestMachineDiagnostics:
         assert result["machine_id"] == "42"
         assert result["checks"][0]["id"] == "offer.available"
         assert result["failure"]["likely_causes"]
+        assert result["failure"]["root_state"] == "offline_or_not_listed"
+        assert result["failure"]["confidence"] == "low"
         assert search.call_count == 2
+
+    def test_no_offer_with_visible_machine_reports_zero_active_offers(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        search = Mock(side_effect=[[], []])
+        monkeypatch.setattr("vastai.cli.commands.machines.offers_api.search_offers", search)
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.machines_api.show_machine",
+            Mock(return_value=[{"id": 42, "hostname": "host-42"}]),
+        )
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        assert result["failure_code"] == "no_offer"
+        assert result["failure"]["root_state"] == "zero_active_offers"
+        assert result["failure"]["confidence"] == "medium"
+        assert "Machine lookup returned a visible machine record." in result["failure"]["evidence"]
+        assert result["diagnostics"]["offer_search"]["machine_lookup"]["row_count"] == 1
+
+    def test_offer_search_permission_error_reports_api_permission_failed(
+        self, parse_argv, patch_get_client, monkeypatch, capsys
+    ):
+        search = Mock(side_effect=_http_error(401))
+        monkeypatch.setattr("vastai.cli.commands.machines.offers_api.search_offers", search)
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert result["failure_code"] == "api_permission_failed"
+        assert result["failure"]["root_state"] == "api_permission_failed"
+        assert result["failure"]["confidence"] == "high"
+        assert result["diagnostics"]["offer_search"]["search_error"]["status_code"] == 401
+        assert "api_key=secret" not in str(result)
+        assert search.call_count == 1
+
+    def test_machine_lookup_permission_error_reports_api_permission_failed(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        search = Mock(side_effect=[[], []])
+        monkeypatch.setattr("vastai.cli.commands.machines.offers_api.search_offers", search)
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.machines_api.show_machine",
+            Mock(side_effect=_http_error(403)),
+        )
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        assert result["failure_code"] == "api_permission_failed"
+        assert result["failure"]["root_state"] == "api_permission_failed"
+        assert result["diagnostics"]["offer_search"]["machine_lookup"]["status_code"] == 403
+
+    def test_no_rentable_offer_reports_currently_rented_state(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        broader_offer = _self_test_offer(rentable=False, rented=True)
+        search = Mock(side_effect=[[], [broader_offer]])
+        monkeypatch.setattr("vastai.cli.commands.machines.offers_api.search_offers", search)
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        assert result["failure_code"] == "no_rentable_offer"
+        assert result["failure"]["root_state"] == "currently_rented"
+        assert result["failure"]["confidence"] == "medium"
+        assert any("rented=true" in item for item in result["failure"]["evidence"])
+
+    def test_no_rentable_offer_reports_deverified_or_below_threshold(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        broader_offer = _self_test_offer(
+            rentable=False,
+            rented=False,
+            reliability=0.89,
+            vericode=8,
+            verified=False,
+            error_description="direct port verification failed",
+        )
+        search = Mock(side_effect=[[], [broader_offer]])
+        monkeypatch.setattr("vastai.cli.commands.machines.offers_api.search_offers", search)
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        assert result["failure_code"] == "no_rentable_offer"
+        assert result["failure"]["root_state"] == "deverified_or_below_threshold"
+        assert result["diagnostics"]["offer_search"]["broader_offers"][0]["vericode"] == 8
+        assert result["diagnostics"]["offer_search"]["broader_offers"][0]["verified"] is False
+        assert any("vericode=8" in item for item in result["failure"]["evidence"])
 
     def test_no_offer_non_raw_renders_once_without_stale_placeholders(
         self, parse_argv, patch_get_client, monkeypatch, capsys
@@ -288,6 +391,8 @@ class TestSelfTestMachineDiagnostics:
         assert "actual: 0 offers" in captured.out
         assert "required: >= 1 offers" in captured.out
         assert "vastai search offers 'machine_id=42 rentable=any rented=any'" in captured.out
+        assert "Root state: currently_rented" in captured.out
+        assert "Suggested steps:" in captured.out
         assert "{machine_id}" not in captured.out
         assert "--filter" not in captured.out
 
@@ -394,6 +499,116 @@ class TestSelfTestMachineDiagnostics:
         assert gpu_ram_check["status"] == "pass"
         assert gpu_ram_check["actual"] == 80
 
+    def test_preflight_direct_port_overage_is_advisory_not_gate(self):
+        from vastai.cli.self_test.machine_diagnostics import (
+            failed_checks,
+            informational_checks,
+            preflight_requirement_checks,
+        )
+
+        offer = _self_test_offer(
+            num_gpus=8,
+            gpu_ram=24 * 1024,
+            gpu_total_ram=8 * 24 * 1024,
+            cpu_ram=256 * 1024,
+            cpu_cores=32,
+            direct_port_count=1000,
+            inet_down=600,
+            inet_up=600,
+        )
+
+        checks = preflight_requirement_checks(offer)
+        direct_ports = next(check for check in checks if check["id"] == "network.direct_ports")
+        advisory = next(
+            check
+            for check in informational_checks(checks)
+            if check["id"] == "network.direct_ports.recommended_max"
+        )
+
+        assert direct_ports["status"] == "pass"
+        assert advisory["status"] == "info"
+        assert advisory["actual"] == 1000
+        assert advisory["required"] == 512
+        assert advisory["operator"] == "<="
+        assert "64 ports per listed GPU" in advisory["purpose"]
+        assert advisory not in failed_checks(checks)
+
+    def test_preflight_direct_port_overage_renders_advisory(
+        self, parse_argv, patch_get_client, monkeypatch, capsys
+    ):
+        offer = _self_test_offer(
+            num_gpus=8,
+            gpu_ram=24 * 1024,
+            gpu_total_ram=8 * 24 * 1024,
+            cpu_ram=256 * 1024,
+            cpu_cores=32,
+            direct_port_count=1000,
+            inet_down=600,
+            inet_up=600,
+            reliability=0.9,
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.offers_api.search_offers",
+            Mock(return_value=[offer]),
+        )
+
+        args = parse_argv(["self-test", "machine", "42"])
+        with pytest.raises(SystemExit) as exc_info:
+            args.func(args)
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code == 1
+        assert "Preflight advisory for machine 42:" in captured.out
+        assert "Direct port count advisory" in captured.out
+        assert "actual: 1000.0 ports" in captured.out
+        assert "recommended: <= 512 ports" in captured.out
+        assert "This is advisory only, not a self-test gate." in captured.out
+
+    def test_preflight_caps_system_ram_requirement_for_huge_vram_hosts(self):
+        from vastai.cli.self_test.machine_diagnostics import preflight_requirement_checks
+
+        offer = _self_test_offer(
+            gpu_name="B300 SXM6 AC",
+            num_gpus=8,
+            gpu_ram=275040,
+            gpu_total_ram=2200320,
+            cpu_ram=2063831,
+            cpu_cores=192,
+            direct_port_count=998,
+            inet_down=600,
+            inet_up=600,
+        )
+
+        checks = preflight_requirement_checks(offer)
+        system_ram = next(check for check in checks if check["id"] == "system.ram")
+
+        assert system_ram["status"] == "pass"
+        assert system_ram["actual"] == 2063831
+        assert system_ram["required"] == 2000000
+        assert "2 TB" in system_ram["purpose"]
+
+    def test_preflight_system_ram_cap_still_fails_below_two_tb(self):
+        from vastai.cli.self_test.machine_diagnostics import preflight_requirement_checks
+
+        offer = _self_test_offer(
+            gpu_name="B300 SXM6 AC",
+            num_gpus=8,
+            gpu_ram=275040,
+            gpu_total_ram=2200320,
+            cpu_ram=1900000,
+            cpu_cores=192,
+            direct_port_count=998,
+            inet_down=600,
+            inet_up=600,
+        )
+
+        checks = preflight_requirement_checks(offer)
+        system_ram = next(check for check in checks if check["id"] == "system.ram")
+
+        assert system_ram["status"] == "fail"
+        assert system_ram["actual"] == 1900000
+        assert system_ram["required"] == 2000000
+
     def test_ignore_requirements_includes_failed_checks_and_continues(
         self, parse_argv, patch_get_client, monkeypatch, capsys
     ):
@@ -414,6 +629,54 @@ class TestSelfTestMachineDiagnostics:
         assert "does not qualify this machine for verification" in captured.out
         create.assert_called_once()
         assert search.call_count == 1
+
+    def test_ignore_requirements_runtime_success_preserves_preflight_as_metadata(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        from vastai.cli.commands import machines
+
+        bad_offer = _self_test_offer(gpu_ram=6 * 1024, gpu_total_ram=6 * 1024, inet_up=98)
+        running_instance = {
+            "id": 123,
+            "actual_status": "running",
+            "intended_status": "running",
+            "public_ipaddr": "127.0.0.1",
+            "ports": {"5000/tcp": [{"HostPort": "5000"}]},
+            "status_msg": "",
+        }
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.offers_api.search_offers",
+            Mock(return_value=[bad_offer]),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.create_instance",
+            Mock(return_value={"new_contract": 123}),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.show_instance",
+            Mock(side_effect=[running_instance, running_instance, None]),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.destroy_instance",
+            Mock(return_value={"success": True}),
+        )
+        monkeypatch.setattr(machines.requests, "get", lambda *_, **__: SimpleNamespace(status_code=200, text="DONE"))
+        monkeypatch.setattr(machines.time, "sleep", lambda *_: None)
+
+        args = parse_argv(["self-test", "machine", "42", "--ignore-requirements", "--raw"])
+        result = args.func(args)
+
+        assert result["success"] is True
+        assert result["failure_code"] is None
+        assert result["failure"] is None
+        assert result["warning"]
+        assert result["diagnostics"]["requirements_ignored"] is True
+        assert result["diagnostics"]["preflight_failure"]["code"] == "preflight_requirements_failed"
+        assert result["diagnostics"].get("runtime_failure") is None
+        assert {check["id"] for check in result["checks"] if check["status"] == "fail"} == {
+            "network.upload",
+            "gpu.ram",
+        }
 
     def test_test_image_option_overrides_default_mapping(
         self, parse_argv, patch_get_client, monkeypatch
@@ -642,3 +905,228 @@ class TestSelfTestMachineDiagnostics:
         assert exc_info.value.code == 1
         assert "api_key=secret" not in captured.out
         assert "api_key=REDACTED" in captured.out
+
+    def test_missing_progress_port_reports_available_ports(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        offer = _self_test_offer()
+        running_instance = {
+            "id": 123,
+            "actual_status": "running",
+            "intended_status": "running",
+            "public_ipaddr": "127.0.0.1",
+            "ports": {"22/tcp": [{"HostPort": "40022"}]},
+            "status_msg": "",
+        }
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.offers_api.search_offers",
+            Mock(return_value=[offer]),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.create_instance",
+            Mock(return_value={"new_contract": 123}),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.show_instance",
+            Mock(return_value=running_instance),
+        )
+        destroy = Mock(return_value={"success": True})
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.destroy_instance", destroy)
+        monkeypatch.setattr("vastai.cli.commands.machines.time.sleep", lambda *_: None)
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        endpoint = result["diagnostics"]["progress_endpoint"]
+        assert result["failure_code"] == "progress_port_not_mapped"
+        assert endpoint["container_port"] == "5000/tcp"
+        assert endpoint["host_port"] is None
+        assert endpoint["mapped_ports"] == ["22/tcp"]
+        assert result["diagnostics"]["runtime_failure"]["progress_endpoint"] == endpoint
+        assert destroy.call_count >= 1
+
+    def test_progress_endpoint_never_reachable_records_endpoint_diagnostic(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        offer = _self_test_offer()
+        running_instance = {
+            "id": 123,
+            "actual_status": "running",
+            "intended_status": "running",
+            "public_ipaddr": "127.0.0.1",
+            "ports": {"5000/tcp": [{"HostPort": "45000"}], "22/tcp": [{"HostPort": "40022"}]},
+            "status_msg": "",
+        }
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.offers_api.search_offers",
+            Mock(return_value=[offer]),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.create_instance",
+            Mock(return_value={"new_contract": 123}),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.show_instance",
+            Mock(return_value=running_instance),
+        )
+        destroy = Mock(return_value={"success": True})
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.destroy_instance", destroy)
+        monkeypatch.setattr("vastai.cli.commands.machines.time.sleep", lambda *_: None)
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.requests.get",
+            Mock(side_effect=requests.exceptions.ConnectTimeout("timed out for ?api_key=secret")),
+        )
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        endpoint = result["diagnostics"]["progress_endpoint"]
+        assert result["failure_code"] == "progress_endpoint_unreachable"
+        assert endpoint["url"] == "https://127.0.0.1:45000/progress"
+        assert endpoint["public_ip"] == "127.0.0.1"
+        assert endpoint["host_port"] == "45000"
+        assert endpoint["attempt_count"] >= 6
+        assert endpoint["first_connection_established"] is False
+        assert endpoint["last_error_type"] == "ConnectTimeout"
+        assert "api_key=secret" not in endpoint["last_error"]
+        assert "api_key=REDACTED" in endpoint["last_error"]
+        assert endpoint["mapped_ports"] == ["22/tcp", "5000/tcp"]
+        assert result["diagnostics"]["runtime_failure"]["progress_endpoint"] == endpoint
+        assert destroy.call_count >= 1
+
+    def test_progress_endpoint_lost_after_success_records_different_failure(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        offer = _self_test_offer()
+        running_instance = {
+            "id": 123,
+            "actual_status": "running",
+            "intended_status": "running",
+            "public_ipaddr": "127.0.0.1",
+            "ports": {"5000/tcp": [{"HostPort": "45000"}]},
+            "status_msg": "",
+        }
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.offers_api.search_offers",
+            Mock(return_value=[offer]),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.create_instance",
+            Mock(return_value={"new_contract": 123}),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.show_instance",
+            Mock(return_value=running_instance),
+        )
+        destroy = Mock(return_value={"success": True})
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.destroy_instance", destroy)
+        monkeypatch.setattr("vastai.cli.commands.machines.time.sleep", lambda *_: None)
+        get = Mock(
+            side_effect=[
+                SimpleNamespace(status_code=200, text="Starting tests..."),
+                requests.exceptions.ConnectionError("connection refused"),
+                requests.exceptions.ConnectionError("connection refused"),
+                requests.exceptions.ConnectionError("connection refused"),
+                requests.exceptions.ConnectionError("connection refused"),
+                requests.exceptions.ConnectionError("connection refused"),
+                requests.exceptions.ConnectionError("connection refused"),
+            ]
+        )
+        monkeypatch.setattr("vastai.cli.commands.machines.requests.get", get)
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        endpoint = result["diagnostics"]["progress_endpoint"]
+        assert result["failure_code"] == "progress_endpoint_lost"
+        assert endpoint["first_connection_established"] is True
+        assert endpoint["last_error_type"] == "ConnectionError"
+        assert endpoint["attempt_count"] >= 7
+        assert result["diagnostics"]["runtime_failure"]["progress_endpoint"] == endpoint
+        assert destroy.call_count >= 1
+
+    def test_progress_endpoint_http_non_200_records_status_code(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        offer = _self_test_offer()
+        running_instance = {
+            "id": 123,
+            "actual_status": "running",
+            "intended_status": "running",
+            "public_ipaddr": "127.0.0.1",
+            "ports": {"5000/tcp": [{"HostPort": "45000"}]},
+            "status_msg": "",
+        }
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.offers_api.search_offers",
+            Mock(return_value=[offer]),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.create_instance",
+            Mock(return_value={"new_contract": 123}),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.show_instance",
+            Mock(return_value=running_instance),
+        )
+        destroy = Mock(return_value={"success": True})
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.destroy_instance", destroy)
+        monkeypatch.setattr("vastai.cli.commands.machines.time.sleep", lambda *_: None)
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.requests.get",
+            Mock(return_value=SimpleNamespace(status_code=500, text="server error")),
+        )
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        endpoint = result["diagnostics"]["progress_endpoint"]
+        assert result["failure_code"] == "progress_endpoint_unreachable"
+        assert endpoint["last_status_code"] == 500
+        assert endpoint["last_error_type"] == "HTTPStatus"
+        assert endpoint["last_error"] == "HTTP 500 from progress endpoint"
+        assert result["diagnostics"]["runtime_failure"]["progress_endpoint"] == endpoint
+        assert destroy.call_count >= 1
+
+    def test_progress_endpoint_empty_200_records_empty_timeout(
+        self, parse_argv, patch_get_client, monkeypatch
+    ):
+        offer = _self_test_offer()
+        running_instance = {
+            "id": 123,
+            "actual_status": "running",
+            "intended_status": "running",
+            "public_ipaddr": "127.0.0.1",
+            "ports": {"5000/tcp": [{"HostPort": "45000"}]},
+            "status_msg": "",
+        }
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.offers_api.search_offers",
+            Mock(return_value=[offer]),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.create_instance",
+            Mock(return_value={"new_contract": 123}),
+        )
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.instances_api.show_instance",
+            Mock(return_value=running_instance),
+        )
+        destroy = Mock(return_value={"success": True})
+        monkeypatch.setattr("vastai.cli.commands.machines.instances_api.destroy_instance", destroy)
+        monkeypatch.setattr("vastai.cli.commands.machines.time.sleep", lambda *_: None)
+        monkeypatch.setattr(
+            "vastai.cli.commands.machines.requests.get",
+            Mock(return_value=SimpleNamespace(status_code=200, text="")),
+        )
+
+        args = parse_argv(["self-test", "machine", "42", "--raw"])
+        result = args.func(args)
+
+        endpoint = result["diagnostics"]["progress_endpoint"]
+        assert result["failure_code"] == "progress_empty_timeout"
+        assert endpoint["first_connection_established"] is True
+        assert endpoint["last_status_code"] == 200
+        assert endpoint["last_error_type"] is None
+        assert result["diagnostics"]["runtime_failure"]["progress_endpoint"] == endpoint
+        assert destroy.call_count >= 1

--- a/tests/cli/test_runtime_diagnostics.py
+++ b/tests/cli/test_runtime_diagnostics.py
@@ -12,11 +12,13 @@ def test_failure_catalog_contains_stable_runtime_codes():
 
 
 def test_make_failure_shapes_raw_output_dict():
+    endpoint = {"url": "https://1.2.3.4:41001/progress"}
     result = diag.make_failure(
         diag.INSTANCE_STATUS_ERROR,
         stage=diag.STAGE_STARTUP,
         error="Error: status failed",
         underlying_error="backend status_msg",
+        progress_endpoint=endpoint,
     )
 
     assert result["code"] == diag.INSTANCE_STATUS_ERROR
@@ -26,11 +28,37 @@ def test_make_failure_shapes_raw_output_dict():
     assert result["suggested_steps"]
     assert result["error"] == "Error: status failed"
     assert result["underlying_error"] == "backend status_msg"
+    assert result["progress_endpoint"] == endpoint
 
 
 def test_make_failure_rejects_unknown_code():
     with pytest.raises(ValueError, match="Unknown runtime failure code"):
         diag.make_failure("not_a_real_failure")
+
+
+def test_make_progress_endpoint_diagnostic_shapes_and_redacts():
+    result = diag.make_progress_endpoint_diagnostic(
+        public_ip="1.2.3.4",
+        host_port=41001,
+        timeout_seconds=10,
+        attempt_count=6,
+        first_connection_established=False,
+        last_error_type="ConnectTimeout",
+        last_error="GET https://console.vast.ai/?api_key=secret timed out",
+        mapped_ports={"5000/tcp": [{"HostPort": "41001"}], "22/tcp": [{"HostPort": "40022"}]},
+    )
+
+    assert result["url"] == "https://1.2.3.4:41001/progress"
+    assert result["public_ip"] == "1.2.3.4"
+    assert result["container_port"] == diag.PROGRESS_CONTAINER_PORT
+    assert result["host_port"] == "41001"
+    assert result["timeout_seconds"] == 10
+    assert result["attempt_count"] == 6
+    assert result["first_connection_established"] is False
+    assert result["last_error_type"] == "ConnectTimeout"
+    assert "api_key=secret" not in result["last_error"]
+    assert "api_key=REDACTED" in result["last_error"]
+    assert result["mapped_ports"] == ["22/tcp", "5000/tcp"]
 
 
 def test_legacy_parser_tracks_stage_and_classifies_nccl_error():

--- a/tests/cli/test_runtime_diagnostics.py
+++ b/tests/cli/test_runtime_diagnostics.py
@@ -51,6 +51,7 @@ def test_make_progress_endpoint_diagnostic_shapes_and_redacts():
     assert result["url"] == "https://1.2.3.4:41001/progress"
     assert result["public_ip"] == "1.2.3.4"
     assert result["container_port"] == diag.PROGRESS_CONTAINER_PORT
+    assert result["external_port"] == "41001"
     assert result["host_port"] == "41001"
     assert result["timeout_seconds"] == 10
     assert result["attempt_count"] == 6

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import re
 import sys
 import time
 import warnings
@@ -52,10 +51,12 @@ from vastai.cli.self_test.runtime_diagnostics import (
     classify_status_msg,
     make_progress_endpoint_diagnostic,
     make_failure,
+    redact_secret_text,
 )
 
 
 parser = _get_parser()
+SELF_TEST_INSTANCE_LABEL_PREFIX = "vast-self-test-machine"
 
 
 # ---------------------------------------------------------------------------
@@ -619,7 +620,7 @@ def self_test__machine(args):
         result["diagnostics"]["runtime_failure"] = diagnostic
 
     def safe_error(error):
-        return re.sub(r"([?&]api_key=)[^&\s]+", r"\1REDACTED", str(error))
+        return redact_secret_text(error) or ""
 
     def render_runtime_failure():
         diagnostic = result.get("diagnostics", {}).get("runtime_failure")
@@ -688,6 +689,14 @@ def self_test__machine(args):
                 return {
                     "status": status,
                     "status_code": status_code,
+                    "error": safe_error(e),
+                    "rows": [],
+                    "row_count": 0,
+                }
+            except requests.exceptions.RequestException as e:
+                return {
+                    "status": "lookup_error",
+                    "status_code": http_status_code(e),
                     "error": safe_error(e),
                     "rows": [],
                     "row_count": 0,
@@ -892,10 +901,12 @@ def self_test__machine(args):
                 from vastai.cli.util import parse_env
                 env = parse_env("-e TZ=PDT -e XNAME=XX4 -p 5000:5000 -p 1234:1234")
                 runtype = "ssh_direc ssh_proxy"
+                self_test_label = f"{SELF_TEST_INSTANCE_LABEL_PREFIX}-{args.machine_id}"
                 result["diagnostics"]["launch"] = {
                     "runtype": runtype,
                     "jupyter_lab": False,
                     "ports": ["5000/tcp", "1234/tcp"],
+                    "label": self_test_label,
                 }
 
                 progress_print(f"Starting test with {docker_image} ({image_reason})")
@@ -906,7 +917,7 @@ def self_test__machine(args):
                     disk=40,
                     env=env,
                     price=None,
-                    label=None,
+                    label=self_test_label,
                     extra=None,
                     onstart_cmd="/verification/remote.sh",
                     login=None,
@@ -1227,7 +1238,7 @@ def self_test__machine(args):
                                     progress_print("  1. TCP firewall/NAT forwarding is blocking the mapped public port")
                                     progress_print("  2. Container did not start or did not bind the progress server")
                                     progress_print("  3. NAT loopback/hairpinning may fail when testing from the same LAN as the host")
-                                    progress_print(f"  4. direct_port_count too low - check with: vastai search offers 'machine_id={machine_id} rentable=any rented=any'")
+                                    progress_print(f"  4. direct_port_count below the 3 ports/GPU minimum - check with: vastai search offers 'machine_id={machine_id} rentable=any rented=any'")
                                     return_reason = "Port never reachable within 120 seconds"
                                     diagnostic = make_failure(
                                         PROGRESS_ENDPOINT_UNREACHABLE,
@@ -1319,7 +1330,7 @@ def self_test__machine(args):
                             progress_print(f"Port 5000/tcp not found in mapped ports. Available ports: {list(all_ports.keys())}")
                             progress_print("Possible causes:")
                             progress_print("  1. The instance launch did not map the self-test progress port")
-                            progress_print(f"  2. direct_port_count too low - check with: vastai search offers 'machine_id={args.machine_id} rentable=any rented=any'")
+                            progress_print(f"  2. direct_port_count below the 3 ports/GPU minimum - check with: vastai search offers 'machine_id={args.machine_id} rentable=any rented=any'")
                             progress_print("  3. Container is not exposing port 5000/tcp")
                             set_runtime_failure(
                                 make_failure(

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -635,6 +635,9 @@ def self_test__machine(args):
         if endpoint:
             if endpoint.get("url"):
                 print(f"- tried: {endpoint['url']}")
+            external_port = endpoint.get("external_port") or endpoint.get("host_port")
+            if external_port:
+                print(f"- external port tested: {external_port}")
             last_bits = []
             if endpoint.get("last_status_code") is not None:
                 last_bits.append(f"HTTP {endpoint['last_status_code']}")
@@ -645,7 +648,7 @@ def self_test__machine(args):
             if last_bits:
                 print(f"- last result: {' - '.join(last_bits)}")
             if endpoint.get("mapped_ports"):
-                print(f"- mapped ports: {', '.join(endpoint['mapped_ports'])}")
+                print(f"- mapped container ports: {', '.join(endpoint['mapped_ports'])}")
         if diagnostic.get("remediation"):
             print(f"- remediation: {diagnostic['remediation']}")
         steps = diagnostic.get("suggested_steps") or []
@@ -1213,6 +1216,8 @@ def self_test__machine(args):
                                 if not first_connection_established:
                                     progress_print("No response for 120s — port was never reachable.")
                                     progress_print(f"Tried: {endpoint.get('url')}")
+                                    if endpoint.get("external_port"):
+                                        progress_print(f"External port tested: {endpoint.get('external_port')}")
                                     if endpoint.get("last_error_type") or endpoint.get("last_status_code") is not None:
                                         last_result = endpoint.get("last_error_type") or f"HTTP {endpoint.get('last_status_code')}"
                                         if endpoint.get("last_error"):
@@ -1233,6 +1238,8 @@ def self_test__machine(args):
                                 elif endpoint.get("last_status_code") == 200 and not endpoint.get("last_error_type"):
                                     progress_print("Progress endpoint was reachable but returned no output for 120s.")
                                     progress_print(f"Tried: {endpoint.get('url')}")
+                                    if endpoint.get("external_port"):
+                                        progress_print(f"External port tested: {endpoint.get('external_port')}")
                                     progress_print("Possible causes:")
                                     progress_print("  1. Runtime script stalled before writing progress")
                                     progress_print("  2. Container process is alive but the test worker is hung")
@@ -1247,6 +1254,8 @@ def self_test__machine(args):
                                 else:
                                     progress_print("Connection lost after initial success — instance may have crashed.")
                                     progress_print(f"Tried: {endpoint.get('url')}")
+                                    if endpoint.get("external_port"):
+                                        progress_print(f"External port tested: {endpoint.get('external_port')}")
                                     if endpoint.get("last_error_type") or endpoint.get("last_status_code") is not None:
                                         last_result = endpoint.get("last_error_type") or f"HTTP {endpoint.get('last_status_code')}"
                                         if endpoint.get("last_error"):

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -30,6 +30,7 @@ from vastai.cli.self_test.machine_diagnostics import (
     failed_checks,
     no_offer_failure,
     preflight_requirement_checks,
+    render_preflight_advisories,
     render_preflight_failure,
     requirement_failure,
 )
@@ -42,11 +43,14 @@ from vastai.cli.self_test.runtime_diagnostics import (
     INTERRUPTED,
     LegacyProgressParser,
     MISSING_PUBLIC_IP,
+    PROGRESS_CONTAINER_PORT,
+    PROGRESS_EMPTY_TIMEOUT,
     PROGRESS_ENDPOINT_LOST,
     PROGRESS_ENDPOINT_UNREACHABLE,
     PROGRESS_PORT_NOT_MAPPED,
     RUNTIME_TEST_TIMEOUT,
     classify_status_msg,
+    make_progress_endpoint_diagnostic,
     make_failure,
 )
 
@@ -588,6 +592,7 @@ def self_test__machine(args):
         args.test_image = None
     if getattr(args, "ignore_requirements", False):
         result["warning"] = ignore_requirements_warning
+        result["diagnostics"]["requirements_ignored"] = True
 
     def progress_print(*args_to_print):
         if not args.raw:
@@ -626,6 +631,21 @@ def self_test__machine(args):
             print(f"- summary: {diagnostic['summary']}")
         if diagnostic.get("underlying_error"):
             print(f"- underlying error: {diagnostic['underlying_error']}")
+        endpoint = diagnostic.get("progress_endpoint") or result.get("diagnostics", {}).get("progress_endpoint")
+        if endpoint:
+            if endpoint.get("url"):
+                print(f"- tried: {endpoint['url']}")
+            last_bits = []
+            if endpoint.get("last_status_code") is not None:
+                last_bits.append(f"HTTP {endpoint['last_status_code']}")
+            if endpoint.get("last_error_type"):
+                last_bits.append(str(endpoint["last_error_type"]))
+            if endpoint.get("last_error"):
+                last_bits.append(str(endpoint["last_error"]))
+            if last_bits:
+                print(f"- last result: {' - '.join(last_bits)}")
+            if endpoint.get("mapped_ports"):
+                print(f"- mapped ports: {', '.join(endpoint['mapped_ports'])}")
         if diagnostic.get("remediation"):
             print(f"- remediation: {diagnostic['remediation']}")
         steps = diagnostic.get("suggested_steps") or []
@@ -637,6 +657,49 @@ def self_test__machine(args):
     client = get_client(args)
 
     try:
+        def http_status_code(error):
+            response = getattr(error, "response", None)
+            return getattr(response, "status_code", None)
+
+        def offer_search_error_summary(error):
+            return {
+                "status_code": http_status_code(error),
+                "error": safe_error(error),
+            }
+
+        def lookup_machine_for_offer_failure(machine_id):
+            try:
+                rows = machines_api.show_machine(client, id=machine_id)
+                if isinstance(rows, dict):
+                    rows_for_status = [rows] if rows else []
+                else:
+                    rows_for_status = rows or []
+                return {
+                    "status": "visible" if rows_for_status else "empty",
+                    "rows": rows_for_status,
+                    "row_count": len(rows_for_status),
+                }
+            except requests.exceptions.HTTPError as e:
+                status_code = http_status_code(e)
+                status = "permission_denied" if status_code in (401, 403) else "not_found" if status_code == 404 else "error"
+                return {
+                    "status": status,
+                    "status_code": status_code,
+                    "error": safe_error(e),
+                    "rows": [],
+                    "row_count": 0,
+                }
+
+        def compact_machine_lookup(machine_lookup):
+            if not machine_lookup:
+                return None
+            return {
+                "status": machine_lookup.get("status"),
+                "status_code": machine_lookup.get("status_code"),
+                "row_count": machine_lookup.get("row_count", len(machine_lookup.get("rows") or [])),
+                "error": machine_lookup.get("error"),
+            }
+
         def selected_offer_for_self_test(machine_id):
             strict_query = {
                 "machine_id": {"eq": machine_id},
@@ -644,16 +707,26 @@ def self_test__machine(args):
                 "rentable": {"eq": True},
                 "rented": {"eq": "any"},
             }
-            strict_offers = offers_api.search_offers(
-                client, query=strict_query, offer_type="on-demand",
-                order=[["score", "desc"]], storage=5.0, no_default=True,
-            )
-            debug_print("Captured strict offers from search_offers:", strict_offers)
             diagnostics = {
-                "strict_offer_count": len(strict_offers or []),
+                "strict_offer_count": None,
                 "broader_offer_count": None,
                 "broader_offers": [],
+                "search_error": None,
+                "machine_lookup": None,
             }
+            try:
+                strict_offers = offers_api.search_offers(
+                    client, query=strict_query, offer_type="on-demand",
+                    order=[["score", "desc"]], storage=5.0, no_default=True,
+                )
+            except requests.exceptions.HTTPError as e:
+                if http_status_code(e) in (401, 403):
+                    diagnostics["search_error"] = offer_search_error_summary(e)
+                    check, failure = no_offer_failure(machine_id, [], search_error=e)
+                    return None, (check, failure), diagnostics
+                raise
+            debug_print("Captured strict offers from search_offers:", strict_offers)
+            diagnostics["strict_offer_count"] = len(strict_offers or [])
             if strict_offers:
                 sorted_offers = sorted(strict_offers, key=lambda x: x.get("dlperf", 0), reverse=True)
                 selected = dict(sorted_offers[0])
@@ -667,16 +740,27 @@ def self_test__machine(args):
                 "rentable": {"eq": "any"},
                 "rented": {"eq": "any"},
             }
-            broader_offers = offers_api.search_offers(
-                client, query=broader_query, offer_type="on-demand",
-                order=[["score", "desc"]], storage=5.0, no_default=True,
-            )
+            try:
+                broader_offers = offers_api.search_offers(
+                    client, query=broader_query, offer_type="on-demand",
+                    order=[["score", "desc"]], storage=5.0, no_default=True,
+                )
+            except requests.exceptions.HTTPError as e:
+                if http_status_code(e) in (401, 403):
+                    diagnostics["search_error"] = offer_search_error_summary(e)
+                    check, failure = no_offer_failure(machine_id, [], search_error=e)
+                    return None, (check, failure), diagnostics
+                raise
             diagnostics["broader_offer_count"] = len(broader_offers or [])
             diagnostics["broader_offers"] = [
                 compact_offer_metadata(dict(offer, machine_id=offer.get("machine_id", machine_id)))
                 for offer in (broader_offers or [])[:5]
             ]
-            check, failure = no_offer_failure(machine_id, broader_offers)
+            machine_lookup = None
+            if not broader_offers:
+                machine_lookup = lookup_machine_for_offer_failure(machine_id)
+                diagnostics["machine_lookup"] = compact_machine_lookup(machine_lookup)
+            check, failure = no_offer_failure(machine_id, broader_offers, machine_lookup=machine_lookup)
             return None, (check, failure), diagnostics
 
         selected_offer, offer_failure, offer_diagnostics = selected_offer_for_self_test(args.machine_id)
@@ -697,16 +781,19 @@ def self_test__machine(args):
         unmet_checks = failed_checks(checks)
         if unmet_checks:
             failure = requirement_failure(checks)
-            result["failure"] = failure
-            result["failure_code"] = failure["code"]
-            result["stage"] = "preflight_requirements"
-            result["reason"] = failure["summary"]
+            result["diagnostics"]["preflight_failure"] = failure
             render_preflight_failure(args.machine_id, checks, failure, progress_print)
+            render_preflight_advisories(args.machine_id, checks, progress_print)
             if not args.ignore_requirements:
+                result["failure"] = failure
+                result["failure_code"] = failure["code"]
+                result["stage"] = "preflight_requirements"
+                result["reason"] = failure["summary"]
                 return finish_failure()
             progress_print("Continuing despite unmet requirements because --ignore-requirements is set.")
         else:
             progress_print(f"Machine ID {args.machine_id} meets all the requirements.")
+            render_preflight_advisories(args.machine_id, checks, progress_print)
         if args.ignore_requirements:
             progress_print(ignore_requirements_warning)
 
@@ -1004,11 +1091,37 @@ def self_test__machine(args):
                     )
 
                 # ----- run machine tester -----
-                def run_machinetester(ip_address, port, inst_id, machine_id, delay):
+                def run_machinetester(ip_address, port, inst_id, machine_id, delay, mapped_ports=None):
                     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
                     delay = int(delay)
                     message = ''
                     legacy_parser = LegacyProgressParser()
+                    progress_url = f"https://{ip_address}:{port}/progress"
+                    request_timeout = 10
+                    attempt_count = 0
+                    last_error_type = None
+                    last_error = None
+                    last_status_code = None
+                    first_connection_established = False
+
+                    def update_progress_endpoint():
+                        endpoint = make_progress_endpoint_diagnostic(
+                            url=progress_url,
+                            public_ip=ip_address,
+                            container_port=PROGRESS_CONTAINER_PORT,
+                            host_port=port,
+                            timeout_seconds=request_timeout,
+                            attempt_count=attempt_count,
+                            first_connection_established=first_connection_established,
+                            last_error_type=last_error_type,
+                            last_error=last_error,
+                            last_status_code=last_status_code,
+                            mapped_ports=mapped_ports,
+                        )
+                        result["diagnostics"]["progress_endpoint"] = endpoint
+                        return endpoint
+
+                    update_progress_endpoint()
 
                     def is_instance(iid):
                         try:
@@ -1030,7 +1143,6 @@ def self_test__machine(args):
                     start_time = time.time()
                     no_response_seconds = 0
                     printed_lines = set()
-                    first_connection_established = False
                     instance_destroyed = False
                     try:
                         while time.time() - start_time < 600:
@@ -1045,18 +1157,31 @@ def self_test__machine(args):
                                 return False, reason, make_failure(INSTANCE_OFFLINE_BEFORE_TEST, stage="runtime")
 
                             try:
-                                debug_print(f"Sending GET request to https://{ip_address}:{port}/progress")
-                                response = requests.get(f'https://{ip_address}:{port}/progress', verify=False, timeout=10)
+                                debug_print(f"Sending GET request to {progress_url}")
+                                attempt_count += 1
+                                response = requests.get(progress_url, verify=False, timeout=request_timeout)
+                                last_status_code = response.status_code
+                                last_error_type = None
+                                last_error = None
 
                                 if response.status_code == 200 and not first_connection_established:
                                     progress_print("Successfully established HTTPS connection to the server.")
                                     first_connection_established = True
 
-                                message = response.text.strip()
+                                if response.status_code == 200:
+                                    message = response.text.strip()
+                                else:
+                                    last_error_type = "HTTPStatus"
+                                    last_error = f"HTTP {response.status_code} from progress endpoint"
+                                    message = ''
                                 debug_print(f"Received message: '{message}'")
                             except requests.exceptions.RequestException as e:
-                                debug_print(f"Error making HTTPS request: {safe_error(e)}")
+                                last_status_code = None
+                                last_error_type = e.__class__.__name__
+                                last_error = safe_error(e)
+                                debug_print(f"Error making HTTPS request: {last_error}")
                                 message = ''
+                            update_progress_endpoint()
 
                             if message:
                                 lines = message.split('\n')
@@ -1084,29 +1209,59 @@ def self_test__machine(args):
                                 debug_print(f"No message received. Incremented no_response_seconds to {no_response_seconds}.")
 
                             if status == 'running' and no_response_seconds >= 120:
+                                endpoint = update_progress_endpoint()
                                 if not first_connection_established:
                                     progress_print("No response for 120s — port was never reachable.")
+                                    progress_print(f"Tried: {endpoint.get('url')}")
+                                    if endpoint.get("last_error_type") or endpoint.get("last_status_code") is not None:
+                                        last_result = endpoint.get("last_error_type") or f"HTTP {endpoint.get('last_status_code')}"
+                                        if endpoint.get("last_error"):
+                                            last_result = f"{last_result}: {endpoint.get('last_error')}"
+                                        progress_print(f"Last result: {last_result}")
                                     progress_print("Possible causes:")
-                                    progress_print("  1. Port not accessible from outside — check firewall and direct_port_count")
-                                    progress_print("  2. Container crashed on startup — check docker logs")
-                                    progress_print(f"  3. direct_port_count too low - check with: vastai search offers 'machine_id={machine_id} rentable=any rented=any'")
+                                    progress_print("  1. TCP firewall/NAT forwarding is blocking the mapped public port")
+                                    progress_print("  2. Container did not start or did not bind the progress server")
+                                    progress_print("  3. NAT loopback/hairpinning may fail when testing from the same LAN as the host")
+                                    progress_print(f"  4. direct_port_count too low - check with: vastai search offers 'machine_id={machine_id} rentable=any rented=any'")
                                     return_reason = "Port never reachable within 120 seconds"
                                     diagnostic = make_failure(
                                         PROGRESS_ENDPOINT_UNREACHABLE,
                                         stage="runtime_connect",
                                         details=return_reason,
+                                        progress_endpoint=endpoint,
+                                    )
+                                elif endpoint.get("last_status_code") == 200 and not endpoint.get("last_error_type"):
+                                    progress_print("Progress endpoint was reachable but returned no output for 120s.")
+                                    progress_print(f"Tried: {endpoint.get('url')}")
+                                    progress_print("Possible causes:")
+                                    progress_print("  1. Runtime script stalled before writing progress")
+                                    progress_print("  2. Container process is alive but the test worker is hung")
+                                    progress_print("  3. Host stall, GPU hang, or slow I/O prevented progress updates")
+                                    return_reason = "Progress endpoint returned no output for 120 seconds"
+                                    diagnostic = make_failure(
+                                        PROGRESS_EMPTY_TIMEOUT,
+                                        stage="runtime_progress",
+                                        details=return_reason,
+                                        progress_endpoint=endpoint,
                                     )
                                 else:
                                     progress_print("Connection lost after initial success — instance may have crashed.")
+                                    progress_print(f"Tried: {endpoint.get('url')}")
+                                    if endpoint.get("last_error_type") or endpoint.get("last_status_code") is not None:
+                                        last_result = endpoint.get("last_error_type") or f"HTTP {endpoint.get('last_status_code')}"
+                                        if endpoint.get("last_error"):
+                                            last_result = f"{last_result}: {endpoint.get('last_error')}"
+                                        progress_print(f"Last result: {last_result}")
                                     progress_print("Possible causes:")
-                                    progress_print("  1. Out of RAM/VRAM — check docker logs")
-                                    progress_print("  2. GPU errors — check dmesg for Xid errors")
-                                    progress_print("  3. Try running individual tests to isolate the failure")
+                                    progress_print("  1. Container crash, OOM, or runtime process exit — check docker logs")
+                                    progress_print("  2. GPU errors or reset — check dmesg for Xid errors")
+                                    progress_print("  3. Host stall or network loss after the progress server started")
                                     return_reason = "Connection lost after 120 seconds — possible crash during stress test"
                                     diagnostic = make_failure(
                                         PROGRESS_ENDPOINT_LOST,
                                         stage="runtime_connect",
                                         details=return_reason,
+                                        progress_endpoint=endpoint,
                                     )
                                 destroy_instance_silent(inst_id)
                                 instance_destroyed = True
@@ -1144,16 +1299,25 @@ def self_test__machine(args):
                         port_mappings = all_ports.get("5000/tcp", [])
                         port = port_mappings[0].get("HostPort") if port_mappings else None
                         if not port:
+                            endpoint = make_progress_endpoint_diagnostic(
+                                public_ip=ip_address,
+                                container_port=PROGRESS_CONTAINER_PORT,
+                                host_port=None,
+                                timeout_seconds=10,
+                                mapped_ports=all_ports,
+                            )
+                            result["diagnostics"]["progress_endpoint"] = endpoint
                             progress_print(f"Port 5000/tcp not found in mapped ports. Available ports: {list(all_ports.keys())}")
                             progress_print("Possible causes:")
-                            progress_print("  1. Firewall blocking the port")
+                            progress_print("  1. The instance launch did not map the self-test progress port")
                             progress_print(f"  2. direct_port_count too low - check with: vastai search offers 'machine_id={args.machine_id} rentable=any rented=any'")
-                            progress_print("  3. Container is not exposing port 5000")
+                            progress_print("  3. Container is not exposing port 5000/tcp")
                             set_runtime_failure(
                                 make_failure(
                                     PROGRESS_PORT_NOT_MAPPED,
                                     stage="instance_network",
                                     details=f"Available ports: {list(all_ports.keys())}",
+                                    progress_endpoint=endpoint,
                                 ),
                                 "Failed to retrieve mapped port.",
                             )
@@ -1162,7 +1326,7 @@ def self_test__machine(args):
                             result["phase"] = "test"
                             result["stage"] = "run_machinetester"
                             success, reason, runtime_diagnostic = run_machinetester(
-                                ip_address, port, instance_id, args.machine_id, delay,
+                                ip_address, port, instance_id, args.machine_id, delay, mapped_ports=all_ports,
                             )
                             result["success"] = success
                             result["reason"] = reason
@@ -1234,7 +1398,11 @@ def self_test__machine(args):
         if result.get("warning"):
             print(result["warning"])
         if result["success"]:
-            print("Test completed successfully.")
+            if result.get("diagnostics", {}).get("preflight_failure"):
+                print("Runtime checks passed, but minimum requirement checks were ignored.")
+                print("This run does not qualify the machine for verification.")
+            else:
+                print("Test completed successfully.")
             sys.exit(0)
         else:
             render_runtime_failure()

--- a/vastai/cli/self_test/machine_diagnostics.py
+++ b/vastai/cli/self_test/machine_diagnostics.py
@@ -4,6 +4,26 @@ from vastai.cli.util import required_inet_mbps
 
 
 DIAGNOSTICS_VERSION = "1"
+ROOT_CURRENTLY_RENTED = "currently_rented"
+ROOT_DEVERIFIED_OR_BELOW_THRESHOLD = "deverified_or_below_threshold"
+ROOT_API_PERMISSION_FAILED = "api_permission_failed"
+ROOT_ZERO_ACTIVE_OFFERS = "zero_active_offers"
+ROOT_OFFLINE_OR_NOT_LISTED = "offline_or_not_listed"
+ROOT_UNKNOWN_NO_RENTABLE_OFFER = "unknown_no_rentable_offer"
+
+NO_OFFER_ROOT_STATES = (
+    ROOT_CURRENTLY_RENTED,
+    ROOT_DEVERIFIED_OR_BELOW_THRESHOLD,
+    ROOT_API_PERMISSION_FAILED,
+    ROOT_ZERO_ACTIVE_OFFERS,
+    ROOT_OFFLINE_OR_NOT_LISTED,
+    ROOT_UNKNOWN_NO_RENTABLE_OFFER,
+)
+
+# Very large GPU hosts, such as 8x B300 systems, can exceed 2 TB of total VRAM.
+# Once a host has about 2 TB of system RAM, do not disqualify it only because it
+# is slightly below 95% of total VRAM.
+SYSTEM_RAM_REQUIREMENT_CAP_MIB = 2_000_000
 
 
 def safe_float(value):
@@ -51,6 +71,10 @@ def compact_offer_metadata(offer):
         "cpu_cores",
         "rentable",
         "rented",
+        "vericode",
+        "verified",
+        "verification",
+        "error_description",
     )
     return {field: offer.get(field) for field in fields if field in offer}
 
@@ -99,6 +123,31 @@ def _check(
     }
 
 
+def _info_check(
+    check_id,
+    title,
+    actual,
+    recommended,
+    operator,
+    unit,
+    summary,
+    purpose,
+    remediation,
+):
+    return {
+        "id": check_id,
+        "title": title,
+        "status": "info",
+        "actual": actual,
+        "required": recommended,
+        "operator": operator,
+        "unit": unit,
+        "summary": summary,
+        "purpose": purpose,
+        "remediation": remediation,
+    }
+
+
 def preflight_requirement_checks(offer):
     gpu_total_ram = safe_float(offer.get("gpu_total_ram"))
     per_gpu_ram_gib = per_gpu_vram_gib(offer)
@@ -106,10 +155,13 @@ def preflight_requirement_checks(offer):
     cpu_ram = safe_float(offer.get("cpu_ram"))
     cpu_cores = int(safe_float(offer.get("cpu_cores")))
     num_gpus = int(safe_float(offer.get("num_gpus")))
-    required_cpu_ram = 0.95 * gpu_total_ram
+    direct_port_count = safe_float(offer.get("direct_port_count"))
+    recommended_max_ports = 64 * num_gpus if num_gpus > 0 else 64
+    uncapped_required_cpu_ram = 0.95 * gpu_total_ram
+    required_cpu_ram = min(uncapped_required_cpu_ram, SYSTEM_RAM_REQUIREMENT_CAP_MIB)
     required_cpu_cores = 2 * num_gpus
 
-    return [
+    checks = [
         _check(
             "cuda.version",
             "CUDA version",
@@ -136,11 +188,11 @@ def preflight_requirement_checks(offer):
         _check(
             "network.direct_ports",
             "Direct port count",
-            safe_float(offer.get("direct_port_count")),
+            direct_port_count,
             3,
             ">",
             "ports",
-            safe_float(offer.get("direct_port_count")) > 3,
+            direct_port_count > 3,
             "The tester needs enough directly mapped ports for remote progress and SSH checks.",
             "Open additional direct ports or adjust host firewall/NAT settings, then rerun verification.",
         ),
@@ -196,8 +248,14 @@ def preflight_requirement_checks(offer):
             ">=",
             "MiB",
             cpu_ram >= required_cpu_ram,
-            "System RAM must be close to total VRAM so CPU-side staging does not starve the tests.",
-            "Add system RAM or reduce the listed GPU set so system RAM is at least 95% of total VRAM.",
+            (
+                "System RAM must be close to total VRAM so CPU-side staging does not starve the tests. "
+                "For very large GPU hosts, this requirement is capped at about 2 TB."
+            ),
+            (
+                "Add system RAM or reduce the listed GPU set so system RAM is at least 95% of "
+                "total VRAM, up to the 2 TB cap."
+            ),
         ),
         _check(
             "cpu.cores",
@@ -211,15 +269,211 @@ def preflight_requirement_checks(offer):
             "Expose more CPU cores to the host or reduce the GPU count for this offer.",
         ),
     ]
+    if direct_port_count > recommended_max_ports:
+        checks.append(
+            _info_check(
+                "network.direct_ports.recommended_max",
+                "Direct port count advisory",
+                direct_port_count,
+                recommended_max_ports,
+                "<=",
+                "ports",
+                (
+                    f"Direct port count: actual {direct_port_count} ports, recommended <= "
+                    f"{recommended_max_ports} ports for {num_gpus or 1} GPU(s)"
+                ),
+                (
+                    "Vast instances can use at most 64 open ports each. Mapping more than "
+                    "64 ports per listed GPU is usually wasted effort."
+                ),
+                (
+                    "This is advisory only, not a self-test gate. Keep enough direct ports for "
+                    "self-test and normal workloads, but avoid mapping very large unused ranges."
+                ),
+            )
+        )
+    return checks
 
 
 def failed_checks(checks):
     return [check for check in checks if check.get("status") == "fail"]
 
 
-def no_offer_failure(machine_id, broader_offers):
+def informational_checks(checks):
+    return [check for check in checks if check.get("status") == "info"]
+
+
+def _http_status(error):
+    if not error:
+        return None
+    if isinstance(error, dict):
+        return error.get("status_code")
+    response = getattr(error, "response", None)
+    return getattr(response, "status_code", None)
+
+
+def _machine_lookup_status(machine_lookup):
+    if not machine_lookup:
+        return None, []
+    if isinstance(machine_lookup, dict) and "status" in machine_lookup:
+        status = machine_lookup.get("status")
+        rows = machine_lookup.get("rows") or []
+        if isinstance(rows, dict):
+            rows = [rows] if rows else []
+        return status, rows
+    if isinstance(machine_lookup, list):
+        return ("visible", machine_lookup) if machine_lookup else ("empty", [])
+    if isinstance(machine_lookup, dict):
+        return ("visible", [machine_lookup]) if machine_lookup else ("empty", [])
+    return None, []
+
+
+def diagnose_no_offer_state(machine_id, broader_offers, machine_lookup=None, search_error=None):
+    """Infer the most likely no-rentable root state from CLI-visible data.
+
+    This is intentionally heuristic. Public offer search alone cannot prove
+    whether a machine is offline, hidden, or has zero active offers, so the
+    return value includes a confidence field for UI/host copy.
+    """
+    offers = broader_offers or []
+    evidence = []
+    suggested_steps = [
+        f"Inspect all visible offers with: vastai search offers 'machine_id={machine_id} rentable=any rented=any'."
+    ]
+
+    search_status = _http_status(search_error)
+    lookup_status, lookup_rows = _machine_lookup_status(machine_lookup)
+    lookup_status_code = machine_lookup.get("status_code") if isinstance(machine_lookup, dict) else None
+
+    if search_status in (401, 403) or lookup_status in ("permission_denied", "unauthorized") or lookup_status_code in (401, 403):
+        if search_status:
+            evidence.append(f"Offer search failed with HTTP {search_status}.")
+        if lookup_status_code:
+            evidence.append(f"Machine lookup failed with HTTP {lookup_status_code}.")
+        evidence.append("The API key or account could not read the required machine/offer state.")
+        suggested_steps = [
+            "Check that the API key is valid and has permission to read offers and hosted machines.",
+            "Retry after logging in with an account that owns or can inspect this host.",
+        ]
+        return {
+            "root_state": ROOT_API_PERMISSION_FAILED,
+            "confidence": "high",
+            "evidence": evidence,
+            "suggested_steps": suggested_steps,
+        }
+
+    if offers:
+        evidence.append(f"Found {len(offers)} visible offer(s), but none were currently rentable.")
+        rented_offers = [offer for offer in offers if offer.get("rented") is True]
+        if rented_offers:
+            evidence.append(f"{len(rented_offers)} visible offer(s) are marked rented=true.")
+            suggested_steps = [
+                "Wait for the current rental to end, then retry the self-test.",
+                suggested_steps[0],
+            ]
+            return {
+                "root_state": ROOT_CURRENTLY_RENTED,
+                "confidence": "medium",
+                "evidence": evidence,
+                "suggested_steps": suggested_steps,
+            }
+
+        state_evidence = []
+        for offer in offers:
+            reliability = safe_float(offer.get("reliability"))
+            vericode = offer.get("vericode")
+            verified = offer.get("verified")
+            verification = offer.get("verification")
+            error_description = offer.get("error_description")
+            if reliability and reliability <= 0.90:
+                state_evidence.append(f"Offer reliability is {reliability}, which is at or below the 0.90 self-test threshold.")
+            if vericode not in (None, "", 0, "0"):
+                state_evidence.append(f"Offer reports vericode={vericode}.")
+            if verified is False:
+                state_evidence.append("Offer is marked verified=false.")
+            if isinstance(verification, str) and verification.lower() not in ("", "verified", "true"):
+                state_evidence.append(f"Offer verification state is {verification}.")
+            if error_description:
+                state_evidence.append(f"Offer error_description is {error_description}.")
+
+        if state_evidence:
+            evidence.extend(state_evidence)
+            suggested_steps = [
+                "Resolve the host verification or reliability issue, then wait for the offer state to refresh.",
+                suggested_steps[0],
+            ]
+            return {
+                "root_state": ROOT_DEVERIFIED_OR_BELOW_THRESHOLD,
+                "confidence": "medium",
+                "evidence": evidence,
+                "suggested_steps": suggested_steps,
+            }
+
+        evidence.append("Visible offers exist, but their payload did not expose a specific non-rentable reason.")
+        suggested_steps = [
+            "Refresh the marketplace/host state and retry shortly.",
+            suggested_steps[0],
+        ]
+        return {
+            "root_state": ROOT_UNKNOWN_NO_RENTABLE_OFFER,
+            "confidence": "low",
+            "evidence": evidence,
+            "suggested_steps": suggested_steps,
+        }
+
+    evidence.append("No visible on-demand offers were returned for this machine.")
+    if lookup_status == "visible" and lookup_rows:
+        evidence.append("Machine lookup returned a visible machine record.")
+        suggested_steps = [
+            "List or relist an on-demand offer for this machine, then retry self-test.",
+            "Check host listing state with: vastai show machines.",
+        ]
+        return {
+            "root_state": ROOT_ZERO_ACTIVE_OFFERS,
+            "confidence": "medium",
+            "evidence": evidence,
+            "suggested_steps": suggested_steps,
+        }
+
+    if lookup_status in ("empty", "not_found") or lookup_status_code == 404:
+        if lookup_status_code == 404:
+            evidence.append("Machine lookup returned HTTP 404.")
+        else:
+            evidence.append("Machine lookup returned no visible machine record.")
+    elif lookup_status:
+        evidence.append(f"Machine lookup status was {lookup_status}.")
+    else:
+        evidence.append("No authoritative machine lookup result was available.")
+
+    suggested_steps = [
+        "Confirm the machine ID is correct and the host is online.",
+        "If this is your host, check that it is listed and visible with: vastai show machines.",
+        suggested_steps[0],
+    ]
+    return {
+        "root_state": ROOT_OFFLINE_OR_NOT_LISTED,
+        "confidence": "low",
+        "evidence": evidence,
+        "suggested_steps": suggested_steps,
+    }
+
+
+def no_offer_failure(machine_id, broader_offers, machine_lookup=None, search_error=None):
+    diagnosis = diagnose_no_offer_state(
+        machine_id,
+        broader_offers,
+        machine_lookup=machine_lookup,
+        search_error=search_error,
+    )
     broad_count = len(broader_offers or [])
-    if broad_count:
+    if diagnosis["root_state"] == ROOT_API_PERMISSION_FAILED:
+        summary = f"Could not inspect rentable offers for machine {machine_id} because API authorization failed."
+        causes = [
+            "The API key may be invalid, expired, or missing permission to read offer/machine state.",
+        ]
+        code = "api_permission_failed"
+        remediation = "Check the API key permissions, then retry with an account that can inspect this host."
+    elif broad_count:
         summary = f"No currently rentable on-demand offer found for machine {machine_id}."
         causes = [
             "The machine may be listed but not rentable right now.",
@@ -227,6 +481,10 @@ def no_offer_failure(machine_id, broader_offers):
             "The machine may already be occupied or temporarily unavailable.",
         ]
         code = "no_rentable_offer"
+        remediation = (
+            "Check host state with: vastai show machines. Then inspect offers with: "
+            f"vastai search offers 'machine_id={machine_id} rentable=any rented=any'."
+        )
     else:
         summary = f"No on-demand offer found for machine {machine_id}."
         causes = [
@@ -235,11 +493,10 @@ def no_offer_failure(machine_id, broader_offers):
             "The machine ID may be incorrect or not visible to this account.",
         ]
         code = "no_offer"
-
-    remediation = (
-        "Check host state with: vastai show machines. Then inspect offers with: "
-        f"vastai search offers 'machine_id={machine_id} rentable=any rented=any'."
-    )
+        remediation = (
+            "Check host state with: vastai show machines. Then inspect offers with: "
+            f"vastai search offers 'machine_id={machine_id} rentable=any rented=any'."
+        )
     check = {
         "id": "offer.available",
         "title": "Rentable offer available",
@@ -257,6 +514,10 @@ def no_offer_failure(machine_id, broader_offers):
         "summary": summary,
         "likely_causes": causes,
         "remediation": remediation,
+        "root_state": diagnosis["root_state"],
+        "confidence": diagnosis["confidence"],
+        "evidence": diagnosis["evidence"],
+        "suggested_steps": diagnosis["suggested_steps"],
     }
     return check, failure
 
@@ -284,3 +545,28 @@ def render_preflight_failure(machine_id, checks, failure=None, print_fn=print):
         print_fn("Likely causes:")
         for cause in failure["likely_causes"]:
             print_fn(f"- {cause}")
+    if failure and failure.get("root_state"):
+        print_fn(f"Root state: {failure['root_state']} (confidence: {failure.get('confidence', 'unknown')})")
+    evidence = failure.get("evidence") if failure else None
+    if evidence:
+        print_fn("Evidence:")
+        for item in evidence:
+            print_fn(f"- {item}")
+    steps = failure.get("suggested_steps") if failure else None
+    if steps:
+        print_fn("Suggested steps:")
+        for step in steps:
+            print_fn(f"- {step}")
+
+
+def render_preflight_advisories(machine_id, checks, print_fn=print):
+    info_checks = informational_checks(checks)
+    if not info_checks:
+        return
+    print_fn(f"Preflight advisory for machine {machine_id}:")
+    for check in info_checks:
+        print_fn(f"- {check['title']}")
+        print_fn(f"  actual: {check['actual']} {check['unit']}")
+        print_fn(f"  recommended: {check['operator']} {check['required']} {check['unit']}")
+        print_fn(f"  purpose: {check['purpose']}")
+        print_fn(f"  note: {check['remediation']}")

--- a/vastai/cli/self_test/machine_diagnostics.py
+++ b/vastai/cli/self_test/machine_diagnostics.py
@@ -155,8 +155,10 @@ def preflight_requirement_checks(offer):
     cpu_ram = safe_float(offer.get("cpu_ram"))
     cpu_cores = int(safe_float(offer.get("cpu_cores")))
     num_gpus = int(safe_float(offer.get("num_gpus")))
+    listed_gpus = num_gpus if num_gpus > 0 else 1
     direct_port_count = safe_float(offer.get("direct_port_count"))
-    recommended_max_ports = 64 * num_gpus if num_gpus > 0 else 64
+    required_min_ports = 3 * listed_gpus
+    recommended_max_ports = 64 * listed_gpus
     uncapped_required_cpu_ram = 0.95 * gpu_total_ram
     required_cpu_ram = min(uncapped_required_cpu_ram, SYSTEM_RAM_REQUIREMENT_CAP_MIB)
     required_cpu_cores = 2 * num_gpus
@@ -189,12 +191,18 @@ def preflight_requirement_checks(offer):
             "network.direct_ports",
             "Direct port count",
             direct_port_count,
-            3,
-            ">",
+            required_min_ports,
+            ">=",
             "ports",
-            direct_port_count > 3,
-            "The tester needs enough directly mapped ports for remote progress and SSH checks.",
-            "Open additional direct ports or adjust host firewall/NAT settings, then rerun verification.",
+            direct_port_count >= required_min_ports,
+            (
+                "The tester needs at least 3 directly mapped ports per listed GPU for remote "
+                "progress, SSH checks, and runtime port allocation."
+            ),
+            (
+                f"Open at least {required_min_ports} direct ports for {listed_gpus} listed GPU(s), "
+                "check firewall/NAT forwarding, and make TCP/UDP forwarding symmetric where required."
+            ),
         ),
         _check(
             "pcie.bandwidth",
@@ -280,7 +288,7 @@ def preflight_requirement_checks(offer):
                 "ports",
                 (
                     f"Direct port count: actual {direct_port_count} ports, recommended <= "
-                    f"{recommended_max_ports} ports for {num_gpus or 1} GPU(s)"
+                    f"{recommended_max_ports} ports for {listed_gpus} GPU(s)"
                 ),
                 (
                     "Vast instances can use at most 64 open ports each. Mapping more than "

--- a/vastai/cli/self_test/runtime_diagnostics.py
+++ b/vastai/cli/self_test/runtime_diagnostics.py
@@ -293,6 +293,7 @@ def make_progress_endpoint_diagnostic(
         "url": url,
         "public_ip": public_ip,
         "container_port": container_port,
+        "external_port": str(host_port) if host_port is not None else None,
         "host_port": str(host_port) if host_port is not None else None,
         "timeout_seconds": timeout_seconds,
         "attempt_count": int(attempt_count or 0),

--- a/vastai/cli/self_test/runtime_diagnostics.py
+++ b/vastai/cli/self_test/runtime_diagnostics.py
@@ -34,6 +34,7 @@ NCCL_FAILED = "nccl_failed"
 STRESS_GPU_BURN_FAILED = "stress_gpu_burn_failed"
 INTERRUPTED = "interrupted"
 CLEANUP_FAILED = "cleanup_failed"
+PROGRESS_CONTAINER_PORT = "5000/tcp"
 
 
 RUNTIME_FAILURE_CODES = (
@@ -117,19 +118,27 @@ FAILURE_CATALOG: dict[str, FailureCatalogEntry] = {
         PROGRESS_PORT_NOT_MAPPED,
         "The runtime progress port was not mapped.",
         "Confirm port 5000/tcp is exposed and direct ports are available.",
-        ("Check instance port mappings.", "Verify the machine has enough direct ports."),
+        ("Check the available mapped ports in the diagnostic output.", "Verify the machine has enough direct ports."),
     ),
     PROGRESS_ENDPOINT_UNREACHABLE: FailureCatalogEntry(
         PROGRESS_ENDPOINT_UNREACHABLE,
         "The runtime progress endpoint was never reachable.",
-        "Check firewall, direct port mapping, and container startup.",
-        ("Confirm port 5000/tcp is mapped.", "Inspect docker logs for startup failures."),
+        "Check TCP firewall/NAT forwarding, direct port mapping, container startup, and NAT hairpinning.",
+        (
+            "Confirm the mapped public TCP port forwards to the host LAN IP.",
+            "Inspect docker logs to confirm the progress server bound port 5000/tcp.",
+            "If testing from the same LAN as the host, retry from an outside network to rule out NAT loopback/hairpinning.",
+        ),
     ),
     PROGRESS_ENDPOINT_LOST: FailureCatalogEntry(
         PROGRESS_ENDPOINT_LOST,
         "The runtime progress endpoint became unreachable after connecting.",
         "Look for container crashes, OOM, GPU errors, or host instability.",
-        ("Inspect docker logs.", "Check dmesg for Xid or GPU reset messages."),
+        (
+            "Inspect docker logs for a crash or missing progress server.",
+            "Check dmesg for Xid, GPU reset, OOM, or host stall messages.",
+            "Check for network loss between the CLI and host public endpoint.",
+        ),
     ),
     PROGRESS_EMPTY_TIMEOUT: FailureCatalogEntry(
         PROGRESS_EMPTY_TIMEOUT,
@@ -245,6 +254,56 @@ _STARTUP_RE = re.compile(
     re.IGNORECASE,
 )
 
+_API_KEY_RE = re.compile(r"([?&]api_key=)[^&\s]+")
+
+
+def redact_secret_text(value: object) -> str | None:
+    """Return a host-visible string with obvious API-key query values redacted."""
+    if value is None:
+        return None
+    return _API_KEY_RE.sub(r"\1REDACTED", str(value))
+
+
+def _mapped_port_names(mapped_ports) -> list[str]:
+    if not mapped_ports:
+        return []
+    if isinstance(mapped_ports, dict):
+        return sorted(str(key) for key in mapped_ports.keys())
+    return sorted(str(port) for port in mapped_ports)
+
+
+def make_progress_endpoint_diagnostic(
+    *,
+    url: str | None = None,
+    public_ip: str | None = None,
+    container_port: str = PROGRESS_CONTAINER_PORT,
+    host_port: str | int | None = None,
+    timeout_seconds: int | float | None = None,
+    attempt_count: int = 0,
+    first_connection_established: bool = False,
+    last_error_type: str | None = None,
+    last_error: object = None,
+    last_status_code: int | None = None,
+    mapped_ports=None,
+) -> dict[str, object]:
+    """Shape progress endpoint state for raw output and UI consumption."""
+    if url is None and public_ip and host_port:
+        url = f"https://{public_ip}:{host_port}/progress"
+    diagnostic: dict[str, object] = {
+        "url": url,
+        "public_ip": public_ip,
+        "container_port": container_port,
+        "host_port": str(host_port) if host_port is not None else None,
+        "timeout_seconds": timeout_seconds,
+        "attempt_count": int(attempt_count or 0),
+        "first_connection_established": bool(first_connection_established),
+        "last_error_type": last_error_type,
+        "last_error": redact_secret_text(last_error),
+        "last_status_code": last_status_code,
+        "mapped_ports": _mapped_port_names(mapped_ports),
+    }
+    return diagnostic
+
 
 def failure_catalog() -> dict[str, dict[str, object]]:
     """Return a JSON-serializable copy of the runtime failure catalog."""
@@ -277,6 +336,7 @@ def make_failure(
     remediation: str | None = None,
     suggested_steps: Iterable[str] | None = None,
     underlying_error: str | None = None,
+    progress_endpoint: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Build a raw-output-friendly diagnostic dictionary."""
     entry = get_failure_entry(code)
@@ -293,6 +353,8 @@ def make_failure(
         diagnostic["error"] = error
     if underlying_error:
         diagnostic["underlying_error"] = underlying_error
+    if progress_endpoint:
+        diagnostic["progress_endpoint"] = progress_endpoint
     return diagnostic
 
 
@@ -407,6 +469,7 @@ __all__ = [
     "NCCL_FAILED",
     "NVML_FAILED",
     "PROGRESS_EMPTY_TIMEOUT",
+    "PROGRESS_CONTAINER_PORT",
     "PROGRESS_ENDPOINT_LOST",
     "PROGRESS_ENDPOINT_UNREACHABLE",
     "PROGRESS_PORT_NOT_MAPPED",
@@ -425,6 +488,8 @@ __all__ = [
     "failure_catalog",
     "get_failure_entry",
     "make_failure",
+    "make_progress_endpoint_diagnostic",
     "parse_legacy_progress",
+    "redact_secret_text",
     "stage_from_progress_line",
 ]


### PR DESCRIPTION
## Summary

Implements CLI-side CON-1514 diagnostics on top of the #408 self-test diagnostics work.

This PR improves two commonly reported self-test failure classes:

- "Machine ID not found or not rentable"
- "No response for 120s"

It also addresses the dogfood finding from the `--ignore-requirements` flow:

- If minimum requirements fail but `--ignore-requirements` is set, those failures are preserved as skipped-gate metadata.
- If the runtime checks pass, the top-level result is `success=true` with no contradictory top-level `failure_code`.
- Output now communicates: runtime checks passed, minimum requirement checks were ignored, and the run does not qualify the machine for verification.

## What Changed

- Adds root-state inference for no-offer/no-rentable cases:
  - `currently_rented`
  - `deverified_or_below_threshold`
  - `api_permission_failed`
  - `zero_active_offers`
  - `offline_or_not_listed`
  - `unknown_no_rentable_offer`
- Adds `root_state`, `confidence`, `evidence`, and `suggested_steps` to structured no-offer failures.
- Preserves more offer status metadata, including `vericode`, `verified`, `verification`, and `error_description`.
- Converts offer/machine lookup 401/403 failures into `api_permission_failed` instead of generic `unexpected_error`.
- Adds structured progress endpoint diagnostics:
  - attempted URL
  - public IP
  - container port
  - host port
  - timeout
  - attempt count
  - first-connection state
  - last error/status
  - mapped ports
- Makes `progress_endpoint_unreachable`, `progress_endpoint_lost`, `progress_empty_timeout`, and `progress_port_not_mapped` easier to diagnose.
- Keeps API key query values redacted in host-visible diagnostics.

## Relationship To #408 And Images

This PR is stacked on #408 while #408 is still open.

The image side must move with the CLI self-test changes:

- New CLI flows use the non-breaking `vastai/test:self-test-v2-cuda-*` image family introduced with #408.
- Existing legacy tags are not overwritten, so older CLIs keep using the old image family.
- No additional image rebuild is required specifically for CON-1514; this PR consumes the v2 structured progress behavior already prepared in the self-test image repo.
- If this PR supersedes #408 before broad use, that is fine: #409 effectively carries the #408 image routing plus the CON-1514 diagnostic refinements.

## Validation

Mocked/local:

- Focused self-test diagnostics:
  - `53 passed, 1 warning`
- Broader required suite:
  - `172 passed, 1 warning`
- `git diff --check`
  - clean

Subagent review:

- Implementation subagent completed the CLI-only patch.
- Independent validator subagent passed the full mocked validation matrix and made no code changes.

Live dogfood:

- Pre-run active-instance audit: `0`
- Paid green run:
  - machine `59568`
  - instance `38367222`
  - image `vastai/test:self-test-v2-cuda-13.0`
  - result `success=true`
  - cleanup audit returned `0` active instances
- Read-only red preflight:
  - machine `35137`
  - reported upload `98.0 Mb/s` vs required `>= 100.0 Mb/s`
  - reported GPU RAM `6.0 GiB` vs required `> 7 GiB`
- Paid `--ignore-requirements` run:
  - machine `35137`
  - instance `38369132`
  - image `vastai/test:self-test-v2-cuda-12.8`
  - runtime passed
  - warning preserved that requirements were ignored
  - failed requirements preserved in structured checks/diagnostics
  - cleanup audit returned `0` active instances

## Known Backend-Dependent Gap

The CLI can now infer likely root states from visible offer/machine data, but it still cannot authoritatively prove some states without backend exposure:

- exact offline vs hidden/not-listed/wrong-account state
- exact failed direct ports
- stale machine-side vs offer-side verification details

Those should be handled by a backend/API follow-up for full CON-1514 completion.
