### PR TITLE
feat(cli): curl|bash installer with vastai update self-update (dark l…

### DIFF
--- a/docs/install-design.md
+++ b/docs/install-design.md
@@ -1,0 +1,334 @@
+# Design: `curl | bash` Installer for the Vast CLI
+
+```
+curl -fsSL https://vast.ai/install.sh | bash
+```
+
+`pip install vastai` stays the documented method until the installer passes
+testing. This splits the audience (CLI users vs. SDK users); it does not
+replace pip.
+
+## 1. Goals
+
+- Install the CLI with **no system Python, pip, or sudo** required. Fresh VMs
+  and CI runners frequently have no usable Python — for a GPU cloud this is the
+  common case.
+- Decouple the CLI from the user's Python environment (avoid PEP 668 refusals,
+  venv confusion, pinned-dependency conflicts on `cryptography`/`pillow`).
+- Provide a first-class `vastai update` so the CLI can ship — and users can
+  adopt — daily releases (pip already lets us release daily; the gap is that
+  users lag, so the fixes never land).
+
+## 2. Core architecture: one-time install script + per-release manifest
+
+The design splits the install into two layers:
+
+- **`install.sh` — a one-time install script** with **no version numbers and
+  no artifact URLs**. It only: detects platform → fetches the manifest →
+  verifies sha256 → bootstraps + symlinks. "One-time" is about *change
+  frequency*: per-release churn lives in the manifest, so the script is written
+  once and rarely touched.
+- **`manifest.{json,env}` — regenerated every release.** Carries the latest
+  version, the CPython pin, and per-platform `uv` URLs + sha256.
+  `manifest.json` is for `vastai update`; flat `manifest.env` is for
+  `install.sh` (bare machines have no JSON parser).
+
+### Install bootstrap sequence
+
+1. Detect platform (os/arch, musl).
+2. Fetch manifest over TLS.
+3. Verify sha256 **before** anything lands in `$ROOT`.
+4. Install + symlink: pinned `uv` provisions managed CPython 3.12 and installs
+   the published PyPI wheel into an isolated venv. **System Python is never
+   used, even if present.**
+
+### Fail-closed guarantees
+
+- Whole script wrapped in `main()`, invoked on the **last line** — a truncated
+  download executes nothing.
+- TLS-only downloads; uv tarball sha256 verified against the manifest before
+  unpacking. (Wheel integrity is delegated to uv: TLS + PyPI hashes.)
+- Runs as root without complaint (no shared prefix — everything lands in the
+  invoking user's `$HOME/.vastai`), since fresh VMs/containers are commonly root.
+- Unsupported platform or bad hash → exits cleanly pointing at pip.
+- PATH/completion edits only with consent at a real TTY; skippable via
+  `--no-modify-path`.
+
+## 3. On-disk layout
+
+Everything lives under `~/.vastai` (`VASTAI_INSTALL_DIR` overrides):
+
+```
+~/.vastai/
+├── bin/
+│   ├── vastai   → ../env/bin/vastai   (fixed symlink; target never changes)
+│   └── uv                              (pinned bootstrap engine, internal)
+├── env/                                (the single active venv — see §6)
+├── python/                             (uv-managed CPython 3.12, shared)
+└── install-receipt.json
+```
+
+- The venv is built **relocatable** (`uv venv --relocatable`) so its
+  entry-point shebangs don't hardcode the build path — that's what lets an
+  update build in a temp dir and rename `env/` into place (§6).
+- `bin/vastai` is a **fixed** symlink into `env/`; it is created once and never
+  retargeted (the `env/` path is constant). `~/.local/bin/vastai` →
+  `~/.vastai/bin/vastai` puts it on PATH.
+- Config lives in `~/.config/vastai` (e.g. `vast_api_key`) — **untouched** by
+  install/uninstall. Switching install methods keeps auth; uninstalling keeps
+  the key.
+- Throwaway state lives in `~/.cache/vastai` (update-check throttle).
+- Uninstall: `rm -rf ~/.vastai ~/.local/bin/vastai`.
+
+### `install-receipt.json`
+
+Ground truth that `vastai update` uses to know it owns the install. Records
+`method`, `version`, `previous_version`, `python`, `installed_at`. **pip
+installs have no receipt and are never touched by the updater.**
+
+## 4. Hosting (decided)
+
+GitHub Releases stores the artifacts; `vast.ai` serves canonical URLs via three
+**307 temporary** redirects in `vast_landing` (branch
+`feat/cli-installer-redirects`):
+
+| vast.ai path | → GitHub Release asset |
+|---|---|
+| `/install.sh` | `releases/latest/download/install.sh` |
+| `/cli/manifest.json` | `releases/latest/download/manifest.json` |
+| `/cli/manifest.env` | `releases/latest/download/manifest.env` |
+
+- **Temporary (307) on purpose:** the published one-liner is sticky forever, so
+  the advertised URL must stay repointable (CDN move, repo move) without
+  redirect-cache poisoning. A 301 could get cached by intermediaries and lock
+  the URL to a stale target.
+- `releases/latest` does the per-release work; the landing repo is touched once.
+
+### Abort path
+
+Hosting is three redirects. Remove them and: the installer 404s with a clear
+error, update nudges go silent, and **every already-installed CLI keeps
+working** (they run from the local install, not the redirect). No client-side
+breakage is possible from un-hosting.
+
+## 5. Single channel (latest only)
+
+There is one channel: whatever `releases/latest` points at. No `stable`/`beta`/
+`canary` split, no per-channel manifests, no channel field in the receipt. If a
+staged-rollout lever is ever wanted, a second manifest file served at a
+different path is the natural seam — but it is explicitly **not** pursued now.
+
+## 6. Update + rollback model
+
+Single active install (the **deno model**): one active venv, replaced in place,
+plus a `--version` flag that doubles as rollback. No version tree, no symlink
+retargeting, no retention/GC, no offline-instant-rollback guarantee.
+
+### Behavior
+- **Single active install.** Update = build-new-then-swap, never mutate in
+  place destructively: build a fresh venv in a temp dir (`.env.new`) → verify →
+  atomically rename over `env/`. An interrupted update only ever dirties the
+  temp dir; the live `env/` is touched by two renames (~instant) and can never
+  be left half-written. **This is the one safety property worth preserving.**
+- `vastai update` — installs the manifest's latest.
+- `vastai update --version X` — installs/pins a specific version. **Downgrade
+  and forward-pin are the identical code path**; rollback is just "don't forbid
+  downgrades," reusing the same install-and-swap. There is no separate rollback
+  machinery and no kept-on-disk previous version.
+- Verification mirrors the installer: confirm the new env runs and reports the
+  expected version before swapping; wheel integrity comes from uv (TLS + PyPI
+  hashes), the uv binary itself from the manifest sha256 at install time.
+
+### Why keep `--version` rollback at all
+We release **daily**, so bad releases ship fairly often. Without a `--version`
+escape hatch a user who pulls a broken daily can only "uninstall, reinstall, and
+hope latest is fixed" — useless mid-incident. `--version` lets them pin to
+yesterday's known-good. It is cheap insurance *because* we release daily, and it
+costs nothing extra on top of single-version (the mechanism already exists for
+pinning).
+
+### Same-method discipline
+pip installs (no receipt) get the correct `pip install --upgrade vastai` hint
+and exit — **never shell out to a guessed pip.** Matches uv's behavior
+(self-update disabled when installed another way).
+
+### Optional later: download cache
+A cache of the last few wheels at `~/.cache/vastai/` would make a re-pin/
+rollback fast or offline. It is **a cache, not a version store** — evict
+oldest, a miss simply re-fetches, no "don't delete what's running" invariant.
+Not built in v1.
+
+## 7. Passive update nudge
+
+- After commands: at most **one manifest GET and one stderr line per 24h**, hard
+  1s timeout, every failure silent with 24h backoff (offline machines pay ≤1s
+  once/day).
+- Suppressed under `--raw`, `CI`, non-TTY, or `VASTAI_NO_UPDATE_CHECK=1`.
+- **No telemetry** — the check is a GET of a static file.
+- The nudge only ever *suggests*; there is no minimum-version gate and no
+  remote-push channel — we never block or force an upgrade.
+
+Note: `latest` governs what gets **installed** (fresh installs + update checks),
+not what gets **run** (the active local install). A hotfix instantly fixes new
+installs and gives existing installs a one-command path to the fix, but does not
+reach out and patch running CLIs.
+
+## 8. Bug-fix propagation model
+
+Two artifacts with **opposite** update properties:
+
+| | Bug in the **wheel** (CLI) | Bug in **`install.sh`** |
+|---|---|---|
+| Runs | on every command | once, at install only |
+| Affects | everyone on that version | only **new installs**, before the fix is uploaded |
+| Fix | hotfix release + manifest bump; existing get it via `vastai update` | upload new `install.sh`; next install gets it instantly |
+| Reaches existing installs? | yes (opt-in via update) | **no — and doesn't need to** (they never re-run the script) |
+
+Consequence: keep `install.sh` as **thin** as possible and push everything that
+might need post-install fixing (update logic, nudge) into the wheel
+(`selfupdate.py`) — the script is the one component you can't retroactively patch
+on existing machines, and its only audience is fresh installs who always fetch
+it fresh.
+
+## 9. Signing (deferred, but know the bar)
+
+Manifest signing (minisign/Sigstore) is a deliberate later-phase option, fine to
+ship v1 without. But be clear-eyed: sha256-in-manifest protects against
+corruption-in-transit and a tampered *artifact* — it does nothing if an attacker
+can rewrite the *manifest itself* (they'd put their own hash in). The current
+trust chain rests on TLS + "GitHub Releases not compromised." Signing the
+manifest closes that gap. Relevant because the CLI holds API keys — don't let
+"we verify sha256" imply the supply chain is signed; it isn't until the manifest
+is.
+
+## 10. Env knobs
+
+- `VASTAI_VERSION` — pin version (also the rollback/downgrade mechanism).
+- `VASTAI_INSTALL_DIR` — override `~/.vastai`.
+- `VASTAI_CLI_BASE_URL` — manifest origin (dev/release verification).
+- `VASTAI_PIP_SPEC` — dev/CI: install from a local wheel path/URL.
+- `VASTAI_NO_UPDATE_CHECK=1` — suppress the nudge.
+- `--no-modify-path` — skip PATH/completion edits.
+
+*Future ergonomic win:* consolidate the CI/ephemeral story into one documented
+switch (uv does this with `UV_UNMANAGED_INSTALL`: custom path + no profile mods
++ self-update disabled). The pieces exist scattered; one "hermetic CI mode" var
+is what CI users will reach for by analogy to uv.
+
+## 11. Manifest generation
+
+`scripts/make_manifest.py` (stdlib-only) renders both forms from a released
+wheel. Pins the `uv` version and embeds per-platform sha256 fetched from uv's
+release assets — no floating tags anywhere in the supply chain. `install.type`
+is the seam that lets a frozen binary replace the wheel later with zero
+user-facing change; a future `wheel_url` field would let the CLI ship faster
+than the PyPI `vastai` package (attach the wheel to the Release, point installs
+there) — not enabled yet, one pipeline at a time.
+
+## 12. Rollout (dark launch)
+
+Nothing user-visible until the redirects go live; README/docs stay pip-only
+until launch.
+
+1. **PR 1 (this PR):** installer scripts, manifest generator, hermetic tests,
+   dormant `vastai update` implementation + unit tests, this doc. **No-op for
+   the existing CLI** — `main.py` and workflows untouched.
+2. **PR 2 (activation):** register `update` + nudge in `main.py`; add the
+   `scripts/publish_release.py` orchestrator (§13) and the release-CI wiring
+   that calls it (attach `manifest.{json,env}` + `install.sh` to the GitHub
+   Release; post-publish install smoke test on clean ubuntu/macos runners;
+   shellcheck + hermetic-test job on PRs).
+3. **Tag a release** so `releases/latest` assets exist.
+4. **Deploy the `vast_landing` redirects** — the activation point.
+5. **Internal testing:** TTY checklist (consent prompts, nudge UX, offline
+   behavior); OS matrix (debian-slim no-Python, alpine/musl, old glibc, both
+   Darwins); team dogfood across ≥1 release cycle including a real `vastai
+   update` and a `--version` downgrade.
+6. **Launch:** flip README to split install (CLI via installer, SDK via pip).
+
+## 13. Release runbook (manual until the activation PR automates it)
+
+PyPI publishing stays automated (`python-publish.yml` on tag push). Manual for
+now is the installer side. ~10 min:
+
+```bash
+git tag v1.0.14 && git push origin v1.0.14         # existing CI publishes to PyPI
+
+# hash the *published* wheel, never a local rebuild (rebuilds aren't byte-identical)
+pip download vastai==1.0.14 --no-deps -d /tmp/rel/
+python3 scripts/make_manifest.py --version 1.0.14 \
+    --wheel '/tmp/rel/vastai-1.0.14-*.whl' --out /tmp/rel/m/
+
+gh release create v1.0.14 --title v1.0.14 --notes "vastai 1.0.14"
+gh release upload v1.0.14 --clobber \
+    /tmp/rel/m/manifest.json /tmp/rel/m/manifest.env scripts/install.sh
+
+# verify the real user path before walking away
+VASTAI_CLI_BASE_URL=https://github.com/vast-ai/vast-cli/releases/latest/download \
+    bash scripts/install.sh
+~/.vastai/bin/vastai --version
+```
+
+Rules the automation must enforce (a human must remember for now):
+- **Hash the published wheel**, not a local rebuild (hash won't match what PyPI serves).
+- **Normal release only** — drafts/pre-releases are skipped by `releases/latest`,
+  so redirects would keep serving the old version.
+- **Upload `install.sh` from the tagged commit**, not a dirty working tree.
+- Once redirects are live, **the asset upload *is* the deploy** — verify immediately.
+
+### Planned: `scripts/publish_release.py` (one orchestrator, human + CI)
+
+The four rules above are exactly the things a human forgets, so the runbook
+collapses into a single script — built as **one orchestrator both a human and
+CI invoke**, so the dangerous steps have one implementation, not a local copy
+plus a divergent YAML copy. Slated for **PR 2 (activation)**, not this PR, since
+it is activation machinery (keeps this PR a no-op for the existing CLI).
+
+```bash
+scripts/publish_release.py 1.0.14            # local: tag → wait for PyPI → manifest → gh release → verify
+scripts/publish_release.py 1.0.14 --ci       # CI: hash dist/*.whl → manifest → attach (tag/poll skipped)
+scripts/publish_release.py 1.0.14 --dry-run  # print every action, touch nothing
+```
+
+It wraps the existing `make_manifest.py` (no duplicated logic) and differs only
+by context:
+
+| | Local (manual window) | CI (`--ci`, on tag push) |
+|---|---|---|
+| Tag | script pushes it | already pushed (the trigger) |
+| Wheel to hash | `pip download` from PyPI after publish — **polls** until available | `dist/*.whl` from `poetry publish --build` — the exact published bytes, no wait |
+| `gh` auth | developer creds | `GITHUB_TOKEN` |
+
+Guardrails (because it triggers irreversible, outward actions): refuse on a
+dirty tree / wrong branch; refuse if the tag already exists (re-runs use
+`gh release upload --clobber`); confirm before the tag push and
+`gh release create` unless `--yes`/`--ci`; baked-in post-upload verification
+(install via the Release URL → `vastai --version`). PR 2's workflow step then
+reduces to `python scripts/publish_release.py "${GITHUB_REF_NAME#v}" --ci`.
+
+(Named `publish_release.py`, not `publish_update.py`: it publishes a *release* —
+`install.sh` + both manifests as Release assets — not "an update.")
+
+## 14. Decisions log
+
+- Canonical URL `https://vast.ai/install.sh`; hosting via `vast_landing` 307
+  redirects → GitHub Release assets.
+- Program in `~/.vastai`, config in `~/.config/vastai`, throwaway state in
+  `~/.cache/vastai`.
+- Managed runtime pinned to CPython 3.12 (independent of the wheel's `>=3.10`
+  for pip users); bumps roll out as manifest changes.
+- Bootstrap engine: pinned `uv` behind the manifest seam — replaceable without
+  user impact. Venv built `--relocatable` so the build-temp-then-rename swap works.
+- **Update model: single active install, replace-in-place (build temp → verify →
+  rename), rollback via `vastai update --version X`. Side-by-side versions /
+  symlink tree / GC explicitly dropped.** Optional download cache later.
+- Single channel (latest only); no channel machinery.
+- Update nudges are same-method only (pip users told pip); cross-promoting the
+  installer to pip users deferred to post-launch.
+- Frozen binaries, a Windows installer, and manifest signing (minisign/Sigstore)
+  are explicit later-phase options.
+- No guard against downgrading below the first update-capable release —
+  deliberate: low-probability, low-severity; recovery is a reinstall.
+- Release orchestration is one script (`scripts/publish_release.py`, §13) shared
+  by humans and CI — not a local helper plus a separate CI YAML copy. Lands in
+  PR 2 to keep PR 1 a no-op.

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Simulate the hosted https://vast.ai/install.sh end-to-end, locally.
+#
+#   scripts/dev-install.sh                       # install latest released version
+#   scripts/dev-install.sh --from-source         # install a wheel built from this tree
+#   VASTAI_VERSION=1.0.12 scripts/dev-install.sh # pin a version
+#   scripts/dev-install.sh --no-modify-path      # other flags pass through
+#
+# Renders the same release manifest CI would publish (real uv checksums from
+# GitHub), then runs scripts/install.sh against it via file:// — everything
+# else is exactly the production path: installs to ~/.vastai, links
+# ~/.local/bin/vastai, consent-gated PATH edit, real PyPI download.
+#
+# --from-source builds the working tree with poetry and installs that wheel
+# through the same path, so unreleased features (e.g. `vastai update`) can be
+# dogfooded. `vastai update` needs a manifest URL until vast.ai/cli is live:
+#   python3 scripts/make_manifest.py --version X --wheel W --out DIR
+#   python3 -m http.server 8901 --directory DIR &
+#   VASTAI_MANIFEST_URL=http://127.0.0.1:8901/manifest.json vastai update --check
+#
+# Uninstall: rm -rf ~/.vastai ~/.local/bin/vastai
+
+set -euo pipefail
+
+repo="$(cd "$(dirname "$0")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+from_source=""
+passthrough=()
+for arg in "$@"; do
+    case "$arg" in
+        --from-source) from_source=1 ;;
+        *) passthrough+=("$arg") ;;
+    esac
+done
+
+if [ -n "$from_source" ]; then
+    echo "dev-install: building wheel from working tree..."
+    rm -f "$repo"/dist/vastai-*.whl
+    (cd "$repo" && poetry build --format wheel --quiet)
+    wheel="$(find "$repo/dist" -name 'vastai-*.whl' -print -quit)"
+    [ -n "$wheel" ] || { echo "dev-install: error: no wheel produced in dist/" >&2; exit 1; }
+    # vastai-<version>-py3-none-any.whl
+    version="$(basename "$wheel" | sed 's/^vastai-//; s/-py3-none-any\.whl$//')"
+    export VASTAI_PIP_SPEC="$wheel"
+else
+    # Default to the latest released tag: that's what the hosted manifest will say.
+    version="${VASTAI_VERSION:-$(git -C "$repo" describe --tags --abbrev=0 | sed 's/^v//')}"
+    wheel="$tmp/dummy.whl"
+    # install.sh never reads the wheel hash (uv verifies PyPI downloads itself),
+    # so a dummy wheel is fine for manifest rendering here.
+    touch "$wheel"
+fi
+
+python3 "$repo/scripts/make_manifest.py" \
+    --version "$version" --wheel "$wheel" --out "$tmp" >/dev/null
+
+echo "dev-install: simulating hosted installer for vastai $version (manifest in $tmp)"
+VASTAI_CLI_BASE_URL="file://$tmp" VASTAI_VERSION="$version" \
+    bash "$repo/scripts/install.sh" ${passthrough[0]+"${passthrough[@]}"}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# Vast.ai CLI installer.
+#
+#   curl -fsSL https://vast.ai/install.sh | bash
+#
+# Installs a self-contained vastai CLI into ~/.vastai (no Python required on
+# the machine, no sudo, nothing outside ~/.vastai and ~/.local/bin is touched
+# except an optional, consent-gated PATH line in your shell rc).
+# Design: install-design.md in https://github.com/vast-ai/vast-cli
+#
+# Options (env vars, or flags after `bash -s --`):
+#   VASTAI_VERSION=1.2.3       install a specific version (default: latest)
+#   VASTAI_INSTALL_DIR=DIR     install root (default: ~/.vastai)
+#   VASTAI_CLI_BASE_URL=URL    manifest base (default: https://vast.ai/cli)
+#   VASTAI_NO_MODIFY_PATH=1    never edit shell rc files  (flag: --no-modify-path)
+#   VASTAI_PIP_SPEC=...        what to install instead of vastai==VERSION
+#                              (dev/CI only: e.g. a local wheel path)
+#
+# Uninstall:  rm -rf ~/.vastai ~/.local/bin/vastai
+
+set -euo pipefail
+
+BASE_URL="${VASTAI_CLI_BASE_URL:-https://vast.ai/cli}"
+ROOT="${VASTAI_INSTALL_DIR:-$HOME/.vastai}"
+LOCAL_BIN="$HOME/.local/bin"
+NO_MODIFY_PATH="${VASTAI_NO_MODIFY_PATH:-}"
+WORKDIR=""
+
+say()  { printf 'vastai-install: %s\n' "$*"; }
+warn() { printf 'vastai-install: warning: %s\n' "$*" >&2; }
+die()  { printf 'vastai-install: error: %s\n' "$*" >&2; exit 1; }
+
+cleanup() { [ -n "$WORKDIR" ] && rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+# download URL DEST
+download() {
+    if command -v curl >/dev/null 2>&1; then
+        case "$1" in
+            https://*) curl --proto '=https' --tlsv1.2 -fsSL --retry 3 -o "$2" "$1" ;;
+            *)         curl -fsSL --retry 3 -o "$2" "$1" ;;
+        esac
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO "$2" "$1"
+    else
+        die "need curl or wget to download files"
+    fi
+}
+
+# sha256_of FILE
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        die "need sha256sum or shasum to verify downloads"
+    fi
+}
+
+# verify_sha FILE EXPECTED LABEL
+verify_sha() {
+    local actual
+    actual="$(sha256_of "$1")"
+    [ "$actual" = "$2" ] || die "checksum mismatch for $3 (expected $2, got $actual) — aborting, nothing was installed"
+}
+
+# manifest_get KEY  (from $WORKDIR/manifest.env; empty if absent)
+manifest_get() {
+    sed -n "s/^$1=//p" "$WORKDIR/manifest.env" | head -n 1 | tr -d '\r'
+}
+
+# link_swap TARGET LINK — atomic-replace a symlink
+link_swap() {
+    local tmp
+    tmp="$(dirname "$2")/.$(basename "$2").tmp"
+    rm -f "$tmp"
+    ln -s "$1" "$tmp"
+    mv -f "$tmp" "$2"
+}
+
+detect_platform() {
+    local os arch libc=""
+    os="$(uname -s)"
+    arch="$(uname -m)"
+    case "$os" in
+        Linux)  os="LINUX" ;;
+        Darwin) os="DARWIN" ;;
+        *) die "unsupported OS: $os — install with pip instead: pip install vastai" ;;
+    esac
+    case "$arch" in
+        x86_64|amd64)  arch="X86_64" ;;
+        aarch64|arm64) [ "$os" = "DARWIN" ] && arch="ARM64" || arch="AARCH64" ;;
+        *) die "unsupported architecture: $arch — install with pip instead: pip install vastai" ;;
+    esac
+    if [ "$os" = "LINUX" ] && command -v ldd >/dev/null 2>&1 \
+        && ldd --version 2>&1 | grep -qi musl; then
+        libc="_MUSL"
+    fi
+    PLATFORM_KEY="${os}_${arch}${libc}"
+}
+
+# is_interactive — can we prompt the user? (stdin is the pipe under curl|bash,
+# and /dev/tty may exist yet be unopenable when there's no controlling terminal)
+is_interactive() { ( : < /dev/tty > /dev/tty; ) 2>/dev/null; }
+
+# ask_yn PROMPT — returns 0 on yes
+ask_yn() {
+    local reply
+    printf '%s [y/N] ' "$1" > /dev/tty
+    read -r reply < /dev/tty || reply=""
+    case "$reply" in y|Y|yes|YES) return 0 ;; *) return 1 ;; esac
+}
+
+rc_file_for_shell() {
+    case "$(basename "${SHELL:-}")" in
+        zsh)  printf '%s\n' "$HOME/.zshrc" ;;
+        bash) printf '%s\n' "$HOME/.bashrc" ;;
+        *)    printf '%s\n' "" ;;
+    esac
+}
+
+install_uv() {
+    local url sha tarball
+    url="$(manifest_get "UV_URL_$PLATFORM_KEY")"
+    sha="$(manifest_get "UV_SHA256_$PLATFORM_KEY")"
+    [ -n "$url" ] && [ -n "$sha" ] \
+        || die "no build available for your platform ($PLATFORM_KEY) — install with pip instead: pip install vastai"
+
+    say "Downloading runtime bootstrap..."
+    tarball="$WORKDIR/uv.tar.gz"
+    download "$url" "$tarball"
+    verify_sha "$tarball" "$sha" "uv"
+
+    mkdir -p "$WORKDIR/uv-extract"
+    tar -xzf "$tarball" -C "$WORKDIR/uv-extract"
+    local uv_bin
+    uv_bin="$(find "$WORKDIR/uv-extract" -type f -name uv | head -n 1)"
+    [ -n "$uv_bin" ] || die "uv binary not found in downloaded archive"
+    chmod +x "$uv_bin"
+    # Nothing lands in $ROOT until the download has been verified.
+    mkdir -p "$ROOT/bin"
+    mv -f "$uv_bin" "$ROOT/bin/uv"
+}
+
+install_version() {
+    local version="$1" python_pin="$2" envdir="$ROOT/env" newdir="$ROOT/.env.new"
+
+    say "Installing vastai $version (Python $python_pin, isolated in $ROOT)..."
+    rm -rf "$newdir"
+    export UV_PYTHON_INSTALL_DIR="$ROOT/python"
+    export UV_PYTHON_PREFERENCE="only-managed"
+    # --relocatable: entry-point shebangs must not hardcode the build path, so
+    # the venv still works after it's renamed from .env.new into place.
+    if ! "$ROOT/bin/uv" venv "$newdir" --python "$python_pin" --relocatable --quiet; then
+        rm -rf "$newdir"
+        die "could not set up the Python $python_pin runtime"
+    fi
+    local spec="${VASTAI_PIP_SPEC:-vastai==$version}"
+    if ! "$ROOT/bin/uv" pip install --python "$newdir/bin/python" --quiet "$spec"; then
+        rm -rf "$newdir"
+        die "could not install $spec (is the version correct?)"
+    fi
+    "$newdir/bin/vastai" --version >/dev/null \
+        || { rm -rf "$newdir"; die "installed CLI failed its smoke test"; }
+
+    # Single active install: swap the freshly built env in. The live env is
+    # only touched by renames, so an interrupted build never breaks it.
+    rm -rf "$ROOT/.env.old"
+    [ -d "$envdir" ] && mv "$envdir" "$ROOT/.env.old"
+    mv "$newdir" "$envdir"
+    rm -rf "$ROOT/.env.old"
+
+    # Fixed-target symlinks (env/ path is constant); never retargeted on update.
+    local name
+    for name in vastai serve-vast-deployment register-python-argcomplete; do
+        [ -e "$envdir/bin/$name" ] && link_swap "../env/bin/$name" "$ROOT/bin/$name"
+    done
+}
+
+write_receipt() {
+    local version="$1" python_pin="$2" previous="null"
+    if [ -f "$ROOT/install-receipt.json" ]; then
+        previous="$(sed -n 's/.*"version": *"\([^"]*\)".*/"\1"/p' "$ROOT/install-receipt.json" | head -n 1)"
+        [ -n "$previous" ] || previous="null"
+    fi
+    cat > "$ROOT/install-receipt.json" <<EOF
+{
+  "method": "installer",
+  "installer_version": "1",
+  "version": "$version",
+  "previous_version": $previous,
+  "python": "cpython-$python_pin",
+  "artifact": "pypi-wheel",
+  "installed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+}
+
+setup_path() {
+    mkdir -p "$LOCAL_BIN"
+    link_swap "$ROOT/bin/vastai" "$LOCAL_BIN/vastai"
+
+    case ":$PATH:" in
+        *":$LOCAL_BIN:"*) PATH_OK=1 ;;
+        *) PATH_OK="" ;;
+    esac
+    [ -n "$PATH_OK" ] && return 0
+
+    local rc_file marker block
+    rc_file="$(rc_file_for_shell)"
+    marker="# >>> vastai installer >>>"
+    block="$marker
+export PATH=\"\$HOME/.local/bin:\$PATH\"
+eval \"\$('$ROOT/bin/register-python-argcomplete' vastai 2>/dev/null)\" 2>/dev/null || true
+# <<< vastai installer <<<"
+
+    if [ -n "$rc_file" ] && [ -f "$rc_file" ] && grep -qF "$marker" "$rc_file"; then
+        return 0  # already configured; takes effect in new shells
+    fi
+
+    if [ -z "$NO_MODIFY_PATH" ] && [ -n "$rc_file" ] && is_interactive \
+        && ask_yn "Add $LOCAL_BIN to PATH and enable tab completion in $rc_file?"; then
+        printf '\n%s\n' "$block" >> "$rc_file"
+        say "Updated $rc_file (takes effect in new shells)."
+    else
+        say "To finish setup, add this to your shell rc file:"
+        printf '\n%s\n\n' "$block"
+    fi
+}
+
+check_pip_coexistence() {
+    local existing
+    existing="$(command -v vastai 2>/dev/null || true)"
+    case "$existing" in
+        ""|"$LOCAL_BIN/vastai"|"$ROOT/bin/vastai") return 0 ;;
+    esac
+    warn "another vastai is on your PATH at $existing (likely a pip install)."
+    warn "whichever comes first in PATH wins; remove the old one with: pip uninstall vastai"
+}
+
+main() {
+    for arg in "$@"; do
+        case "$arg" in
+            --no-modify-path) NO_MODIFY_PATH=1 ;;
+            --version) die "pass a version with VASTAI_VERSION=x.y.z instead" ;;
+            *) die "unknown option: $arg" ;;
+        esac
+    done
+
+    need_cmd uname
+    need_cmd tar
+    need_cmd mktemp
+    detect_platform
+    WORKDIR="$(mktemp -d)"
+
+    download "$BASE_URL/manifest.env" "$WORKDIR/manifest.env" \
+        || die "could not fetch release manifest from $BASE_URL/manifest.env"
+    local schema latest python_pin version
+    schema="$(manifest_get SCHEMA)"
+    [ "$schema" = "1" ] || die "manifest schema '$schema' not understood by this installer; get the latest from https://vast.ai/install.sh"
+    latest="$(manifest_get LATEST)"
+    python_pin="$(manifest_get PYTHON)"
+    [ -n "$latest" ] && [ -n "$python_pin" ] || die "malformed release manifest"
+    version="${VASTAI_VERSION:-$latest}"
+
+    install_uv
+    install_version "$version" "$python_pin"
+    write_receipt "$version" "$python_pin"
+    setup_path
+    check_pip_coexistence
+
+    say ""
+    say "vastai $version installed to $ROOT"
+    say "  Get started:  vastai set api-key YOUR_API_KEY   (https://cloud.vast.ai/manage-keys/)"
+    say "  Update later: vastai update"
+}
+
+main "$@"

