### PR TITLE
CON-1519: add self-test diagnostic support bundles

### DIFF
--- a/tests/cli/test_self_test_support_bundle.py
+++ b/tests/cli/test_self_test_support_bundle.py
@@ -1,0 +1,118 @@
+"""Tests for self-test diagnostic support bundles."""
+
+import json
+import tarfile
+from unittest.mock import Mock
+
+import pytest
+
+from vastai.cli.self_test.support_bundle import create_support_bundle
+
+
+def test_support_bundle_contains_redacted_result_and_cli_output(tmp_path):
+    bundle = create_support_bundle(
+        machine_id="42",
+        output_dir=str(tmp_path),
+        result={
+            "machine_id": "42",
+            "error": "request failed: https://console.vast.ai/?api_key=secret",
+            "diagnostics": {"jupyter_token": "secret-token"},
+        },
+        cli_output=["Starting self-test", "token=supersecret"],
+        run_started_at="20260602T100000Z",
+        command=["vastai", "--api-key", "secret", "self-test", "machine", "42"],
+        secrets=["secret", "supersecret"],
+        include_host_logs=False,
+    )
+
+    with tarfile.open(bundle["path"], "r:gz") as tar:
+        names = set(tar.getnames())
+        result_json = tar.extractfile("self-test-result.json").read().decode()
+        output_log = tar.extractfile("self-test-output.log").read().decode()
+        manifest = json.loads(tar.extractfile("manifest.json").read().decode())
+
+    assert {"manifest.json", "self-test-result.json", "self-test-output.log", "collection-errors.json"} <= names
+    assert "secret" not in result_json
+    assert "secret" not in output_log
+    assert "REDACTED" in result_json
+    assert "REDACTED" in output_log
+    assert manifest["machine_id"] == "42"
+    assert manifest["run_started_at_utc"] == "20260602T100000Z"
+
+
+def test_self_test_failure_creates_support_bundle(
+    parse_argv, patch_get_client, monkeypatch, tmp_path, capsys
+):
+    from vastai.cli.commands import machines
+
+    def fake_bundle(**kwargs):
+        assert kwargs["machine_id"] == "42"
+        assert kwargs["output_dir"] == str(tmp_path)
+        assert kwargs["include_host_logs"] is True
+        assert kwargs["result"]["failure_code"] == "preflight_requirements_failed"
+        assert any("Preflight diagnostics for machine 42 failed:" in line for line in kwargs["cli_output"])
+        return {
+            "path": str(tmp_path / "vast_selftest_42_20260602T100000Z.tar.gz"),
+            "created_at_utc": "20260602T100000Z",
+            "size_bytes": 123,
+            "files": ["manifest.json", "self-test-result.json", "self-test-output.log"],
+            "collection_errors": [],
+        }
+
+    bad_offer = {
+        "id": 777,
+        "cuda_max_good": "11.7",
+        "compute_cap": 750,
+        "dlperf": 1,
+        "reliability": 0.99,
+        "direct_port_count": 1,
+        "pcie_bw": 1.0,
+        "gpu_total_ram": 6 * 1024,
+        "inet_down": 10,
+        "inet_up": 10,
+        "gpu_ram": 6 * 1024,
+        "cpu_ram": 1024,
+        "cpu_cores": 1,
+        "num_gpus": 1,
+        "machine_id": 42,
+    }
+    monkeypatch.setenv("VAST_SELF_TEST_SUPPORT_BUNDLE", "1")
+    monkeypatch.setattr(machines, "create_support_bundle", fake_bundle)
+    monkeypatch.setattr(machines.offers_api, "search_offers", Mock(return_value=[bad_offer]))
+
+    args = parse_argv(["self-test", "machine", "42", "--support-bundle-dir", str(tmp_path)])
+    with pytest.raises(SystemExit) as exc_info:
+        args.func(args)
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "Self-test diagnostic bundle saved to:" in captured.out
+    assert "self-test-result.json" in captured.out
+    assert "Review this tarball before sharing it with support." in captured.out
+
+
+def test_dump_logs_command_creates_same_bundle(parse_argv, monkeypatch, tmp_path):
+    from vastai.cli.commands import machines
+
+    created = {}
+
+    def fake_bundle(**kwargs):
+        created.update(kwargs)
+        return {
+            "path": str(tmp_path / "vast_selftest_42_20260602T100000Z.tar.gz"),
+            "created_at_utc": "20260602T100000Z",
+            "size_bytes": 123,
+            "files": ["manifest.json", "host/docker-info.txt"],
+            "collection_errors": [],
+        }
+
+    monkeypatch.setattr(machines, "create_support_bundle", fake_bundle)
+
+    args = parse_argv(["dump-logs", "42", "--output-dir", str(tmp_path), "--raw"])
+    result = args.func(args)
+
+    assert result["path"].endswith("vast_selftest_42_20260602T100000Z.tar.gz")
+    assert created["machine_id"] == "42"
+    assert created["output_dir"] == str(tmp_path)
+    assert created["include_host_logs"] is True
+    assert created["result"]["stage"] == "manual_dump_logs"

--- a/tests/cli/test_self_test_support_bundle.py
+++ b/tests/cli/test_self_test_support_bundle.py
@@ -38,6 +38,7 @@ def test_support_bundle_contains_redacted_result_and_cli_output(tmp_path):
     assert "REDACTED" in output_log
     assert manifest["machine_id"] == "42"
     assert manifest["run_started_at_utc"] == "20260602T100000Z"
