### PR TITLE
AUTO-1418: update CLI benchmark fields to new schema

### DIFF
--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -192,7 +192,11 @@ class TestFieldSets:
 
     def test_benchmarks_fields_not_empty(self):
         assert len(benchmarks_fields) > 0
-        assert "score" in benchmarks_fields
+        assert "value" in benchmarks_fields
+        assert "template_hash" in benchmarks_fields
+        # AUTO-1418 renamed these away; they must not linger as real columns.
+        assert "score" not in benchmarks_fields
+        assert "name" not in benchmarks_fields
 
     def test_templates_fields_not_empty(self):
         assert len(templates_fields) > 0

--- a/vastai/api/query.py
+++ b/vastai/api/query.py
@@ -184,14 +184,17 @@ offers_mult = {
 
 benchmarks_fields = {
     "contract_id",#             int        ID of instance/contract reporting benchmark
+    "gpu_name",#                string     GPU model benchmarked (e.g. RTX_4090)
     "id",#                      int        benchmark unique ID
     "image",#                   string     image used for benchmark
     "last_update",#             float      date of benchmark
+    "launch_args",#             string     launch args of the benchmarked worker
     "machine_id",#              int        id of machine benchmarked
-    "model",#                   string     name of model used in benchmark
-    "name",#                    string     name of benchmark
     "num_gpus",#                int        number of gpus used in benchmark
-    "score"#                   float      benchmark score result
+    "template_hash",#           string     hash of the template benchmarked (formerly 'name')
+    "template_id",#             int        id of the template benchmarked
+    "type",#                    string     benchmark type
+    "value",#                   float      benchmark result (formerly 'score')
 }
 
 invoices_fields = {

--- a/vastai/cli/commands/offers.py
+++ b/vastai/cli/commands/offers.py
@@ -4,7 +4,7 @@ import json
 import time
 
 from vastai.cli.parser import argument, hidden_aliases
-from vastai.cli.display import display_table, displayable_fields, displayable_fields_reserved, deindent
+from vastai.cli.display import display_table, displayable_fields, displayable_fields_reserved, benchmarks_displayable_fields, deindent
 from vastai.api import offers as offers_api
 
 
@@ -222,22 +222,25 @@ def search__offers(args):
 
         Examples:
 
-            # search for benchmarks with score > 100 for llama2_70B model on 2 specific machines
-            vastai search benchmarks 'score > 100.0  model=llama2_70B  machine_id in [302,402]'
+            # search for benchmarks with value > 100 on RTX 4090s for 2 specific machines
+            vastai search benchmarks 'value > 100.0  gpu_name=RTX_4090  machine_id in [302,402]'
 
         Available fields:
 
               Name                  Type       Description
 
             contract_id             int        ID of instance/contract reporting benchmark
+            gpu_name                string     GPU model benchmarked (e.g. RTX_4090)
             id                      int        benchmark unique ID
             image                   string     image used for benchmark
             last_update             float      date of benchmark
+            launch_args             string     launch args of the benchmarked worker
             machine_id              int        id of machine benchmarked
-            model                   string     name of model used in benchmark
-            name                    string     name of benchmark
             num_gpus                int        number of gpus used in benchmark
-            score                   float      benchmark score result
+            template_hash           string     hash of the template benchmarked (formerly 'name')
+            template_id             int        id of the template benchmarked
+            type                    string     benchmark type
+            value                   float      benchmark result (formerly 'score')
     """),
     aliases=hidden_aliases(["search benchmarks"]),
 )
@@ -260,7 +263,7 @@ def search__benchmarks(args):
     rows = offers_api.search_benchmarks(client, query=query)
     if args.raw:
         return rows
-    display_table(rows, displayable_fields)
+    display_table(rows, benchmarks_displayable_fields)
 
 
 # ---------------------------------------------------------------------------

--- a/vastai/cli/display.py
+++ b/vastai/cli/display.py
@@ -149,6 +149,21 @@ nw_vol_displayable_fields = (
 
 )
 
+# These fields are displayed for 'search benchmarks' (benchmarks table, AUTO-1418 schema)
+benchmarks_displayable_fields = (
+    ("id", "ID", "{}", None, True),
+    ("machine_id", "mach_id", "{}", None, True),
+    ("gpu_name", "Model", "{}", None, True),
+    ("num_gpus", "N", "{}x", None, False),
+    ("value", "Value", "{:0.2f}", None, True),
+    ("type", "Type", "{}", None, True),
+    ("template_hash", "Template", "{}", None, True),
+    ("template_id", "Templ_ID", "{}", None, True),
+    ("contract_id", "contract", "{}", None, True),
+    ("image", "Image", "{}", None, True),
+    ("last_update", "Date", "{}", lambda x: datetime.fromtimestamp(x, timezone.utc).strftime("%Y-%m-%d %H:%M"), True),
+)
+
 # These fields are displayed when you do 'show instances'
 instance_fields = (
     ("id", "ID", "{}", None, True),


### PR DESCRIPTION
since we renamed some benchmark columns and added new ones,  need to update `search benchmarks`