--- a/scripts/make_manifest.py
+++ b/scripts/make_manifest.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Generate the CLI release manifest (manifest.json + manifest.env).
+
+To be run after a release is published to PyPI (release-CI wiring lands in a
+follow-up PR; until then run manually or via scripts/dev-install.sh):
+
+    python scripts/make_manifest.py --version 1.3.0 --wheel dist/vastai-1.3.0-*.whl --out dist-manifest/
+
+manifest.json is consumed by the (future) `vastai update` and passive version
+check; manifest.env is the flat key=value rendering consumed by install.sh
+(no JSON parser required on a bare machine). Both get attached to the GitHub
+Release, which the vast.ai redirects serve via releases/latest/download/.
+
+stdlib only — must run on a bare CI python with no project deps installed.
+"""
+
+import argparse
+import glob
+import hashlib
+import json
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCHEMA = 1
+
+# The Python minor every managed install runs on (docs/install-design.md).
+PYTHON_PIN = "3.12"
+
+# Pinned uv release used to bootstrap installs. Bump deliberately; the
+# installer and `vastai update` only ever see the artifacts listed here.
+UV_VERSION = "0.11.21"
+UV_BASE = f"https://github.com/astral-sh/uv/releases/download/{UV_VERSION}"
+
+# manifest platform key -> uv release target triple
+UV_TARGETS = {
+    "linux-x86_64":       "x86_64-unknown-linux-gnu",
+    "linux-x86_64-musl":  "x86_64-unknown-linux-musl",
+    "linux-aarch64":      "aarch64-unknown-linux-gnu",
+    "linux-aarch64-musl": "aarch64-unknown-linux-musl",
+    "darwin-arm64":       "aarch64-apple-darwin",
+    "darwin-x86_64":      "x86_64-apple-darwin",
+}
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def fetch_uv_sha(target: str) -> str:
+    """uv publishes <asset>.sha256 files containing '<hex>  <filename>'."""
+    url = f"{UV_BASE}/uv-{target}.tar.gz.sha256"
+    with urllib.request.urlopen(url, timeout=30) as r:
+        return r.read().decode().split()[0]
+
+
+def build_manifest(version: str, wheel_sha: str, channel: str) -> dict:
+    uv_artifacts = {
+        key: {
+            "url": f"{UV_BASE}/uv-{target}.tar.gz",
+            "sha256": fetch_uv_sha(target),
+        }
+        for key, target in UV_TARGETS.items()
+    }
+    return {
+        "schema": SCHEMA,
+        "channel": channel,
+        "latest": version,
+        "published_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "install": {
+            "type": "pypi-wheel",
+            "package": "vastai",
+            "python": PYTHON_PIN,
+            "wheel_sha256": wheel_sha,
+            "uv": {
+                "version": UV_VERSION,
+                "artifacts": uv_artifacts,
+            },
+        },
+    }
+
+
+def render_env(manifest: dict) -> str:
+    """Flat rendering for install.sh: KEY=VALUE, platform keys upper_snake."""
+    install = manifest["install"]
+    lines = [
+        f"SCHEMA={manifest['schema']}",
+        f"CHANNEL={manifest['channel']}",
+        f"LATEST={manifest['latest']}",
+        f"PYTHON={install['python']}",
+        f"WHEEL_SHA256={install['wheel_sha256']}",
+        f"UV_VERSION={install['uv']['version']}",
+    ]
+    for key, art in install["uv"]["artifacts"].items():
+        env_key = key.upper().replace("-", "_")
+        lines.append(f"UV_URL_{env_key}={art['url']}")
+        lines.append(f"UV_SHA256_{env_key}={art['sha256']}")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--version", required=True, help="CLI version being released (no leading v)")
+    ap.add_argument("--wheel", required=True, help="path (or glob) to the published vastai wheel")
+    ap.add_argument("--channel", default="stable")
+    ap.add_argument("--out", required=True, help="output directory")
+    args = ap.parse_args()
+
+    wheels = sorted(glob.glob(args.wheel))
+    if len(wheels) != 1:
+        print(f"error: --wheel {args.wheel!r} matched {len(wheels)} files, need exactly 1", file=sys.stderr)
+        return 1
+
+    manifest = build_manifest(args.version, sha256_file(Path(wheels[0])), args.channel)
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    (out / "manifest.env").write_text(render_env(manifest))
+    print(f"wrote {out / 'manifest.json'} and {out / 'manifest.env'} for vastai {args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -1,0 +1,215 @@
+"""Tests for the (dormant) `vastai update` command and self-update machinery.
+
+The command is not registered in vastai.cli.main yet; tests/conftest.py
+imports it onto the test parser. Coverage focuses on the core invariants:
+atomic swap/rollback safety, the pip-install refusal, exit-code contract,
+and the nudge's silence guarantees (offline, throttled, suppressed).
+"""
+
+import os
+import stat
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from vastai.cli import selfupdate
+from vastai.cli.selfupdate import (
+    UpdateError, is_newer, version_key, read_receipt, write_receipt,
+    perform_update,
+)
+
+MANIFEST = {
+    "schema": 1,
+    "channel": "stable",
+    "latest": "1.3.0",
+    "install": {"type": "pypi-wheel", "package": "vastai", "python": "3.12"},
+}
+
+
+class TestVersionOrdering:
+    @pytest.mark.parametrize("newer,older", [
+        ("1.0.1", "1.0.0"),
+        ("1.10.0", "1.9.9"),
+        ("1.0.0", "1.0.0.dev3"),
+        ("1.0.0", "1.0.0rc1"),
+        ("1.0.0.post1", "1.0.0"),
+        ("1.0.13", "0.5.0.post116+aba334f"),
+    ])
+    def test_ordering(self, newer, older):
+        assert is_newer(newer, older)
+        assert not is_newer(older, newer)
+
+    @pytest.mark.parametrize("a,b", [("1.0.0+local", "1.0.0"), ("1.0", "1.0.0")])
+    def test_equivalent_forms(self, a, b):
+        assert version_key(a) == version_key(b)
+
+
+@pytest.fixture
+def install_root(tmp_path, monkeypatch):
+    root = tmp_path / "vastai-root"
+    (root / "bin").mkdir(parents=True)
+    monkeypatch.setenv("VASTAI_INSTALL_DIR", str(root))
+    return root
+
+
+@pytest.fixture
+def managed_receipt(install_root):
+    receipt = {"method": "installer", "version": "1.2.3", "previous_version": None}
+    write_receipt(receipt)
+    return receipt
+
+
+def _seed_env(root, version):
+    """Create a live env/ with a runnable vastai (a prior install to replace)."""
+    bindir = root / "env" / "bin"
+    bindir.mkdir(parents=True)
+    exe = bindir / "vastai"
+    exe.write_text(f"#!/bin/sh\necho '{version}'\n")
+    exe.chmod(exe.stat().st_mode | stat.S_IXUSR)
+
+
+def test_receipt_never_raises(install_root):
+    assert read_receipt() is None  # missing
+    (install_root / "install-receipt.json").write_text("{not json")
+    assert read_receipt() is None  # corrupt
+    write_receipt({"method": "installer", "version": "1.0.0"})
+    assert read_receipt() == {"method": "installer", "version": "1.0.0"}
+
+
+# Fake uv: `uv venv DIR ...` and `uv pip install --python PY ... vastai==VER`
+FAKE_UV = """#!/bin/sh
+set -e
+if [ "$1" = "venv" ]; then
+    mkdir -p "$2/bin"; touch "$2/bin/python"; chmod +x "$2/bin/python"
+elif [ "$1" = "pip" ]; then
+    py="" prev="" last=""
+    for a in "$@"; do
+        [ "$prev" = "--python" ] && py="$a"
+        prev="$a"; last="$a"
+    done
+    bindir="$(dirname "$py")"
+    printf '#!/bin/sh\\necho "%s"\\n' "${last#vastai==}" > "$bindir/vastai"
+    chmod +x "$bindir/vastai"
+fi
+"""
+
+
+@pytest.fixture
+def fake_uv(install_root):
+    uv = install_root / "bin" / "uv"
+    uv.write_text(FAKE_UV)
+    uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
+    return uv
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="managed install is POSIX-only (the installer does not support Windows); "
+           "these tests execute shell-script fakes",
+)
+class TestPerformUpdate:
+    def test_success_swaps_in_new_env(self, install_root, managed_receipt, fake_uv):
+        _seed_env(install_root, "1.2.3")
+        perform_update("1.3.0", MANIFEST, receipt=managed_receipt)
+
+        # single fixed env, symlink points into it, no version retention
+        assert "env/bin/vastai" in os.readlink(str(install_root / "bin" / "vastai"))
+        assert (install_root / "env" / "bin" / "vastai").exists()
+        assert not (install_root / ".env.new").exists()
+        assert not (install_root / "versions").exists()
+        receipt = read_receipt()
+        assert receipt["version"] == "1.3.0"
+        assert receipt["previous_version"] == "1.2.3"
+
+    def test_failure_leaves_current_install_untouched(
+        self, install_root, managed_receipt
+    ):
+        _seed_env(install_root, "1.2.3")  # live install that must survive
+        before = (install_root / "env" / "bin" / "vastai").read_text()
+        uv = install_root / "bin" / "uv"
+        uv.write_text("#!/bin/sh\nexit 1\n")
+        uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
+
+        with pytest.raises(UpdateError):
+            perform_update("1.3.0", MANIFEST, receipt=managed_receipt)
+
+        assert (install_root / "env" / "bin" / "vastai").read_text() == before
+        assert not (install_root / ".env.new").exists()
+        assert read_receipt()["version"] == "1.2.3"
+
+
+class TestUpdateCommand:
+    """Argv-level tests: these also pin the parser verb-merge fix
+    (`update` collides with the `update instance` verb)."""
+
+    def test_check_stale_exits_10(self, parse_argv, capsys):
+        args = parse_argv(["update", "--check"])
+        with patch("vastai.cli.commands.update.fetch_manifest", return_value=MANIFEST), \
+             patch("vastai.cli.commands.update.VERSION", "1.2.0"):
+            assert args.func(args) == 10
+        assert "Update available: 1.3.0" in capsys.readouterr().out
+
+    def test_pip_install_refused_with_hint(self, parse_argv, capsys, install_root):
+        args = parse_argv(["update"])  # no receipt under install_root
+        assert args.func(args) == 1
+        assert "pip install --upgrade vastai" in capsys.readouterr().err
+
+    def test_version_flag_targets_specific_version(self, parse_argv, managed_receipt):
+        args = parse_argv(["update", "--version", "1.2.9"])
+        with patch("vastai.cli.commands.update.fetch_manifest", return_value=MANIFEST), \
+             patch("vastai.cli.commands.update.perform_update") as mock_update:
+            assert args.func(args) == 0
+        mock_update.assert_called_once_with("1.2.9", MANIFEST, receipt=managed_receipt)
+
+
+@pytest.fixture
+def nudge_env(tmp_path, monkeypatch):
+    """Environment where the nudge is allowed to fire: tty stderr, no CI,
+    empty install root (not the developer's real ~/.vastai)."""
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("VASTAI_NO_UPDATE_CHECK", raising=False)
+    monkeypatch.setenv("VASTAI_INSTALL_DIR", str(tmp_path / "no-receipt-root"))
+    monkeypatch.setattr(selfupdate, "UPDATE_CHECK_FILE", str(tmp_path / "check.json"))
+    monkeypatch.setattr(selfupdate, "VERSION", "1.0.0")
+    monkeypatch.setattr(selfupdate, "_stderr_is_tty", lambda: True)
+    return SimpleNamespace(raw=False)
+
+
+class TestNudge:
+    def test_fires_when_stale_with_method_aware_hint(self, nudge_env, capsys):
+        with patch.object(selfupdate, "fetch_manifest", return_value=MANIFEST):
+            selfupdate.maybe_notify_update(nudge_env)
+        err = capsys.readouterr().err
+        assert "1.3.0 is available" in err
+        assert "pip install --upgrade vastai" in err  # no receipt -> pip hint
+
+    def test_silent_on_fetch_failure(self, nudge_env, capsys):
+        with patch.object(selfupdate, "fetch_manifest", side_effect=UpdateError("down")):
+            selfupdate.maybe_notify_update(nudge_env)
+        assert capsys.readouterr().err == ""
+
+    def test_one_check_and_one_notice_per_24h(self, nudge_env, capsys):
+        with patch.object(selfupdate, "fetch_manifest", return_value=MANIFEST) as f:
+            selfupdate.maybe_notify_update(nudge_env)
+            selfupdate.maybe_notify_update(nudge_env)
+        assert f.call_count == 1
+        assert capsys.readouterr().err.count("is available") == 1
+
+    @pytest.mark.parametrize("mute", [
+        lambda mp, args: mp.setenv("CI", "1"),
+        lambda mp, args: mp.setenv("VASTAI_NO_UPDATE_CHECK", "1"),
+        lambda mp, args: setattr(args, "raw", True),
+        lambda mp, args: mp.setattr(selfupdate, "_stderr_is_tty", lambda: False),
+    ], ids=["ci-env", "opt-out-env", "raw-mode", "no-tty"])
+    def test_suppressed_makes_no_network_call(self, nudge_env, monkeypatch, capsys, mute):
+        mute(monkeypatch, nudge_env)
+        with patch.object(selfupdate, "fetch_manifest", return_value=MANIFEST) as f:
+            selfupdate.maybe_notify_update(nudge_env)
+        assert f.call_count == 0
+        assert capsys.readouterr().err == ""
+
+    def test_never_raises(self, nudge_env):
+        with patch.object(selfupdate, "_load_check_state", side_effect=RuntimeError("boom")):
+            selfupdate.maybe_notify_update(nudge_env)  # must not raise

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1788,6 +1788,7 @@ def cli_parser():
         billing, storage, clusters, auth, misc, deployments,
         benchmarks,
         price_increase,
+        update,
     )
     from vastai.cli.util import server_url_default, api_key_guard
     parser.add_argument("--url", help="Server REST API URL", default=server_url_default)

