### PR TITLE
fix(AUTO-959): shared util moved to set up for GA4 analytics tracking for created_endpoint through the sdk flow

### DIFF
--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 from unittest.mock import patch, MagicMock
 from vastai.api.client import VastClient
+from vastai.utils import VERSION
 
 
 class TestBuildUrl:
@@ -57,10 +58,20 @@ class TestBuildHeaders:
         h = c._build_headers()
         assert h["Authorization"] == "Bearer mykey"
 
-    def test_empty_when_no_key(self):
+    def test_no_auth_when_no_key(self):
         c = VastClient(api_key=None)
         h = c._build_headers()
-        assert h == {}
+        assert "Authorization" not in h
+
+    def test_user_agent_defaults_to_sdk(self):
+        c = VastClient(api_key=None)
+        h = c._build_headers()
+        assert h["User-Agent"] == f"vastai-sdk/{VERSION}"
+
+    def test_user_agent_client_type(self):
+        c = VastClient(api_key=None, client_type="cli")
+        h = c._build_headers()
+        assert h["User-Agent"] == f"vastai-cli/{VERSION}"
 
 
 class TestHttpMethods:

--- a/vastai/_base.py
+++ b/vastai/_base.py
@@ -1,6 +1,8 @@
 import os
 from typing import Optional
 
+from vastai.utils import VERSION
+
 _APIKEY_SENTINEL = object()
 
 def _resolve_api_key(api_key: object) -> str:
@@ -45,7 +47,7 @@ class _BaseClient:
         self._vast_server = vast_server.rstrip("/")
 
     def _headers(self) -> dict:
-        return {"Authorization": f"Bearer {self._api_key}"}
+        return {"Authorization": f"Bearer {self._api_key}", "User-Agent": f"vastai-sdk/{VERSION}"}
 
     def _url(self, path: str) -> str:
         return f"{self._vast_server}{path}"

--- a/vastai/api/client.py
+++ b/vastai/api/client.py
@@ -9,6 +9,8 @@ import requests
 from urllib.parse import quote_plus
 from typing import Dict, Optional
 
+from vastai.utils import VERSION
+
 try:
     import curlify
 except ImportError:
@@ -42,13 +44,14 @@ class VastClient:
     """HTTP client for Vast.ai API requests."""
 
     def __init__(self, api_key=None, server_url=None, retry=3, explain=False, curl=False,
-                 timeout=_DEFAULT_TIMEOUT_SECONDS):
+                 timeout=_DEFAULT_TIMEOUT_SECONDS, client_type="sdk"):
         self.api_key = api_key
         self.server_url = server_url or server_url_default
         self.retry = retry
         self.explain = explain
         self.curl = curl
         self.timeout = timeout
+        self.user_agent = f"vastai-{client_type}/{VERSION}"
 
     def _build_url(self, subpath: str, query_args: Optional[Dict] = None) -> str:
         """Build full API URL from subpath and optional query args."""
@@ -79,7 +82,7 @@ class VastClient:
 
     def _build_headers(self) -> Dict:
         """Build request headers with auth."""
-        result = {}
+        result = {"User-Agent": self.user_agent}
         if self.api_key is not None:
             result["Authorization"] = "Bearer " + self.api_key
         return result

--- a/vastai/cli/util.py
+++ b/vastai/cli/util.py
@@ -16,7 +16,6 @@ import time
 import math
 import subprocess
 import shutil
-import importlib.metadata
 import requests
 import getpass
 from pathlib import Path
@@ -26,6 +25,7 @@ from typing import Dict, List, Optional
 
 # Re-export string_to_unix_epoch so CLI command modules can import from here
 from vastai.api.query import string_to_unix_epoch  # noqa: F401
+from vastai.utils import VERSION, parse_version  # noqa: F401
 
 
 # Server URL default — canonical definition lives in api/client.py
@@ -36,45 +36,10 @@ api_key_guard = object()
 
 
 # ---------------------------------------------------------------------------