+    assert manifest["includes_local_host_artifacts"] is False
 
 
 def test_self_test_failure_creates_support_bundle(
@@ -48,7 +49,9 @@ def test_self_test_failure_creates_support_bundle(
     def fake_bundle(**kwargs):
         assert kwargs["machine_id"] == "42"
         assert kwargs["output_dir"] == str(tmp_path)
-        assert kwargs["include_host_logs"] is True
+        assert kwargs["include_local_host_artifacts"] is False
+        assert kwargs["extra_files"] == {}
+        assert kwargs["extra_errors"] == []
         assert kwargs["result"]["failure_code"] == "preflight_requirements_failed"
         assert any("Preflight diagnostics for machine 42 failed:" in line for line in kwargs["cli_output"])
         return {
@@ -91,7 +94,96 @@ def test_self_test_failure_creates_support_bundle(
     assert "Review this tarball before sharing it with support." in captured.out
 
 
-def test_dump_logs_command_creates_same_bundle(parse_argv, monkeypatch, tmp_path):
+def test_self_test_runtime_failure_bundle_includes_instance_logs(
+    parse_argv, patch_get_client, monkeypatch, tmp_path
+):
+    from vastai.cli.commands import machines
+
+    created = {}
+    destroyed = set()
+
+    def fake_bundle(**kwargs):
+        created.update(kwargs)
+        return {
+            "path": str(tmp_path / "vast_selftest_42_20260602T100000Z.tar.gz"),
+            "created_at_utc": "20260602T100000Z",
+            "size_bytes": 123,
+            "files": [
+                "manifest.json",
+                "self-test-result.json",
+                "self-test-output.log",
+                "instance/container.log",
+                "instance/daemon.log",
+                "instance/show-instance.json",
+            ],
+            "collection_errors": [],
+        }
+
+    good_offer = {
+        "id": 777,
+        "cuda_max_good": "12.8",
+        "compute_cap": 750,
+        "dlperf": 1,
+        "reliability": 0.99,
+        "direct_port_count": 3,
+        "pcie_bw": 16.0,
+        "gpu_total_ram": 12 * 1024,
+        "inet_down": 500,
+        "inet_up": 500,
+        "gpu_ram": 12 * 1024,
+        "cpu_ram": 16 * 1024,
+        "cpu_cores": 4,
+        "num_gpus": 1,
+        "machine_id": 42,
+    }
+
+    def fake_show_instance(client, id):
+        assert client is patch_get_client
+        if id in destroyed:
+            return {"id": id, "actual_status": "destroyed", "intended_status": "destroyed"}
+        return {
+            "id": id,
+            "actual_status": "created",
+            "intended_status": "running",
+            "status_msg": "docker_build() error writing dockerfile",
+            "label": "vast-self-test-machine-42",
+        }
+
+    def fake_logs(client, instance_id, tail=None, filter=None, daemon_logs=False):
+        assert client is patch_get_client
+        assert instance_id == 123
+        assert tail == machines.INSTANCE_LOG_TAIL_LINES
+        assert filter is None
+        return "daemon startup failure" if daemon_logs else "container startup failure"
+
+    def fake_destroy_instance(client, id):
+        assert client is patch_get_client
+        destroyed.add(id)
+        return {"success": True}
+
+    monkeypatch.setenv("VAST_SELF_TEST_SUPPORT_BUNDLE", "1")
+    monkeypatch.setattr(machines, "create_support_bundle", fake_bundle)
+    monkeypatch.setattr(machines.offers_api, "search_offers", Mock(return_value=[good_offer]))
+    monkeypatch.setattr(machines.instances_api, "create_instance", Mock(return_value={"new_contract": 123}))
+    monkeypatch.setattr(machines.instances_api, "show_instance", fake_show_instance)
+    monkeypatch.setattr(machines.instances_api, "logs", fake_logs)
+    monkeypatch.setattr(machines.instances_api, "destroy_instance", fake_destroy_instance)
+
+    args = parse_argv(["self-test", "machine", "42", "--support-bundle-dir", str(tmp_path)])
+    with pytest.raises(SystemExit) as exc_info:
+        args.func(args)
+
+    assert exc_info.value.code == 1
+    assert 123 in destroyed
+    assert created["include_local_host_artifacts"] is False
+    assert created["result"]["failure_code"] == "daemon_startup_failed"
+    assert created["extra_files"]["instance/container.log"] == "container startup failure"
+    assert created["extra_files"]["instance/daemon.log"] == "daemon startup failure"
+    assert '"label": "vast-self-test-machine-42"' in created["extra_files"]["instance/show-instance.json"]
+    assert created["extra_errors"] == []
+
+
+def test_dump_logs_command_creates_cli_visible_bundle(parse_argv, monkeypatch, tmp_path):
     from vastai.cli.commands import machines
 
     created = {}
@@ -102,7 +194,7 @@ def test_dump_logs_command_creates_same_bundle(parse_argv, monkeypatch, tmp_path
             "path": str(tmp_path / "vast_selftest_42_20260602T100000Z.tar.gz"),
             "created_at_utc": "20260602T100000Z",
             "size_bytes": 123,
-            "files": ["manifest.json", "host/docker-info.txt"],
+            "files": ["manifest.json", "self-test-result.json", "self-test-output.log"],
             "collection_errors": [],
         }
 
@@ -114,5 +206,67 @@ def test_dump_logs_command_creates_same_bundle(parse_argv, monkeypatch, tmp_path
     assert result["path"].endswith("vast_selftest_42_20260602T100000Z.tar.gz")
     assert created["machine_id"] == "42"
     assert created["output_dir"] == str(tmp_path)
-    assert created["include_host_logs"] is True
+    assert created["include_local_host_artifacts"] is False
+    assert created["extra_files"] == {}
+    assert created["extra_errors"] == []
     assert created["result"]["stage"] == "manual_dump_logs"
+    assert "No --instance-id provided" in "\n".join(created["cli_output"])
+
+
+def test_dump_logs_command_can_pull_instance_logs(
+    parse_argv, patch_get_client, monkeypatch, tmp_path
+):
+    from vastai.cli.commands import machines
+
+    created = {}
+
+    def fake_bundle(**kwargs):
+        created.update(kwargs)
+        return {
+            "path": str(tmp_path / "vast_selftest_42_20260602T100000Z.tar.gz"),
+            "created_at_utc": "20260602T100000Z",
+            "size_bytes": 123,
+            "files": [
+                "manifest.json",
+                "instance/container.log",
+                "instance/daemon.log",
+                "instance/show-instance.json",
+            ],
+            "collection_errors": [],
+        }
+
+    def fake_show_instance(client, id):
+        assert client is patch_get_client
+        assert id == 123
+        return {"id": 123, "actual_status": "running", "label": "vast-self-test-machine-42"}
+
+    def fake_logs(client, instance_id, tail=None, filter=None, daemon_logs=False):
+        assert client is patch_get_client
+        assert instance_id == 123
+        assert tail == machines.INSTANCE_LOG_TAIL_LINES
+        assert filter is None
+        return "daemon log" if daemon_logs else "container log"
+
+    monkeypatch.setattr(machines, "create_support_bundle", fake_bundle)
+    monkeypatch.setattr(machines.instances_api, "show_instance", fake_show_instance)
+    monkeypatch.setattr(machines.instances_api, "logs", fake_logs)
+
+    args = parse_argv([
+        "dump-logs",
+        "42",
+        "--instance-id",
+        "123",
+        "--output-dir",
+        str(tmp_path),
+        "--raw",
+    ])
+    result = args.func(args)
+
+    assert result["path"].endswith("vast_selftest_42_20260602T100000Z.tar.gz")
+    assert created["machine_id"] == "42"
+    assert created["include_local_host_artifacts"] is False
+    assert created["result"]["instance_id"] == 123
+    assert created["extra_files"]["instance/container.log"] == "container log"
+    assert created["extra_files"]["instance/daemon.log"] == "daemon log"
+    assert '"actual_status": "running"' in created["extra_files"]["instance/show-instance.json"]
+    assert created["extra_errors"] == []

--- a/tests/cli/test_self_test_support_bundle.py
+++ b/tests/cli/test_self_test_support_bundle.py
@@ -41,6 +41,22 @@ def test_support_bundle_contains_redacted_result_and_cli_output(tmp_path):
     assert manifest["includes_local_host_artifacts"] is False
 
 
+def test_support_bundle_sanitizes_archive_names(tmp_path):
+    bundle = create_support_bundle(
+        machine_id="42",
+        output_dir=str(tmp_path),
+        extra_files={"../../evil.txt": "payload"},
+        include_local_host_artifacts=False,
+    )
+
+    with tarfile.open(bundle["path"], "r:gz") as tar:
+        names = set(tar.getnames())
+
+    assert "../../evil.txt" not in names
+    assert all(".." not in name for name in names)
+    assert "_/_/evil.txt" in names
+
+
 def test_self_test_failure_creates_support_bundle(
     parse_argv, patch_get_client, monkeypatch, tmp_path, capsys
 ):
@@ -92,6 +108,43 @@ def test_self_test_failure_creates_support_bundle(
     assert "Self-test diagnostic bundle saved to:" in captured.out
     assert "self-test-result.json" in captured.out
     assert "Review this tarball before sharing it with support." in captured.out
+
+
+def test_self_test_bundle_creation_error_preserves_original_failure(
+    parse_argv, patch_get_client, monkeypatch, tmp_path, capsys
+):
+    from vastai.cli.commands import machines
+
+    bad_offer = {
+        "id": 777,
+        "cuda_max_good": "11.7",
+        "compute_cap": 750,
+        "dlperf": 1,
+        "reliability": 0.99,
+        "direct_port_count": 1,
+        "pcie_bw": 1.0,
+        "gpu_total_ram": 6 * 1024,
+        "inet_down": 10,
+        "inet_up": 10,
+        "gpu_ram": 6 * 1024,
+        "cpu_ram": 1024,
+        "cpu_cores": 1,
+        "num_gpus": 1,
+        "machine_id": 42,
+    }
+
+    monkeypatch.setenv("VAST_SELF_TEST_SUPPORT_BUNDLE", "1")
+    monkeypatch.setattr(machines, "create_support_bundle", Mock(side_effect=OSError("disk full")))
+    monkeypatch.setattr(machines.offers_api, "search_offers", Mock(return_value=[bad_offer]))
+
+    args = parse_argv(["self-test", "machine", "42", "--support-bundle-dir", str(tmp_path)])
+    with pytest.raises(SystemExit) as exc_info:
+        args.func(args)
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "WARNING: failed to create self-test diagnostic bundle: disk full" in captured.out
+    assert "Test failed: 8 preflight requirement check(s) failed." in captured.out
 
 
 def test_self_test_runtime_failure_bundle_includes_instance_logs(
@@ -211,6 +264,20 @@ def test_dump_logs_command_creates_cli_visible_bundle(parse_argv, monkeypatch, t
     assert created["extra_errors"] == []
     assert created["result"]["stage"] == "manual_dump_logs"
     assert "No --instance-id provided" in "\n".join(created["cli_output"])
+
+
+def test_dump_logs_bundle_creation_error_is_friendly(parse_argv, monkeypatch, tmp_path, capsys):
+    from vastai.cli.commands import machines
+
+    monkeypatch.setattr(machines, "create_support_bundle", Mock(side_effect=OSError("read-only directory")))
+
+    args = parse_argv(["dump-logs", "42", "--output-dir", str(tmp_path)])
+    with pytest.raises(SystemExit) as exc_info:
+        args.func(args)
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "WARNING: failed to create diagnostic bundle: read-only directory" in captured.out
 
 
 def test_dump_logs_command_can_pull_instance_logs(

--- a/tests/cli/test_util.py
+++ b/tests/cli/test_util.py
@@ -3,6 +3,7 @@
 import argparse
 import pytest
 from datetime import datetime, timedelta
+from unittest.mock import Mock
 
 
 class TestParseEnv:
@@ -88,6 +89,32 @@ class TestValidateSeconds:
         from vastai.cli.util import validate_seconds
         with pytest.raises(argparse.ArgumentTypeError):
             validate_seconds("not_a_number")
+
+
+class TestGetGpuNames:
+    def test_returns_none_when_live_lookup_fails(self, monkeypatch, tmp_path):
+        from requests.exceptions import HTTPError
+        from vastai.cli import util
+
+        response = Mock()
+        response.raise_for_status.side_effect = HTTPError("403 Client Error")
+
+        monkeypatch.setattr(util, "CACHE_FILE", str(tmp_path / "missing-cache.json"))
+        monkeypatch.setattr(util.requests, "get", Mock(return_value=response))
+
+        assert util._get_gpu_names() is None
+
+    def test_formats_gpu_names_from_live_lookup(self, monkeypatch, tmp_path):
+        from vastai.cli import util
+
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"gpu_names": ["RTX 4090", "H100-SXM"]}
+
+        monkeypatch.setattr(util, "CACHE_FILE", str(tmp_path / "gpu-cache.json"))
+        monkeypatch.setattr(util.requests, "get", Mock(return_value=response))
+
+        assert util._get_gpu_names() == ["RTX_4090", "H100_SXM"]
 
 
 class TestSmartSplit:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,12 @@ def _restore_serverless_logger_state():
     log.disabled = old_disabled
 
 
+@pytest.fixture(autouse=True)
+def _disable_self_test_support_bundle_by_default(monkeypatch):
+    """Avoid writing host diagnostic bundles from ordinary unit tests."""
+    monkeypatch.setenv("VAST_SELF_TEST_SUPPORT_BUNDLE", "0")
+
+
 # ---------------------------------------------------------------------------
 # Server Worker test helpers (mocks for generate_client_response etc.)
 # ---------------------------------------------------------------------------

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -618,7 +618,10 @@ def collect_instance_log_artifacts(client, instance_id):
         action="store_true",
         help="Include local OS/kaalia artifacts; only use when running on the actual Vast host",
     ),
-    usage="vastai dump-logs <machine_id> [--instance-id INSTANCE_ID] [--output-dir DIR]",
+    usage=(
+        "vastai dump-logs <machine_id> [--instance-id INSTANCE_ID] "
+        "[--output-dir DIR] [--include-local-host-artifacts]"
+    ),
     help="[Host] Bundle self-test diagnostics for support",
     epilog=deindent("""
         Creates a redacted diagnostic tarball containing CLI-visible self-test
@@ -654,24 +657,35 @@ def dump_logs(args):
             "--include-local-host-artifacts only when running on the actual host."
         )
 
-    bundle = create_support_bundle(
-        machine_id=args.machine_id,
-        output_dir=args.output_dir,
-        result={
-            "machine_id": args.machine_id,
-            "stage": "manual_dump_logs",
-            "reason": "Manual diagnostic bundle requested with vastai dump-logs.",
-            "instance_id": args.instance_id,
-            "includes_local_host_artifacts": args.include_local_host_artifacts,
-        },
-        cli_output=cli_output,
-        extra_files=extra_files,
-        extra_errors=extra_errors,
-        run_started_at=run_started_at,
-        command=sys.argv,
-        secrets=[getattr(args, "api_key", None), os.environ.get("VAST_API_KEY")],
-        include_local_host_artifacts=args.include_local_host_artifacts,
-    )
+    try:
+        bundle = create_support_bundle(
+            machine_id=args.machine_id,
+            output_dir=args.output_dir,
+            result={
+                "machine_id": args.machine_id,
+                "stage": "manual_dump_logs",
+                "reason": "Manual diagnostic bundle requested with vastai dump-logs.",
+                "instance_id": args.instance_id,
+                "includes_local_host_artifacts": args.include_local_host_artifacts,
+            },
+            cli_output=cli_output,
+            extra_files=extra_files,
+            extra_errors=extra_errors,
+            run_started_at=run_started_at,
+            command=sys.argv,
+            secrets=[getattr(args, "api_key", None), os.environ.get("VAST_API_KEY")],
+            include_local_host_artifacts=args.include_local_host_artifacts,
+        )
+    except Exception as e:
+        error = _diagnostic_error(e)
+        if getattr(args, "raw", False):
+            return {
+                "success": False,
+                "machine_id": args.machine_id,
+                "error": f"Failed to create diagnostic bundle: {error}",
+            }
+        print(f"WARNING: failed to create diagnostic bundle: {error}")
+        sys.exit(1)
     if getattr(args, "raw", False):
         return bundle
     for line in format_bundle_summary(bundle):
@@ -767,18 +781,24 @@ def self_test__machine(args):
             return None
         if instance_id:
             collect_instance_logs(instance_id)
-        bundle = create_support_bundle(
-            machine_id=args.machine_id,
-            output_dir=args.support_bundle_dir,
-            result=result,
-            cli_output=cli_output,
-            extra_files=instance_log_files,
-            extra_errors=instance_log_errors,
-            run_started_at=run_started_at,
-            command=sys.argv,
-            secrets=[getattr(args, "api_key", None), os.environ.get("VAST_API_KEY")],
-            include_local_host_artifacts=False,
-        )
+        try:
+            bundle = create_support_bundle(
+                machine_id=args.machine_id,
+                output_dir=args.support_bundle_dir,
+                result=result,
+                cli_output=cli_output,
+                extra_files=instance_log_files,
+                extra_errors=instance_log_errors,
+                run_started_at=run_started_at,
+                command=sys.argv,
+                secrets=[getattr(args, "api_key", None), os.environ.get("VAST_API_KEY")],
+                include_local_host_artifacts=False,
+            )
+        except Exception as e:
+            error = redact_secret_text(e) or ""
+            result["diagnostics"]["support_bundle_error"] = error
+            progress_print(f"WARNING: failed to create self-test diagnostic bundle: {error}")
+            return None
         result["diagnostics"]["support_bundle"] = bundle
         return bundle
 
@@ -1013,7 +1033,7 @@ def self_test__machine(args):
             if compute_cap is not None and compute_cap < 700:
                 return (
                     image_for("11.8"),
-                    f"compute_cap={compute_cap} below sm_70 → forced {image_tag_prefix}-11.8",
+                    f"compute_cap={compute_cap} below sm_70 -> forced {image_tag_prefix}-11.8",
                 )
 
             # Volta sm_70/sm_72 hosts: cuda-12.8 wheels include sm_70 but
@@ -1046,13 +1066,13 @@ def self_test__machine(args):
                 selected_version_str = f"{selected_version:.1f}"
                 image = docker_tag_map[selected_version_str]
                 if clamped_for_volta:
-                    reason = f"{cap_hint} (Volta) + cuda_max_good={original_cuda} → clamped to {cuda_version} → {image}"
+                    reason = f"{cap_hint} (Volta) + cuda_max_good={original_cuda} -> clamped to {cuda_version} -> {image}"
                 elif selected_version_str == cuda_version:
-                    reason = f"{cap_hint}, cuda_max_good={cuda_version} → exact match → {image}"
+                    reason = f"{cap_hint}, cuda_max_good={cuda_version} -> exact match -> {image}"
                 else:
                     reason = (
-                        f"{cap_hint}, cuda_max_good={original_cuda} → "
-                        f"selected newest image <= host CUDA ({selected_version_str}) → {image}"
+                        f"{cap_hint}, cuda_max_good={original_cuda} -> "
+                        f"selected newest image <= host CUDA ({selected_version_str}) -> {image}"
                     )
                 return image, reason
 

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -62,6 +62,7 @@ from vastai.cli.self_test.support_bundle import (
 
 parser = _get_parser()
 SELF_TEST_INSTANCE_LABEL_PREFIX = "vast-self-test-machine"
+INSTANCE_LOG_TAIL_LINES = 1000
 
 
 # ---------------------------------------------------------------------------
@@ -564,22 +565,95 @@ def add__network_disk(args):
 # dump-logs
 # ---------------------------------------------------------------------------
 
+def _diagnostic_error(error):
+    return redact_secret_text(error) or ""
+
+
+def _artifact_text(value):
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, indent=2, sort_keys=True, default=str)
+
+
+def collect_instance_log_artifacts(client, instance_id):
+    files = {}
+    errors = []
+
+    try:
+        instance_info = instances_api.show_instance(client, id=instance_id)
+        files["instance/show-instance.json"] = _artifact_text(instance_info)
+    except Exception as e:
+        errors.append({
+            "artifact": "instance/show-instance.json",
+            "error": _diagnostic_error(e),
+        })
+
+    for archive_name, daemon_logs in (
+        ("instance/container.log", False),
+        ("instance/daemon.log", True),
+    ):
+        try:
+            logs = instances_api.logs(
+                client,
+                instance_id=instance_id,
+                tail=INSTANCE_LOG_TAIL_LINES,
+                daemon_logs=daemon_logs,
+            )
+            files[archive_name] = _artifact_text(logs)
+        except Exception as e:
+            errors.append({
+                "artifact": archive_name,
+                "error": _diagnostic_error(e),
+            })
+
+    return files, errors
+
+
 @parser.command(
     argument("machine_id", help="Machine ID", type=str),
+    argument("--instance-id", help="Instance ID to pull Vast instance logs from", type=int),
     argument("--output-dir", help="Directory for the diagnostic bundle (default: /tmp)", type=str),
-    usage="vastai dump-logs <machine_id> [--output-dir DIR]",
-    help="[Host] Bundle local host diagnostics for support",
+    argument(
+        "--include-local-host-artifacts",
+        action="store_true",
+        help="Include local OS/kaalia artifacts; only use when running on the actual Vast host",
+    ),
+    usage="vastai dump-logs <machine_id> [--instance-id INSTANCE_ID] [--output-dir DIR]",
+    help="[Host] Bundle self-test diagnostics for support",
     epilog=deindent("""
-        Creates a redacted local diagnostic tarball containing kaalia logs,
-        Docker/NVIDIA/system summaries, and other host artifacts support often
-        asks for after a self-test failure.
+        Creates a redacted diagnostic tarball containing CLI-visible self-test
+        evidence. If --instance-id is provided, the command also pulls container
+        and daemon logs from the Vast instance logs API.
+
+        Local OS/kaalia artifacts are only collected with
+        --include-local-host-artifacts. Use that option only when running this
+        command on the actual host machine; from a laptop, it would collect the
+        laptop's logs instead.
 
         Example:
-         vastai dump-logs 12345
+         vastai dump-logs 12345 --instance-id 67890
     """),
 )
 def dump_logs(args):
     run_started_at = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    cli_output = [f"Manual diagnostic bundle requested for machine {args.machine_id}."]
+    extra_files = {}
+    extra_errors = []
+    if args.instance_id:
+        client = get_client(args)
+        cli_output.append(f"Requested Vast instance logs for instance {args.instance_id}.")
+        instance_files, instance_errors = collect_instance_log_artifacts(client, args.instance_id)
+        extra_files.update(instance_files)
+        extra_errors.extend(instance_errors)
+    else:
+        cli_output.append("No --instance-id provided; Vast instance logs were not requested.")
+
+    if not args.include_local_host_artifacts:
+        cli_output.append(
+            "Local host OS/kaalia artifacts were not collected. Use "
+            "--include-local-host-artifacts only when running on the actual host."
+        )
+
     bundle = create_support_bundle(
         machine_id=args.machine_id,
         output_dir=args.output_dir,
@@ -587,12 +661,16 @@ def dump_logs(args):
             "machine_id": args.machine_id,
             "stage": "manual_dump_logs",
             "reason": "Manual diagnostic bundle requested with vastai dump-logs.",
+            "instance_id": args.instance_id,
+            "includes_local_host_artifacts": args.include_local_host_artifacts,
         },
-        cli_output=[f"Manual diagnostic bundle requested for machine {args.machine_id}."],
+        cli_output=cli_output,
+        extra_files=extra_files,
+        extra_errors=extra_errors,
         run_started_at=run_started_at,
         command=sys.argv,
         secrets=[getattr(args, "api_key", None), os.environ.get("VAST_API_KEY")],
-        include_host_logs=True,
+        include_local_host_artifacts=args.include_local_host_artifacts,
     )
     if getattr(args, "raw", False):
         return bundle
@@ -631,6 +709,9 @@ def self_test__machine(args):
     result = base_result(args.machine_id)
     run_started_at = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
     cli_output = []
+    instance_log_files = {}
+    instance_log_errors = []
+    instance_log_collected = set()
     ignore_requirements_warning = (
         "WARNING: --ignore-requirements is set. Requirement checks are skipped as a "
         "pass/fail gate, and passing this self-test does not qualify this machine for verification."
@@ -662,6 +743,21 @@ def self_test__machine(args):
         if args.debugging and not args.raw:
             print(*args_to_print)
 
+    def collect_instance_logs(inst_id):
+        if args.no_support_bundle or not support_bundles_enabled():
+            return
+        if not inst_id or inst_id in instance_log_collected:
+            return
+        instance_log_collected.add(inst_id)
+        files, errors = collect_instance_log_artifacts(client, inst_id)
+        instance_log_files.update(files)
+        instance_log_errors.extend(errors)
+        result["diagnostics"]["instance_log_collection"] = {
+            "instance_id": inst_id,
+            "files": sorted(instance_log_files.keys()),
+            "collection_errors": instance_log_errors,
+        }
+
     def ensure_support_bundle():
         if result.get("success"):
             return None
@@ -669,15 +765,19 @@ def self_test__machine(args):
             return result["diagnostics"]["support_bundle"]
         if args.no_support_bundle or not support_bundles_enabled():
             return None
+        if instance_id:
+            collect_instance_logs(instance_id)
         bundle = create_support_bundle(
             machine_id=args.machine_id,
             output_dir=args.support_bundle_dir,
             result=result,
             cli_output=cli_output,
+            extra_files=instance_log_files,
+            extra_errors=instance_log_errors,
             run_started_at=run_started_at,
             command=sys.argv,
             secrets=[getattr(args, "api_key", None), os.environ.get("VAST_API_KEY")],
-            include_host_logs=True,
+            include_local_host_artifacts=False,
         )
         result["diagnostics"]["support_bundle"] = bundle
         return bundle
@@ -1064,7 +1164,9 @@ def self_test__machine(args):
                         return False
 
                 # ----- helper: destroy instance silently with retries -----
-                def destroy_instance_silent(inst_id):
+                def destroy_instance_silent(inst_id, collect_logs=False):
+                    if collect_logs:
+                        collect_instance_logs(inst_id)
                     max_retries = 10
                     for attempt in range(1, max_retries + 1):
                         try:
@@ -1126,7 +1228,7 @@ def self_test__machine(args):
                                 reason = f"Instance {inst_id} encountered an error: {status_msg_clean}"
                                 progress_print(reason)
                                 if instance_exist(inst_id):
-                                    destroy_instance_silent(inst_id)
+                                    destroy_instance_silent(inst_id, collect_logs=True)
                                     progress_print(f"Instance {inst_id} has been destroyed due to error.")
                                 else:
                                     progress_print(f"Instance {inst_id} could not be destroyed or does not exist.")
@@ -1139,7 +1241,7 @@ def self_test__machine(args):
                                 diagnostic = make_failure(INSTANCE_OFFLINE_BEFORE_TEST, stage="startup")
                                 progress_print(reason)
                                 if instance_exist(inst_id):
-                                    destroy_instance_silent(inst_id)
+                                    destroy_instance_silent(inst_id, collect_logs=True)
                                     progress_print(f"Instance {inst_id} has been destroyed due to being offline.")
                                 else:
                                     progress_print(f"Instance {inst_id} could not be destroyed or does not exist.")
@@ -1161,7 +1263,7 @@ def self_test__machine(args):
                                     )
                                 progress_print(reason)
                                 if instance_exist(inst_id):
-                                    destroy_instance_silent(inst_id)
+                                    destroy_instance_silent(inst_id, collect_logs=True)
                                     progress_print(f"Instance {inst_id} has been destroyed due to startup failure.")
                                 else:
                                     progress_print(f"Instance {inst_id} could not be destroyed or does not exist.")
@@ -1250,7 +1352,7 @@ def self_test__machine(args):
                             if status == 'offline':
                                 reason = "Instance offline during testing"
                                 progress_print(f"Instance {inst_id} went offline. {reason}")
-                                destroy_instance_silent(inst_id)
+                                destroy_instance_silent(inst_id, collect_logs=True)
                                 instance_destroyed = True
                                 return False, reason, make_failure(INSTANCE_OFFLINE_BEFORE_TEST, stage="runtime")
 
@@ -1295,7 +1397,7 @@ def self_test__machine(args):
                                     elif line.startswith('ERROR'):
                                         progress_print(line)
                                         progress_print(f"Test failed with error: {line}.")
-                                        destroy_instance_silent(inst_id)
+                                        destroy_instance_silent(inst_id, collect_logs=True)
                                         instance_destroyed = True
                                         return False, line, diagnostic
                                     else:
@@ -1367,7 +1469,7 @@ def self_test__machine(args):
                                         details=return_reason,
                                         progress_endpoint=endpoint,
                                     )
-                                destroy_instance_silent(inst_id)
+                                destroy_instance_silent(inst_id, collect_logs=True)
                                 instance_destroyed = True
                                 return False, return_reason, diagnostic
 
@@ -1381,7 +1483,7 @@ def self_test__machine(args):
                         )
                     finally:
                         if not instance_destroyed and inst_id and instance_exist(inst_id):
-                            destroy_instance_silent(inst_id)
+                            destroy_instance_silent(inst_id, collect_logs=True)
                         progress_print(f"Machine: {machine_id} Done with testing remote.py results {message}")
                         warnings.simplefilter('default')
 
@@ -1473,6 +1575,8 @@ def self_test__machine(args):
                     info = {}
                 status = (info or {}).get('intended_status') or (info or {}).get('actual_status')
                 if info and status not in ('destroyed', 'terminated', 'offline'):
+                    if not result.get("success"):
+                        collect_instance_logs(instance_id)
                     progress_print(f"Destroying test instance {instance_id} (status: {status})...")
                     instances_api.destroy_instance(client, id=instance_id)
                     progress_print(f"Test instance {instance_id} destroyed.")
@@ -1497,6 +1601,8 @@ def self_test__machine(args):
                 )
 
     if args.raw:
+        if not result.get("success"):
+            ensure_support_bundle()
         return result
     else:
         if result.get("warning"):

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -53,6 +53,11 @@ from vastai.cli.self_test.runtime_diagnostics import (
     make_failure,
     redact_secret_text,
 )
+from vastai.cli.self_test.support_bundle import (
+    create_support_bundle,
+    format_bundle_summary,
+    support_bundles_enabled,
+)
 
 
 parser = _get_parser()
@@ -556,6 +561,46 @@ def add__network_disk(args):
 
 
 # ---------------------------------------------------------------------------
+# dump-logs
+# ---------------------------------------------------------------------------
+
+@parser.command(
+    argument("machine_id", help="Machine ID", type=str),
+    argument("--output-dir", help="Directory for the diagnostic bundle (default: /tmp)", type=str),
+    usage="vastai dump-logs <machine_id> [--output-dir DIR]",
+    help="[Host] Bundle local host diagnostics for support",
+    epilog=deindent("""
+        Creates a redacted local diagnostic tarball containing kaalia logs,
+        Docker/NVIDIA/system summaries, and other host artifacts support often
+        asks for after a self-test failure.
+
+        Example:
+         vastai dump-logs 12345
+    """),
+)
+def dump_logs(args):
+    run_started_at = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    bundle = create_support_bundle(
+        machine_id=args.machine_id,
+        output_dir=args.output_dir,
+        result={
+            "machine_id": args.machine_id,
+            "stage": "manual_dump_logs",
+            "reason": "Manual diagnostic bundle requested with vastai dump-logs.",
+        },
+        cli_output=[f"Manual diagnostic bundle requested for machine {args.machine_id}."],
+        run_started_at=run_started_at,
+        command=sys.argv,
+        secrets=[getattr(args, "api_key", None), os.environ.get("VAST_API_KEY")],
+        include_host_logs=True,
+    )
+    if getattr(args, "raw", False):
+        return bundle
+    for line in format_bundle_summary(bundle):
+        print(line)
+
+
+# ---------------------------------------------------------------------------
 # self-test machine
 # ---------------------------------------------------------------------------
 
@@ -564,6 +609,8 @@ def add__network_disk(args):
     argument("--debugging", action="store_true", help="Enable debugging output"),
     argument("--ignore-requirements", action="store_true", help="Ignore the minimum system requirements and run the self test regardless"),
     argument("--test-image", help="Use a custom self-test image for testing custom self-test images. Overrides VAST_SELF_TEST_IMAGE and CUDA mapping.", type=str),
+    argument("--support-bundle-dir", help="Directory for failure diagnostic bundles (default: /tmp)", type=str),
+    argument("--no-support-bundle", action="store_true", help="Do not create a diagnostic tarball when the self-test fails"),
     usage="vastai self-test machine <machine_id> [--debugging] [--ignore-requirements] [--test-image IMAGE]",
     help="[Host] Perform a self-test on the specified machine",
     epilog=deindent("""
@@ -582,6 +629,8 @@ def self_test__machine(args):
     """
     instance_id = None
     result = base_result(args.machine_id)
+    run_started_at = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    cli_output = []
     ignore_requirements_warning = (
         "WARNING: --ignore-requirements is set. Requirement checks are skipped as a "
         "pass/fail gate, and passing this self-test does not qualify this machine for verification."
@@ -591,24 +640,59 @@ def self_test__machine(args):
         args.debugging = False
     if not hasattr(args, 'test_image'):
         args.test_image = None
+    if not hasattr(args, 'support_bundle_dir'):
+        args.support_bundle_dir = None
+    if not hasattr(args, 'no_support_bundle'):
+        args.no_support_bundle = False
     if getattr(args, "ignore_requirements", False):
         result["warning"] = ignore_requirements_warning
         result["diagnostics"]["requirements_ignored"] = True
 
+    def output_line(*args_to_print):
+        return " ".join(str(item) for item in args_to_print)
+
     def progress_print(*args_to_print):
+        cli_output.append(output_line(*args_to_print))
         if not args.raw:
             print(*args_to_print)
 
     def debug_print(*args_to_print):
+        if args.debugging:
+            cli_output.append(f"DEBUG: {output_line(*args_to_print)}")
         if args.debugging and not args.raw:
             print(*args_to_print)
 
+    def ensure_support_bundle():
+        if result.get("success"):
+            return None
+        if result.get("diagnostics", {}).get("support_bundle"):
+            return result["diagnostics"]["support_bundle"]
+        if args.no_support_bundle or not support_bundles_enabled():
+            return None
+        bundle = create_support_bundle(
+            machine_id=args.machine_id,
+            output_dir=args.support_bundle_dir,
+            result=result,
+            cli_output=cli_output,
+            run_started_at=run_started_at,
+            command=sys.argv,
+            secrets=[getattr(args, "api_key", None), os.environ.get("VAST_API_KEY")],
+            include_host_logs=True,
+        )
+        result["diagnostics"]["support_bundle"] = bundle
+        return bundle
+
     def finish_failure():
         if args.raw:
+            ensure_support_bundle()
             return result
         if result.get("warning"):
             print(result["warning"])
         render_runtime_failure()
+        bundle = ensure_support_bundle()
+        if bundle:
+            for line in format_bundle_summary(bundle):
+                print(line)
         print(f"Test failed: {result['reason']}")
         sys.exit(1)
 
@@ -626,19 +710,19 @@ def self_test__machine(args):
         diagnostic = result.get("diagnostics", {}).get("runtime_failure")
         if not diagnostic:
             return
-        print("Runtime failure diagnostics:")
-        print(f"- code: {diagnostic.get('code')}")
+        progress_print("Runtime failure diagnostics:")
+        progress_print(f"- code: {diagnostic.get('code')}")
         if diagnostic.get("summary"):
-            print(f"- summary: {diagnostic['summary']}")
+            progress_print(f"- summary: {diagnostic['summary']}")
         if diagnostic.get("underlying_error"):
-            print(f"- underlying error: {diagnostic['underlying_error']}")
+            progress_print(f"- underlying error: {diagnostic['underlying_error']}")
         endpoint = diagnostic.get("progress_endpoint") or result.get("diagnostics", {}).get("progress_endpoint")
         if endpoint:
             if endpoint.get("url"):
-                print(f"- tried: {endpoint['url']}")
+                progress_print(f"- tried: {endpoint['url']}")
             external_port = endpoint.get("external_port") or endpoint.get("host_port")
             if external_port:
-                print(f"- external port tested: {external_port}")
+                progress_print(f"- external port tested: {external_port}")
             last_bits = []
             if endpoint.get("last_status_code") is not None:
                 last_bits.append(f"HTTP {endpoint['last_status_code']}")
@@ -647,16 +731,16 @@ def self_test__machine(args):
             if endpoint.get("last_error"):
                 last_bits.append(str(endpoint["last_error"]))
             if last_bits:
-                print(f"- last result: {' - '.join(last_bits)}")
+                progress_print(f"- last result: {' - '.join(last_bits)}")
             if endpoint.get("mapped_ports"):
-                print(f"- mapped container ports: {', '.join(endpoint['mapped_ports'])}")
+                progress_print(f"- mapped container ports: {', '.join(endpoint['mapped_ports'])}")
         if diagnostic.get("remediation"):
-            print(f"- remediation: {diagnostic['remediation']}")
+            progress_print(f"- remediation: {diagnostic['remediation']}")
         steps = diagnostic.get("suggested_steps") or []
         if steps:
-            print("- suggested steps:")
+            progress_print("- suggested steps:")
             for step in steps:
-                print(f"  - {step}")
+                progress_print(f"  - {step}")
 
     client = get_client(args)
 
@@ -1426,5 +1510,9 @@ def self_test__machine(args):
             sys.exit(0)
         else:
             render_runtime_failure()
+            bundle = ensure_support_bundle()
+            if bundle:
+                for line in format_bundle_summary(bundle):
+                    print(line)
             print(f"Test failed: {result['reason']}")
             sys.exit(1)

--- a/vastai/cli/self_test/support_bundle.py
+++ b/vastai/cli/self_test/support_bundle.py
@@ -1,0 +1,271 @@
+"""Support bundle helpers for host self-test failures."""
+
+from __future__ import annotations
+
+import json
+import io
+import os
+import re
+import subprocess
+import tarfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from vastai.cli.self_test.runtime_diagnostics import redact_secret_text
+
+
+DEFAULT_BUNDLE_DIR = "/tmp"
+MAX_TEXT_BYTES = 256 * 1024
+MAX_LOG_BYTES = 256 * 1024
+MAX_COMMAND_SECONDS = 10
+SENSITIVE_KEY_RE = re.compile(
+    r"(api[_-]?key|token|secret|password|passwd|authorization|jupyter_token|instance_api_key|host_port_range)",
+    re.IGNORECASE,
+)
+SENSITIVE_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(api[_-]?key|token|secret|password|passwd|authorization|jupyter_token|instance_api_key|host_port_range)"
+    r"\b\s*[:=]\s*([^\s,;]+)"
+)
+DMESG_KEYWORDS_RE = re.compile(r"\b(warn|warning|err|error|fail|fault|crit|panic|oops|bug)\b", re.IGNORECASE)
+
+
+def utc_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def support_bundles_enabled() -> bool:
+    value = os.environ.get("VAST_SELF_TEST_SUPPORT_BUNDLE", "")
+    return value.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _safe_machine_id(machine_id: object) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", str(machine_id or "unknown"))[:80]
+
+
+def _redact_text(text: object, secrets: list[str] | None = None) -> str:
+    redacted = redact_secret_text("" if text is None else str(text)) or ""
+    for secret in secrets or []:
+        if secret:
+            redacted = redacted.replace(str(secret), "REDACTED")
+    return SENSITIVE_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}=REDACTED", redacted)
+
+
+def _redact_json(value: Any, secrets: list[str] | None = None) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): "REDACTED" if SENSITIVE_KEY_RE.search(str(key)) else _redact_json(item, secrets)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_json(item, secrets) for item in value]
+    if isinstance(value, str):
+        return _redact_text(value, secrets)
+    return value
+
+
+def _truncate_text(text: str, max_bytes: int) -> str:
+    encoded = text.encode("utf-8", errors="replace")
+    if len(encoded) <= max_bytes:
+        return text
+    tail = encoded[-max_bytes:].decode("utf-8", errors="replace")
+    return f"[truncated to last {max_bytes} bytes]\n{tail}"
+
+
+def _decode_bytes(data: bytes) -> str:
+    return data.decode("utf-8", errors="replace")
+
+
+def _read_file_tail(path: Path, max_bytes: int) -> str:
+    size = path.stat().st_size
+    with path.open("rb") as handle:
+        if size > max_bytes:
+            handle.seek(-max_bytes, os.SEEK_END)
+        data = handle.read()
+    text = _decode_bytes(data)
+    if size > max_bytes:
+        return f"[truncated from {size} bytes to last {max_bytes} bytes]\n{text}"
+    return text
+
+
+def _run_command(args: list[str], *, timeout: int = MAX_COMMAND_SECONDS) -> tuple[str, str | None]:
+    try:
+        proc = subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False)
+    except FileNotFoundError:
+        return "", f"command not found: {args[0]}"
+    except subprocess.TimeoutExpired:
+        return "", f"command timed out after {timeout}s: {' '.join(args)}"
+    output = proc.stdout or ""
+    if proc.stderr:
+        output = f"{output}\n[stderr]\n{proc.stderr}".strip()
+    error = None
+    if proc.returncode != 0:
+        error = f"command exited {proc.returncode}: {' '.join(args)}"
+    return output, error
+
+
+def _summarize_ss_output(text: str) -> str:
+    lines = [line for line in text.splitlines() if line.strip()]
+    if not lines:
+        return ""
+    summarized = []
+    for idx, line in enumerate(lines):
+        parts = line.split()
+        if idx == 0 and parts:
+            summarized.append(" ".join(parts[:5]))
+            continue
+        if len(parts) >= 5:
+            summarized.append(" ".join(parts[:5]))
+        else:
+            summarized.append(line)
+    return "\n".join(summarized)
+
+
+def _collect_host_artifacts(secrets: list[str] | None = None) -> tuple[dict[str, str], list[dict[str, str]]]:
+    files: dict[str, str] = {}
+    errors: list[dict[str, str]] = []
+
+    for path in sorted(Path("/var/lib/vastai_kaalia").glob("kaalia.log*")):
+        if not path.is_file():
+            continue
+        archive_name = f"host/kaalia/{path.name}"
+        try:
+            files[archive_name] = _redact_text(_read_file_tail(path, MAX_LOG_BYTES), secrets)
+        except Exception as exc:
+            errors.append({"artifact": archive_name, "error": _redact_text(exc, secrets)})
+
+    daemon_json = Path("/etc/docker/daemon.json")
+    if daemon_json.exists():
+        try:
+            files["host/etc-docker-daemon.json"] = _redact_text(_read_file_tail(daemon_json, MAX_TEXT_BYTES), secrets)
+        except Exception as exc:
+            errors.append({"artifact": "host/etc-docker-daemon.json", "error": _redact_text(exc, secrets)})
+    else:
+        errors.append({"artifact": "host/etc-docker-daemon.json", "error": "file not found"})
+
+    command_specs = [
+        ("host/dmesg-filtered.log", ["dmesg", "-T"], "dmesg"),
+        (
+            "host/journalctl-docker-vastai_kaalia.log",
+            ["journalctl", "-b", "-p", "err..alert", "-u", "docker", "-u", "vastai_kaalia", "--since", "-24h", "--no-pager"],
+            "journalctl",
+        ),
+        ("host/nvidia-smi.txt", ["nvidia-smi"], "nvidia-smi"),
+        ("host/nvidia-smi-L.txt", ["nvidia-smi", "-L"], "nvidia-smi -L"),
+        ("host/docker-info.txt", ["docker", "info"], "docker info"),
+        ("host/ip-addr.txt", ["ip", "addr"], "ip addr"),
+        ("host/ss-tlnp-summary.txt", ["ss", "-tlnp"], "ss -tlnp summary"),
+    ]
+
+    for archive_name, command, label in command_specs:
+        output, error = _run_command(command)
+        if archive_name == "host/dmesg-filtered.log":
+            output = "\n".join(line for line in output.splitlines() if DMESG_KEYWORDS_RE.search(line))
+        elif archive_name == "host/ss-tlnp-summary.txt":
+            output = _summarize_ss_output(output)
+        files[archive_name] = _truncate_text(_redact_text(output, secrets), MAX_TEXT_BYTES)
+        if error:
+            errors.append({"artifact": label, "error": _redact_text(error, secrets)})
+
+    mounts = Path("/proc/mounts")
+    if mounts.exists():
+        try:
+            mount_lines = [
+                line for line in _read_file_tail(mounts, MAX_TEXT_BYTES).splitlines()
+                if "/var/lib/docker" in line
+            ]
+            files["host/docker-mounts.txt"] = _redact_text("\n".join(mount_lines), secrets)
+        except Exception as exc:
+            errors.append({"artifact": "host/docker-mounts.txt", "error": _redact_text(exc, secrets)})
+    else:
+        errors.append({"artifact": "host/docker-mounts.txt", "error": "/proc/mounts not found"})
+
+    return files, errors
+
+
+def create_support_bundle(
+    *,
+    machine_id: object,
+    output_dir: str | None = None,
+    result: dict[str, Any] | None = None,
+    cli_output: list[str] | None = None,
+    extra_files: dict[str, str] | None = None,
+    run_started_at: str | None = None,
+    command: list[str] | None = None,
+    secrets: list[str] | None = None,
+    include_host_logs: bool = True,
+) -> dict[str, Any]:
+    """Create a redacted host/self-test support tarball and return metadata."""
+
+    created_at = utc_timestamp()
+    safe_id = _safe_machine_id(machine_id)
+    bundle_dir = Path(output_dir or DEFAULT_BUNDLE_DIR).expanduser()
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    bundle_path = bundle_dir / f"vast_selftest_{safe_id}_{created_at}.tar.gz"
+
+    files: dict[str, str] = {}
+    errors: list[dict[str, str]] = []
+    if cli_output:
+        files["self-test-output.log"] = _redact_text("\n".join(cli_output), secrets)
+    if result is not None:
+        files["self-test-result.json"] = json.dumps(_redact_json(result, secrets), indent=2, sort_keys=True)
+    if extra_files:
+        for name, content in extra_files.items():
+            files[name] = _redact_text(content, secrets)
+    if include_host_logs:
+        host_files, host_errors = _collect_host_artifacts(secrets)
+        files.update(host_files)
+        errors.extend(host_errors)
+
+    manifest = {
+        "bundle_version": 1,
+        "machine_id": str(machine_id),
+        "created_at_utc": created_at,
+        "run_started_at_utc": run_started_at,
+        "command": _redact_json(command or [], secrets),
+        "max_text_bytes_per_artifact": MAX_TEXT_BYTES,
+        "max_log_bytes_per_artifact": MAX_LOG_BYTES,
+        "files": sorted(files.keys()) + ["manifest.json", "collection-errors.json"],
+        "collection_errors": errors,
+        "note": "Review contents before sharing with Vast support.",
+    }
+    files["manifest.json"] = json.dumps(manifest, indent=2, sort_keys=True)
+    files["collection-errors.json"] = json.dumps(errors, indent=2, sort_keys=True)
+
+    with tarfile.open(bundle_path, "w:gz") as tar:
+        for name, content in sorted(files.items()):
+            safe_name = re.sub(r"(^/|\\.\\.|\\\\)", "_", name)
+            data = _truncate_text(content, MAX_LOG_BYTES).encode("utf-8", errors="replace")
+            info = tarfile.TarInfo(safe_name)
+            info.size = len(data)
+            info.mtime = int(time.time())
+            tar.addfile(info, fileobj=io.BytesIO(data))
+
+    size_bytes = bundle_path.stat().st_size
+    return {
+        "path": str(bundle_path),
+        "created_at_utc": created_at,
+        "size_bytes": size_bytes,
+        "files": sorted(files.keys()),
+        "collection_errors": errors,
+    }
+
+
+def format_bundle_summary(bundle: dict[str, Any]) -> list[str]:
+    lines = [
+        "Self-test diagnostic bundle saved to:",
+        f"  {bundle.get('path')}",
+        "Bundle contents:",
+    ]
+    for name in bundle.get("files", []):
+        lines.append(f"  - {name}")
+    errors = bundle.get("collection_errors") or []
+    if errors:
+        lines.append("Some host artifacts could not be collected:")
+        for item in errors[:10]:
+            lines.append(f"  - {item.get('artifact')}: {item.get('error')}")
+        if len(errors) > 10:
+            lines.append(f"  - ... {len(errors) - 10} more")
+    lines.append("Review this tarball before sharing it with support.")
+    return lines

--- a/vastai/cli/self_test/support_bundle.py
+++ b/vastai/cli/self_test/support_bundle.py
@@ -191,12 +191,17 @@ def create_support_bundle(
     result: dict[str, Any] | None = None,
     cli_output: list[str] | None = None,
     extra_files: dict[str, str] | None = None,
+    extra_errors: list[dict[str, str]] | None = None,
     run_started_at: str | None = None,
     command: list[str] | None = None,
     secrets: list[str] | None = None,
-    include_host_logs: bool = True,
+    include_local_host_artifacts: bool = False,
+    include_host_logs: bool | None = None,
 ) -> dict[str, Any]:
-    """Create a redacted host/self-test support tarball and return metadata."""
+    """Create a redacted self-test support tarball and return metadata."""
+
+    if include_host_logs is not None:
+        include_local_host_artifacts = include_host_logs
 
     created_at = utc_timestamp()
     safe_id = _safe_machine_id(machine_id)
@@ -213,7 +218,9 @@ def create_support_bundle(
     if extra_files:
         for name, content in extra_files.items():
             files[name] = _redact_text(content, secrets)
-    if include_host_logs:
+    if extra_errors:
+        errors.extend(_redact_json(extra_errors, secrets))
+    if include_local_host_artifacts:
         host_files, host_errors = _collect_host_artifacts(secrets)
         files.update(host_files)
         errors.extend(host_errors)
@@ -226,9 +233,15 @@ def create_support_bundle(
         "command": _redact_json(command or [], secrets),
         "max_text_bytes_per_artifact": MAX_TEXT_BYTES,
         "max_log_bytes_per_artifact": MAX_LOG_BYTES,
+        "includes_local_host_artifacts": include_local_host_artifacts,
         "files": sorted(files.keys()) + ["manifest.json", "collection-errors.json"],
         "collection_errors": errors,
-        "note": "Review contents before sharing with Vast support.",
+        "note": (
+            "This bundle contains CLI-visible self-test evidence. Host OS artifacts "
+            "are included only when includes_local_host_artifacts=true; otherwise "
+            "host daemon/kaalia/system logs need host-side daemon/backend collection "
+            "or an explicit dump run on the actual host."
+        ),
     }
     files["manifest.json"] = json.dumps(manifest, indent=2, sort_keys=True)
     files["collection-errors.json"] = json.dumps(errors, indent=2, sort_keys=True)
@@ -262,7 +275,7 @@ def format_bundle_summary(bundle: dict[str, Any]) -> list[str]:
         lines.append(f"  - {name}")
     errors = bundle.get("collection_errors") or []
     if errors:
-        lines.append("Some host artifacts could not be collected:")
+        lines.append("Some artifacts could not be collected:")
         for item in errors[:10]:
             lines.append(f"  - {item.get('artifact')}: {item.get('error')}")
         if len(errors) > 10:

--- a/vastai/cli/self_test/support_bundle.py
+++ b/vastai/cli/self_test/support_bundle.py
@@ -20,6 +20,7 @@ DEFAULT_BUNDLE_DIR = "/tmp"
 MAX_TEXT_BYTES = 256 * 1024
 MAX_LOG_BYTES = 256 * 1024
 MAX_COMMAND_SECONDS = 10
+JSON_ARTIFACT_RE = re.compile(r"(^|/)[^/]+\.json$")
 SENSITIVE_KEY_RE = re.compile(
     r"(api[_-]?key|token|secret|password|passwd|authorization|jupyter_token|instance_api_key|host_port_range)",
     re.IGNORECASE,
@@ -103,6 +104,10 @@ def _run_command(args: list[str], *, timeout: int = MAX_COMMAND_SECONDS) -> tupl
     if proc.returncode != 0:
         error = f"command exited {proc.returncode}: {' '.join(args)}"
     return output, error
+
+
+def _safe_archive_name(name: str) -> str:
+    return re.sub(r"(^/+|\.\.|\\)", "_", name)
 
 
 def _summarize_ss_output(text: str) -> str:
@@ -248,12 +253,14 @@ def create_support_bundle(
 
     with tarfile.open(bundle_path, "w:gz") as tar:
         for name, content in sorted(files.items()):
-            safe_name = re.sub(r"(^/|\\.\\.|\\\\)", "_", name)
-            data = _truncate_text(content, MAX_LOG_BYTES).encode("utf-8", errors="replace")
+            safe_name = _safe_archive_name(name)
+            artifact_text = content if JSON_ARTIFACT_RE.search(name) else _truncate_text(content, MAX_LOG_BYTES)
+            data = artifact_text.encode("utf-8", errors="replace")
             info = tarfile.TarInfo(safe_name)
             info.size = len(data)
             info.mtime = int(time.time())
             tar.addfile(info, fileobj=io.BytesIO(data))
+    os.chmod(bundle_path, 0o600)
 
     size_bytes = bundle_path.stat().st_size
     return {

--- a/vastai/cli/util.py
+++ b/vastai/cli/util.py
@@ -120,7 +120,7 @@ CACHE_FILE = os.path.join(DIRS['temp'], "gpu_names_cache.json")
 CACHE_DURATION = timedelta(hours=24)
 
 
-def _get_gpu_names() -> List[str]:
+def _get_gpu_names() -> Optional[List[str]]:
     """Returns a set of GPU names available on Vast.ai, with results cached for 24 hours."""
 
     def is_cache_valid() -> bool:
@@ -131,21 +131,32 @@ def _get_gpu_names() -> List[str]:
         return cache_age < CACHE_DURATION
 
     if is_cache_valid():
-        with open(CACHE_FILE, "r") as file:
-            gpu_names = json.load(file)
+        try:
+            with open(CACHE_FILE, "r") as file:
+                gpu_names = json.load(file)
+        except (OSError, json.JSONDecodeError):
+            gpu_names = None
     else:
         endpoint = "/api/v0/gpu_names/unique/"
         url = f"{server_url_default}{endpoint}"
-        r = requests.get(url, headers={})
-        r.raise_for_status()  # Will raise an exception for HTTP errors
-        gpu_names = r.json()
-        with open(CACHE_FILE, "w") as file:
-            json.dump(gpu_names, file)
+        try:
+            r = requests.get(url, headers={})
+            r.raise_for_status()
+            gpu_names = r.json()
+        except (requests.exceptions.RequestException, ValueError):
+            return None
+        try:
+            with open(CACHE_FILE, "w") as file:
+                json.dump(gpu_names, file)
+        except OSError:
+            pass
 
-    formatted_gpu_names = [
-        name.replace(" ", "_").replace("-", "_") for name in gpu_names['gpu_names']
-    ]
-    return formatted_gpu_names
+    try:
+        return [
+            name.replace(" ", "_").replace("-", "_") for name in gpu_names['gpu_names']
+        ]
+    except (TypeError, KeyError):
+        return None
 
 
 APIKEY_FILE = os.path.join(DIRS['config'], "vast_api_key")


### PR DESCRIPTION
## Summary

Implements CON-1519 support-bundle handoff for host self-test failures.

This PR adds:
- automatic diagnostic bundle creation on `vastai self-test machine <machine_id>` failure;
- clear console output showing the tarball path and bundle contents before sharing;
- `vastai dump-logs <machine_id>` for on-demand bundle creation;
- redaction for API keys, tokens, secrets, authorization fields, `instance_api_key`, `jupyter_token`, and `host_port_range` style values;
- per-artifact truncation to keep bundles small;
- raw diagnostics support via `result["diagnostics"]["support_bundle"]`;
- `--support-bundle-dir` and `--no-support-bundle` controls;
- `VAST_SELF_TEST_SUPPORT_BUNDLE=0` escape hatch for tests/automation.

## Bundle Contents

The bundle includes the self-test output/result plus best-effort local host artifacts:
- `/var/lib/vastai_kaalia/kaalia.log*` rotations, truncated/redacted;
- filtered `dmesg -T` output;
- `journalctl -b -p err..alert -u docker -u vastai_kaalia --since -24h`;
- `/etc/docker/daemon.json`;
- `nvidia-smi` and `nvidia-smi -L`;
- `docker info`;
- `/proc/mounts` entries for `/var/lib/docker`;
- `ip addr`;
- summarized `ss -tlnp` output without the process column.

Unavailable artifacts are recorded in `collection-errors.json` and shown in the console summary.

## Validation

Local tests:
- `uv run --with pycryptodome --with pytest --with pytest-mock python -m pytest tests/cli/test_self_test_support_bundle.py tests/cli/test_machines_commands.py -q`
  - 51 passed
- `uv run --with pycryptodome --with pytest --with pytest-mock python -m pytest tests/cli -q`
  - 295 passed
- `git diff --check`
  - clean

Local smoke:
- `vastai dump-logs 42 --output-dir <tmp>` created a tarball, printed the contents, and the tarball opened successfully.
- `vastai self-test machine 56732 --support-bundle-dir <tmp>` failed in preflight with no rental, automatically wrote a bundle, printed the bundle path/contents, and the tarball opened successfully.

## Stack / Merge Note

This is stacked on #409 because CON-1519 builds on the current self-test diagnostics branch. Merge/rebase this after #409 lands.