--- a/tests/installer/run_tests.sh
+++ b/tests/installer/run_tests.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Hermetic tests for scripts/install.sh — drives the REAL installer against a
+# fake uv tarball and fake manifests served over 127.0.0.1. No external
+# network, runs in seconds. Each scenario gets a fresh sandbox (HOME +
+# install root) and asserts on exit code, filesystem state, and messages.
+#
+#   tests/installer/run_tests.sh                   # run everything
+#   tests/installer/run_tests.sh checksum_abort    # run a subset
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+INSTALL_SH="$REPO/scripts/install.sh"
+TESTS_TMP="$(mktemp -d)"
+FIXTURES="$TESTS_TMP/fixtures"
+SERVER_PID=""
+PASS=0
+FAIL=0
+
+cleanup() {
+    [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null
+    rm -rf "$TESTS_TMP"
+}
+trap cleanup EXIT
+
+# Without setsid we can't guarantee a detached tty; force no-modify-path then.
+HAVE_SETSID=""
+command -v setsid >/dev/null 2>&1 && HAVE_SETSID=1
+
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'
+    else shasum -a 256 "$1" | awk '{print $1}'; fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures: fake uv tarball + manifest variants, served over localhost HTTP
+# ---------------------------------------------------------------------------
+
+build_fake_uv() {
+    local dir="$TESTS_TMP/uv-build/uv-test"
+    mkdir -p "$dir"
+    cat > "$dir/uv" <<'EOF'
+#!/bin/sh
+# Fake uv: handles `uv venv DIR ...` and `uv pip install --python PY ... SPEC`
+set -e
+if [ "$1" = "venv" ]; then
+    mkdir -p "$2/bin"
+    printf '#!/bin/sh\nexit 0\n' > "$2/bin/python"
+    chmod +x "$2/bin/python"
+elif [ "$1" = "pip" ]; then
+    py="" prev="" last=""
+    for a in "$@"; do
+        [ "$prev" = "--python" ] && py="$a"
+        prev="$a"; last="$a"
+    done
+    bindir="$(dirname "$py")"
+    for name in vastai serve-vast-deployment register-python-argcomplete; do
+        printf '#!/bin/sh\necho "%s"\n' "${last#vastai==}" > "$bindir/$name"
+        chmod +x "$bindir/$name"
+    done
+fi
+exit 0
+EOF
+    chmod +x "$dir/uv"
+    tar -czf "$FIXTURES/uv.tar.gz" -C "$TESTS_TMP/uv-build" uv-test
+    UV_SHA="$(sha256_of "$FIXTURES/uv.tar.gz")"
+}
+
+# write_manifest SUBDIR LATEST [SHA]
+write_manifest() {
+    local dir="$FIXTURES/$1" latest="$2" sha="${3:-$UV_SHA}" key
+    mkdir -p "$dir"
+    {
+        echo "SCHEMA=1"
+        echo "CHANNEL=stable"
+        echo "LATEST=$latest"
+        echo "PYTHON=3.12"
+        echo "UV_VERSION=0.0.0-test"
+        for key in LINUX_X86_64 LINUX_X86_64_MUSL LINUX_AARCH64 LINUX_AARCH64_MUSL DARWIN_ARM64 DARWIN_X86_64; do
+            echo "UV_URL_$key=$SERVER/uv.tar.gz"
+            echo "UV_SHA256_$key=$sha"
+        done
+    } > "$dir/manifest.env"
+}
+
+start_server() {
+    local port
+    port="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')"
+    (cd "$FIXTURES" && exec python3 -m http.server "$port" --bind 127.0.0.1 >/dev/null 2>&1) &
+    SERVER_PID=$!
+    SERVER="http://127.0.0.1:$port"
+    for _ in $(seq 1 50); do
+        python3 -c "import urllib.request; urllib.request.urlopen('$SERVER/', timeout=1)" 2>/dev/null && return 0
+        sleep 0.1
+    done
+    echo "FATAL: fixture http server did not start" >&2
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+new_sandbox() {
+    SB="$TESTS_TMP/sb-$1"
+    SB_HOME="$SB/home"
+    SB_ROOT="$SB/root"
+    SB_OUT="$SB/out.log"
+    mkdir -p "$SB_HOME"
+}
+
+# run_install [VAR=VAL ...] — real install.sh, detached from any tty
+run_install() {
+    local envs=("HOME=$SB_HOME" "VASTAI_INSTALL_DIR=$SB_ROOT" "VASTAI_CLI_BASE_URL=$SERVER/good" "SHELL=/bin/bash" "$@")
+    [ -z "$HAVE_SETSID" ] && envs+=("VASTAI_NO_MODIFY_PATH=1")
+    if [ -n "$HAVE_SETSID" ]; then
+        setsid -w env "${envs[@]}" bash "$INSTALL_SH" >"$SB_OUT" 2>&1 </dev/null
+    else
+        env "${envs[@]}" bash "$INSTALL_SH" >"$SB_OUT" 2>&1 </dev/null
+    fi
+}
+
+assert() { # assert DESC command...
+    local desc="$1"; shift
+    "$@" || { echo "    assert failed: $desc"; return 1; }
+}
+
+out_contains() { grep -q "$1" "$SB_OUT"; }
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+test_fresh_install() { # happy path: fixed env symlink, receipt, runnable CLI
+    new_sandbox fresh
+    run_install || { cat "$SB_OUT"; return 1; }
+    assert "vastai symlink -> env bin" \
+        [ "$(readlink "$SB_ROOT/bin/vastai")" = "../env/bin/vastai" ] &&
+    assert "installed CLI runs" [ "$("$SB_ROOT/bin/vastai" --version)" = "1.2.3" ] &&
+    assert "receipt says installer" grep -q '"method": "installer"' "$SB_ROOT/install-receipt.json" &&
+    assert "local bin link exists" [ -L "$SB_HOME/.local/bin/vastai" ]
+}
+
+test_pinned_reinstall() { # VASTAI_VERSION pin replaces in place; receipt chains
+    new_sandbox reinstall
+    run_install || { cat "$SB_OUT"; return 1; }
+    run_install VASTAI_VERSION=0.9.9 || { cat "$SB_OUT"; return 1; }
+    assert "pinned version live" [ "$("$SB_ROOT/bin/vastai" --version)" = "0.9.9" ] &&
+    assert "previous chained in receipt" grep -q '"previous_version": "1.2.3"' "$SB_ROOT/install-receipt.json" &&
+    assert "single active install, no version retention" [ ! -e "$SB_ROOT/versions" ] &&
+    assert "no leftover temp env" [ ! -e "$SB_ROOT/.env.new" ]
+}
+
+test_checksum_abort() { # tampered artifact -> abort with zero residue
+    new_sandbox badsha
+    write_manifest badsha 1.2.3 "$(printf 'a%.0s' $(seq 64))"
+    run_install "VASTAI_CLI_BASE_URL=$SERVER/badsha" && { echo "    expected failure"; return 1; }
+    assert "names the mismatch" out_contains "checksum mismatch for uv" &&
+    assert "no install root created" [ ! -e "$SB_ROOT" ]
+}
+
+test_truncation_guard() { # partial download executes nothing (main()-last)
+    new_sandbox trunc
+    local size n
+    size="$(wc -c < "$INSTALL_SH")"
+    for n in 200 $((size * 2 / 5)) $((size * 19 / 20)); do
+        head -c "$n" "$INSTALL_SH" | env HOME="$SB_HOME" VASTAI_INSTALL_DIR="$SB_ROOT" \
+            VASTAI_CLI_BASE_URL="$SERVER/good" bash >"$SB_OUT" 2>&1 </dev/null
+        assert "cut at $n/$size bytes: no side effects" \
+            [ ! -e "$SB_ROOT" ] || return 1
+    done
+}
+
+test_rc_safety() { # never edits shell rc non-interactively; marker idempotent
+    new_sandbox rc
+    run_install VASTAI_NO_MODIFY_PATH=1 || { cat "$SB_OUT"; return 1; }
+    assert "prints rc instructions" out_contains "add this to your shell rc" &&
+    assert "no bashrc created" [ ! -e "$SB_HOME/.bashrc" ] || return 1
+
+    new_sandbox rc2
+    printf '# >>> vastai installer >>>\nexport PATH=x\n# <<< vastai installer <<<\n' > "$SB_HOME/.bashrc"
+    cp "$SB_HOME/.bashrc" "$SB/before"
+    run_install || { cat "$SB_OUT"; return 1; }
+    assert "rc untouched when marker present" cmp -s "$SB_HOME/.bashrc" "$SB/before"
+}
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+ALL_TESTS=(fresh_install pinned_reinstall checksum_abort truncation_guard rc_safety)
+SELECTED=("${@:-${ALL_TESTS[@]}}")
+
+mkdir -p "$FIXTURES"
+start_server
+build_fake_uv
+write_manifest good 1.2.3
+
+echo "install.sh hermetic tests (fixtures at $SERVER)"
+for t in "${SELECTED[@]}"; do
+    if "test_$t"; then
+        echo "PASS $t"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL $t  (output below)"
+        sed 's/^/    | /' "$SB_OUT" 2>/dev/null
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+echo
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/vastai/cli/commands/update.py
+++ b/vastai/cli/commands/update.py
@@ -1,0 +1,79 @@
+"""`vastai update` — self-update for managed (curl | bash installer) installs.
+
+NOT YET REGISTERED: intentionally absent from the command imports in
+``vastai.cli.main`` (and from the post-command nudge), so the command does not
+exist in the shipped CLI yet. Activation is a follow-up once the hosted
+manifests are live — see docs/install-design.md. Tests register it via
+tests/conftest.py.
+
+pip installs have no install receipt; for those this command only prints the
+correct pip upgrade instructions and exits non-zero — it never shells out to
+pip, since the CLI cannot know which pip/venv owns its environment.
+"""
+
+import sys
+
+from vastai.cli.parser import argument
+from vastai.cli.display import deindent
+from vastai.cli.util import VERSION
+from vastai.cli.selfupdate import (
+    INSTALL_SH_HINT, PIP_UPGRADE_HINT, UpdateError,
+    fetch_manifest, is_newer, perform_update, read_receipt,
+)
+from vastai.cli.utils import get_parser as _get_parser
+
+parser = _get_parser()
+
+EXIT_STALE = 10  # `update --check` exit code when a newer version exists
+
+
+@parser.command(
+    argument("--check", action="store_true", help="only check for a newer version; exit 0 if current, 10 if an update is available"),
+    argument("--version", dest="target_version", metavar="VERSION", help="install a specific version instead of the latest (also how you pin or roll back)"),
+    usage="vastai update [--check | --version VERSION]",
+    help="Update the CLI to the latest version",
+    epilog=deindent("""
+        Updates a CLI installed with the managed installer
+        (curl -fsSL https://vast.ai/install.sh | bash). The new version is
+        installed into a fresh environment and verified before it is swapped
+        in, so an interrupted update never leaves a broken CLI. To roll back a
+        bad release, pin the previous one: vastai update --version 1.2.3
+        For pip installs, update with: pip install --upgrade vastai
+    """),
+)
+def update(args):
+    try:
+        if args.check:
+            latest = fetch_manifest()["latest"]
+            if is_newer(latest, VERSION):
+                print(f"Update available: {latest} (you have {VERSION})")
+                return EXIT_STALE
+            print(f"vastai {VERSION} is up to date (latest: {latest})")
+            return 0
+
+        receipt = read_receipt()
+        if not receipt or receipt.get("method") != "installer":
+            print(
+                "This CLI was not installed with the managed installer, so it "
+                f"cannot self-update.\n  Installed via pip? Run: {PIP_UPGRADE_HINT}\n"
+                f"  Or switch to the managed install: {INSTALL_SH_HINT}",
+                file=sys.stderr,
+            )
+            return 1
+
+        manifest = fetch_manifest()
+        target = args.target_version or manifest["latest"]
+        current = receipt.get("version") or VERSION
+        if target == current:
+            print(f"vastai {current} is already installed.")
+            return 0
+        print(f"Updating vastai {current} -> {target} ...")
+        perform_update(target, manifest, receipt=receipt)
+        print(f"Done. vastai is now {target} (roll back with `vastai update --version {current}`).")
+        return 0
+
+    except UpdateError as e:
+        print(str(e), file=sys.stderr)
+        if not args.check:
+            print("The current install was left untouched.", file=sys.stderr)
+        return 1

--- a/vastai/cli/parser.py
+++ b/vastai/cli/parser.py
@@ -101,6 +101,7 @@ COMMAND_GROUPS = {
     'vastai.cli.commands.metrics':      'Metrics',
     'vastai.cli.commands.storage':      'Storage volumes',
     'vastai.cli.commands.misc':         'Other',
+    'vastai.cli.commands.update':       'Other',
 }
 
 # Some misc.py commands belong with their target resource section, not Other.
@@ -287,7 +288,10 @@ class apwrap(object):
             argv = sys.argv[1:]
         argv_ = []
         for x in argv:
-            if argv_ and argv_[-1] in self.verbs:
+            # Merge "verb object" into one command token, but never swallow a
+            # flag: a verb that is also a bare command (e.g. `update`) must
+            # accept options (`vastai update --check`).
+            if argv_ and argv_[-1] in self.verbs and not x.startswith("-"):
                 argv_[-1] += " " + x
             else:
                 argv_.append(x)

--- a/vastai/cli/selfupdate.py
+++ b/vastai/cli/selfupdate.py
@@ -1,0 +1,267 @@
+"""Self-update engine for the managed (curl | bash) CLI install.
+
+Layout (docs/install-design.md): everything under $VASTAI_INSTALL_DIR
+(default ~/.vastai) — a single active venv at env/, with bin/vastai a fixed
+symlink into it, and install-receipt.json recording how the CLI was installed.
+Updating rebuilds env/ in place (build temp → verify → swap); there is no
+version retention. No receipt means pip owns the install and we never touch it.
+
+The passive nudge is throttled to one manifest GET and one notice per 24h,
+capped at 1s, and swallows every failure — the CLI must never get slower or
+noisier because the manifest endpoint is unreachable.
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+from vastai.cli.util import DIRS, VERSION
+
+DEFAULT_MANIFEST_URL = "https://vast.ai/cli/manifest.json"
+INSTALL_SH_HINT = "curl -fsSL https://vast.ai/install.sh | bash"
+PIP_UPGRADE_HINT = "pip install --upgrade vastai"
+
+UPDATE_CHECK_FILE = os.path.join(DIRS['temp'], "update_check.json")
+CHECK_INTERVAL_S = 24 * 60 * 60
+NUDGE_TIMEOUT_S = 1.0
+
+# Console scripts shipped in the wheel; each gets a swapped symlink in bin/.
+MANAGED_BINARIES = ("vastai", "serve-vast-deployment", "register-python-argcomplete")
+
+
+class UpdateError(Exception):
+    """A self-update step failed; the current install is untouched."""
+
+
+# ---------------------------------------------------------------------------
+# Receipt / manifest / versions
+# ---------------------------------------------------------------------------
+
+def install_root() -> Path:
+    return Path(os.environ.get("VASTAI_INSTALL_DIR") or Path.home() / ".vastai")
+
+
+def read_receipt():
+    """Install receipt dict, or None for non-managed (pip) installs."""
+    try:
+        with open(install_root() / "install-receipt.json") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+def write_receipt(receipt: dict) -> None:
+    path = install_root() / "install-receipt.json"
+    tmp = path.with_suffix(".tmp")
+    with open(tmp, "w") as f:
+        json.dump(receipt, f, indent=2)
+        f.write("\n")
+    os.replace(tmp, path)
+
+
+def fetch_manifest(timeout: float = 10.0) -> dict:
+    url = os.environ.get("VASTAI_MANIFEST_URL") or DEFAULT_MANIFEST_URL
+    try:
+        r = requests.get(url, timeout=timeout)
+        r.raise_for_status()
+        data = r.json()
+    except (requests.exceptions.RequestException, ValueError) as e:
+        raise UpdateError(f"Could not fetch release manifest from {url}: {e}")
+    if not isinstance(data, dict) or "latest" not in data:
+        raise UpdateError(f"Malformed release manifest at {url}")
+    if data.get("schema") != 1:
+        raise UpdateError(
+            f"Release manifest schema {data.get('schema')!r} is not supported "
+            f"by this CLI version.\nRe-run the installer: {INSTALL_SH_HINT}"
+        )
+    return data
+
+
+def version_key(v: str):
+    """Sort key tolerant of dev/rc (below release), post (above), +local (ignored)."""
+    v = (v or "").strip().lstrip("v").split("+", 1)[0]
+    nums, extra = [], 0
+    for part in v.split("."):
+        if part.isdigit():
+            nums.append(int(part))
+            continue
+        m = re.match(r"\d+", part)
+        if m:
+            nums.append(int(m.group()))
+        extra = 1 if part.startswith("post") else -1
+        break
+    while len(nums) < 3:
+        nums.append(0)
+    return tuple(nums), extra
+
+
+def is_newer(candidate: str, current: str) -> bool:
+    return version_key(candidate) > version_key(current)
+
+
+# ---------------------------------------------------------------------------
+# Passive nudge
+# ---------------------------------------------------------------------------
+
+def _load_check_state() -> dict:
+    try:
+        with open(UPDATE_CHECK_FILE) as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_check_state(state: dict) -> None:
+    try:
+        with open(UPDATE_CHECK_FILE, "w") as f:
+            json.dump(state, f)
+    except OSError:
+        pass
+
+
+def _stderr_is_tty() -> bool:
+    try:
+        return sys.stderr.isatty()
+    except Exception:
+        return False
+
+
+def maybe_notify_update(args=None) -> None:
+    """Post-command, best-effort upgrade nudge. Must never raise or block."""
+    try:
+        _maybe_notify_update(args)
+    except Exception:
+        pass
+
+
+def _maybe_notify_update(args) -> None:
+    suppressed = (
+        os.environ.get("VASTAI_NO_UPDATE_CHECK")
+        or os.environ.get("CI")
+        or getattr(args, "raw", False)
+        or not _stderr_is_tty()
+        # the updater itself doesn't need a nudge
+        or getattr(getattr(args, "func", None), "__module__", "") == "vastai.cli.commands.update"
+    )
+    if suppressed:
+        return
+
+    now = time.time()
+    state = _load_check_state()
+    if now - state.get("checked_at", 0) > CHECK_INTERVAL_S:
+        state["checked_at"] = now  # stamped even on failure, so errors back off too
+        try:
+            state["latest"] = fetch_manifest(timeout=NUDGE_TIMEOUT_S).get("latest")
+        except UpdateError:
+            pass
+        _save_check_state(state)
+
+    latest = state.get("latest")
+    if not latest or not is_newer(latest, VERSION):
+        return
+    if now - state.get("notified_at", 0) <= CHECK_INTERVAL_S:
+        return
+
+    receipt = read_receipt()
+    hint = "vastai update" if receipt and receipt.get("method") == "installer" else PIP_UPGRADE_HINT
+    arrow = "↑" if "utf" in (sys.stderr.encoding or "").lower() else "*"
+    print(
+        f"{arrow} vastai {latest} is available (you have {VERSION}). Run `{hint}`.",
+        file=sys.stderr,
+    )
+    state["notified_at"] = now
+    _save_check_state(state)
+
+
+# ---------------------------------------------------------------------------
+# Update / rollback (managed installs only)
+# ---------------------------------------------------------------------------
+
+def _run(cmd, *, env=None):
+    cmd = [str(c) for c in cmd]
+    try:
+        return subprocess.run(cmd, env=env, check=True, capture_output=True, text=True)
+    except FileNotFoundError:
+        raise UpdateError(f"Required tool not found: {cmd[0]}")
+    except subprocess.CalledProcessError as e:
+        detail = (e.stderr or "").strip()
+        raise UpdateError(f"Command failed ({' '.join(cmd)})" + (f":\n{detail}" if detail else ""))
+
+
+def _link_binaries(root: Path) -> None:
+    """Point bin/<name> at the fixed env/bin/<name> for each shipped console
+    script. The target path is constant across updates (always ``env/``), so
+    this is not symlink *retargeting* — just (re)creating stable links."""
+    for name in MANAGED_BINARIES:
+        if not (root / "env" / "bin" / name).exists():
+            continue
+        link, tmp = root / "bin" / name, root / "bin" / f".{name}.tmp"
+        if tmp.is_symlink() or tmp.exists():
+            tmp.unlink()
+        os.symlink(Path("..") / "env" / "bin" / name, tmp)
+        os.replace(tmp, link)
+
+
+def perform_update(target: str, manifest: dict, *, receipt: dict) -> None:
+    """Install ``target`` into a fresh env, verify it, then swap it in.
+
+    Single active install (the deno model): the new env is built in a temp dir
+    and only swapped over the live one after it verifies, so an interrupted
+    update can never leave a half-written or broken ``vastai``. There is no
+    version retention — a re-pin or rollback is just ``update --version X``,
+    which reinstalls. Wheel integrity is delegated to uv (TLS + PyPI hashes);
+    we additionally confirm the installed version matches ``target``.
+    """
+    root = install_root()
+    uv = root / "bin" / "uv"
+    if not uv.exists():
+        raise UpdateError(f"Bootstrap tool missing at {uv}.\nRe-run the installer: {INSTALL_SH_HINT}")
+
+    python_pin = (manifest.get("install") or {}).get("python") or "3.12"
+    env_dir, new_dir, old_dir = root / "env", root / ".env.new", root / ".env.old"
+    shutil.rmtree(new_dir, ignore_errors=True)
+
+    uv_env = dict(os.environ,
+                  UV_PYTHON_INSTALL_DIR=str(root / "python"),
+                  UV_PYTHON_PREFERENCE="only-managed")
+    try:
+        # --relocatable: entry-point shebangs must not hardcode the build path,
+        # so the venv still works after .env.new is renamed into place.
+        _run([uv, "venv", new_dir, "--python", python_pin, "--relocatable", "--quiet"], env=uv_env)
+        _run([uv, "pip", "install", "--python", new_dir / "bin" / "python",
+              "--quiet", f"vastai=={target}"], env=uv_env)
+        installed = (_run([new_dir / "bin" / "vastai", "--version"]).stdout or "").strip()
+        if target not in installed:
+            raise UpdateError(
+                f"Verification failed: new install reports version {installed!r}, expected {target}"
+            )
+    except UpdateError:
+        shutil.rmtree(new_dir, ignore_errors=True)
+        raise
+
+    # Swap: the live env is only ever touched by these two renames (~instant);
+    # a crash mid-build dirties .env.new, never the running install.
+    shutil.rmtree(old_dir, ignore_errors=True)
+    if env_dir.exists():
+        os.replace(env_dir, old_dir)
+    os.replace(new_dir, env_dir)
+    _link_binaries(root)
+    shutil.rmtree(old_dir, ignore_errors=True)
+
+    receipt = dict(receipt)
+    receipt.update(
+        version=target,
+        previous_version=receipt.get("version"),
+        installed_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    )
+    write_receipt(receipt)


### PR DESCRIPTION
## Summary

Adds the `curl | bash` installer for the Vast CLI ([`docs/install-design.md`](https://github.com/vast-ai/vast-cli/blob/feat/curl-installer/docs/install-design.md)), shipped **dark**: no workflow changes, `main.py` untouched, README stays pip-only — **a no-op for the existing CLI.**

```
curl -fsSL https://vast.ai/install.sh | bash
        │
        ▼
  install.sh ──fetch──► manifest.{json,env}      (stable script + per-release manifest:
  (no versions,         latest ver · py pin ·     script holds no version/URLs, so it's
   no URLs)             per-platform uv + sha256)  written once and rarely touched)
        │
        ▼  pinned uv → own CPython 3.12 → vastai wheel (system Python never used)
  ~/.vastai/
   ├── bin/vastai → ../env/bin/vastai   (fixed symlink, never retargeted)
   ├── bin/uv                            ~/.local/bin/vastai → bin/vastai  (on PATH)
   ├── env/                              (single active venv; update = build temp → verify → swap)
   ├── python/                           config stays in ~/.config/vastai (survives uninstall)
   └── install-receipt.json
```

- **`scripts/install.sh`** — self-contained install into `~/.vastai`; no Python/sudo needed, runs fine as root. sha256-verified downloads, consent-gated PATH/completion, install receipt. Uninstall: `rm -rf ~/.vastai ~/.local/bin/vastai`.
- **`vastai update` (dormant)** — single active install (deno model): build a fresh env, verify it runs, atomically rename into place (interrupted update never breaks the live CLI). `--check` / `--version X` (the latter is also how you pin or roll back — no version retention). pip installs refused with the pip hint. **Implemented + tested but not registered in `main.py`** — activation, the passive nudge, and release-CI are the follow-up PR.
- **`scripts/make_manifest.py`** — renders the per-release `manifest.{json,env}` the script + updater consume.
- **`scripts/dev-install.sh [--from-source]`** — simulate the hosted installer locally.
- **Parser fix** — verb-merge no longer swallows flags (`update` collides with the `update instance` verb); affects no currently-valid command.

## Testing

- **23 unit tests** for the dormant update engine (atomic swap, failed update leaves install untouched, pip refusal, nudge silence/throttle/offline guarantees); full CLI suite green.
- **Hermetic harness** (`tests/installer/run_tests.sh`) — 5 no-network scenarios against the real `install.sh`: happy path, pinned reinstall + receipt chain, checksum abort with zero residue, truncated-script guard, rc-edit safety.
- **Real end-to-end:** install 1.0.13 from PyPI → `update --version 1.0.12` (atomic swap) → pin back to 1.0.13.

## Rollout

① this PR → ② activation PR (`main.py` wiring + release CI) → ③ tag a release → ④ deploy the `vast_landing` redirects (`vast.ai/install.sh` → GitHub Release assets) — **in that order, so redirects never 404** → ⑤ internal testing → ⑥ flip README/docs.