-# Version helpers (for --version output only)
-# ---------------------------------------------------------------------------
-
-def parse_version(version: str) -> tuple:
-    parts = version.split(".")
-
-    if len(parts) < 3:
-        print(f"Invalid version format: {version}", file=sys.stderr)
-
-    return tuple(int(part) for part in parts)
-
-
-def _get_git_version():
-    try:
-        result = subprocess.run(
-            ["git", "describe", "--tags", "--abbrev=0"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        tag = result.stdout.strip()
-        return tag[1:] if tag.startswith("v") else tag
-    except Exception:
-        return "0.0.0"
-
-
-def _get_local_version():
-    try:
-        return importlib.metadata.version("vastai")
-    except Exception:
-        return _get_git_version()
-
-
-# ---------------------------------------------------------------------------
 # App constants
 # ---------------------------------------------------------------------------
 
 APP_NAME = "vastai"
-VERSION = _get_local_version()
 
 # Define emoji support and fallbacks
 _HAS_EMOJI = sys.stdout.encoding and 'utf' in sys.stdout.encoding.lower()

--- a/vastai/cli/utils.py
+++ b/vastai/cli/utils.py
@@ -15,4 +15,5 @@ def get_client(args):
         retry=args.retry,
         explain=getattr(args, 'explain', False),
         curl=getattr(args, 'curl', False),
+        client_type="cli",
     )

--- a/vastai/serverless/client/connection.py
+++ b/vastai/serverless/client/connection.py
@@ -5,6 +5,8 @@ import random
 import json
 from typing import AsyncIterator, Dict, Optional, Any
 
+from vastai.utils import VERSION
+
 _JITTER_CAP_SECONDS = 5.0
 
 def _retryable(status: int) -> bool:
@@ -115,7 +117,7 @@ async def _make_request(
     params = {**(params or {})}
     params["api_key"] = api_key
 
-    headers = {"Authorization": f"Bearer {api_key}"}
+    headers = {"Authorization": f"Bearer {api_key}", "User-Agent": f"vastai-sdk/{VERSION}"}
 
     session = await client._get_session()
     ssl_context = await client.get_ssl_context() if client else None

--- a/vastai/utils.py
+++ b/vastai/utils.py
@@ -8,6 +8,8 @@ import sys
 import time
 import math
 import argparse
+import subprocess
+import importlib.metadata
 from datetime import datetime, timedelta, timezone
 from concurrent.futures import ThreadPoolExecutor
 
@@ -23,6 +25,30 @@ def parse_version(version: str) -> tuple:
         print(f"Invalid version format: {version}", file=sys.stderr)
 
     return tuple(int(part) for part in parts)
+
+
+def _get_git_version():
+    try:
+        result = subprocess.run(
+            ["git", "describe", "--tags", "--abbrev=0"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        tag = result.stdout.strip()
+        return tag[1:] if tag.startswith("v") else tag
+    except Exception:
+        return "0.0.0"
+
+
+def _get_local_version():
+    try:
+        return importlib.metadata.version("vastai")
+    except Exception:
+        return _get_git_version()
+
+
+VERSION = _get_local_version()
 
 
 # ---------------------------------------------------------------------------

--- a/vastai/utils.py
+++ b/vastai/utils.py
@@ -4,6 +4,7 @@ Generic helpers that are not specific to any single layer (CLI, API, SDK).
 """
 
 import re
+import os
 import sys
 import time
 import math
@@ -34,6 +35,7 @@ def _get_git_version():
             capture_output=True,
             text=True,
             check=True,
+            cwd=os.path.dirname(__file__),
         )
         tag = result.stdout.strip()
         return tag[1:] if tag.startswith("v") else tag


### PR DESCRIPTION
## What

All HTTP clients in the package now send an identifying `User-Agent` header on every request to the console API:

- SDK surfaces (`VastAI`, serverless client, `SyncClient`/`AsyncClient`): `vastai-sdk/<version>`
- CLI (`vastai` command): `vastai-cli/<version>`

## Why

The webserver emits a GA4 `created_endpoint` event when an endpoint is created, with a
`source` param telling us where it came from. Detection was cookie-based ("no cookies = CLI"),
so SDK, CLI, and curl traffic were indistinguishable — everything reported as `CLI`, and there
was no way to track SDK adoption. This pairs with a server-side change (AUTO-959) that reads
these UA prefixes to label `source` as `SDK` / `CLI` / `UI`.

Versioned UAs also let us slice analytics by client version later (e.g. measuring upgrade lag).

## How

- `VastClient` gains a `client_type` kwarg (default `"sdk"`); the CLI's `get_client()` passes
  `"cli"`. Needed because both layers share the same HTTP client.
- The serverless async client (`_make_request`) and `_BaseClient` (sync/async instance clients)
  send the SDK UA unconditionally — they have no CLI entry point.
- `_get_git_version` / `_get_local_version` / `VERSION` moved from `vastai/cli/util.py` to
  `vastai/utils.py` so the API layer can import the version without a circular import
  (`cli/util.py` imports from `api/client.py`). `cli/util.py` re-exports them, so `--version`
  and existing imports are unchanged.

## Compatibility

- No behavior change for any API call — requests just carry one extra header.
- Old SDK/CLI versions in the wild keep being labeled `CLI` server-side via the existing
  cookie heuristic; labels improve as clients upgrade.

## Testing

- Full unit suite passes (381 passed).
- Replaced `test_empty_when_no_key` (headers are never empty now) with assertions for the
  no-auth case and both `client_type` UA variants.
- Verified against a local webserver: endpoint creation with the new headers logs GA4 events
  with `source: "SDK"` / `source: "CLI"` respectively.