### PR TITLE
feat(CLN-3413): read GPU names + VRAM from /api/v0/gpu_types/ with hardcoded fallback

### DIFF
--- a/tests/cli/test_benchmarks_commands.py
+++ b/tests/cli/test_benchmarks_commands.py
@@ -14,6 +14,19 @@ import pytest
 from vastai.cli.commands import benchmarks as bench
 
 
+@pytest.fixture(autouse=True)
+def _stub_gpu_catalog():
+    """Force the catalog fetch in _parse_gpu_spec to fall back to the hardcoded
+    constants so no live HTTP call leaks into these tests.
+    """
+    bench._canonical_gpu_names.cache_clear()
+    bench._catalog_vram_map.cache_clear()
+    with patch.object(bench, "_get_gpu_types", return_value=None):
+        yield
+    bench._canonical_gpu_names.cache_clear()
+    bench._catalog_vram_map.cache_clear()
+
+
 # ---------------------------------------------------------------------------
 # _benchmark_gpu — cleanup invariant
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_benchmarks_gpu_catalog.py
+++ b/tests/cli/test_benchmarks_gpu_catalog.py
@@ -1,0 +1,82 @@
+"""Tests for the gpu_types catalog integration in ``vastai run benchmarks``.
+
+Covers the table-primary + hardcoded-fallback contract:
+  1. Name canonicalization is the union of the query.py constants and the
+     /api/v0/gpu_types/ catalog (new SKUs resolve; constants never lost).
+  2. Per-card VRAM prefers the catalog's gpu_ram_mb when populated, and falls
+     back to the _DEFAULT_GPUS dict when the column is null or the catalog is
+     unreachable.
+"""
+
+import pytest
+
+from vastai.cli.commands import benchmarks as bench
+
+
+@pytest.fixture(autouse=True)
+def _clear_catalog_caches():
+    """The catalog helpers are lru_cached; clear between cases so each test sees
+    its own monkeypatched _get_gpu_types.
+    """
+    bench._canonical_gpu_names.cache_clear()
+    bench._catalog_vram_map.cache_clear()
+    yield
+    bench._canonical_gpu_names.cache_clear()
+    bench._catalog_vram_map.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Name canonicalization — union of constants + catalog
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_union_adds_catalog_skus(monkeypatch):
+    monkeypatch.setattr(bench, "_get_gpu_types", lambda: [
+        {"canonical_name": "RTX 6090", "gpu_ram_mb": 49152},
+    ])
+    canonical = bench._canonical_gpu_names()
+    assert canonical["rtx 6090"] == "RTX 6090"   # new SKU sourced from the catalog
+    assert canonical["rtx 4090"] == "RTX 4090"   # existing constant preserved by the union
+
+
+def test_canonical_falls_back_to_constants_when_catalog_unreachable(monkeypatch):
+    monkeypatch.setattr(bench, "_get_gpu_types", lambda: None)
+    canonical = bench._canonical_gpu_names()
+    assert canonical["rtx 4090"] == "RTX 4090"
+    assert "rtx 6090" not in canonical
+
+
+def test_parse_gpu_spec_resolves_catalog_only_name(monkeypatch):
+    monkeypatch.setattr(bench, "_get_gpu_types", lambda: [
+        {"canonical_name": "RTX 6090", "gpu_ram_mb": 49152},
+    ])
+    assert bench._parse_gpu_spec("2x rtx_6090", 1) == ("RTX 6090", 2)
+
+
+# ---------------------------------------------------------------------------
+# Per-card VRAM — catalog-primary, dict fallback
+# ---------------------------------------------------------------------------
+
+
+def test_per_card_vram_prefers_populated_catalog(monkeypatch):
+    monkeypatch.setattr(bench, "_get_gpu_types", lambda: [
+        {"canonical_name": "RTX 4090", "gpu_ram_mb": 24576},
+    ])
+    assert bench._per_card_vram_mb("RTX 4090") == 24576   # catalog overrides dict's 24564
+
+
+def test_per_card_vram_falls_back_when_unbackfilled(monkeypatch):
+    monkeypatch.setattr(bench, "_get_gpu_types", lambda: [
+        {"canonical_name": "RTX 4090", "gpu_ram_mb": None},
+    ])
+    assert bench._per_card_vram_mb("RTX 4090") == 24564   # _DEFAULT_GPUS fallback
+
+
+def test_per_card_vram_falls_back_when_catalog_unreachable(monkeypatch):
+    monkeypatch.setattr(bench, "_get_gpu_types", lambda: None)
+    assert bench._per_card_vram_mb("RTX A6000") == 49140
+
+
+def test_per_card_vram_none_for_unknown_gpu(monkeypatch):
+    monkeypatch.setattr(bench, "_get_gpu_types", lambda: [])
+    assert bench._per_card_vram_mb("Totally Fake GPU") is None

--- a/vastai/cli/commands/benchmarks.py
+++ b/vastai/cli/commands/benchmarks.py
@@ -5,6 +5,7 @@ template's pyworker benchmark.
 
 import argparse
 import atexit
+import functools
 import json
 import math
 import random
@@ -24,6 +25,7 @@ from vastai import VastAI
 from vastai.cli.parser import argument
 from vastai.cli.display import deindent
 from vastai.cli.utils import get_parser as _get_parser, get_client  # noqa: F401  (used by test conftest)
+from vastai.cli.util import _get_gpu_types
 from vastai.data.query import OP_TO_STR
 from vastai.data import query as _query_consts
 
@@ -31,7 +33,8 @@ from vastai.data import query as _query_consts
 parser = _get_parser()
 
 
-# Default GPUs (per-card VRAM in MB).
+# Default GPU sweep set + per-card VRAM fallback (MB). Catalog gpu_ram_mb
+# overrides these values when populated; the keys stay the editorial sweep set.
 _DEFAULT_GPUS = {
     "RTX 5090":  32607,
     "RTX 4090":  24564,
@@ -64,6 +67,45 @@ def _format_time_elapsed(seconds):
     return f"{m}:{s:02d}"
 
 
+@functools.lru_cache(maxsize=1)
+def _canonical_gpu_names():
+    """Map of lower-cased GPU name -> canonical name, for resolving user input
+    like "rtx_4090"/"RTX 4090" to the canonical "RTX 4090".
+
+    Union of the hardcoded query.py constants (fallback floor) with the
+    /api/v0/gpu_types/ catalog (picks up newly-onboarded SKUs). On a catalog
+    fetch failure the constants alone are used, so resolution never gets worse.
+    """
+    canonical = {
+        v.lower(): v for k, v in vars(_query_consts).items()
+        if isinstance(v, str) and not k.startswith("_")
+    }
+    for gpu_type in (_get_gpu_types() or []):
+        name = gpu_type.get("canonical_name")
+        if name:
+            canonical[name.lower()] = name
+    return canonical
+
+
+@functools.lru_cache(maxsize=1)
+def _catalog_vram_map():
+    """Map canonical_name -> gpu_ram_mb for entries the catalog has populated.
+    Empty when the catalog is unreachable or the column is unbackfilled.
+    """
+    return {
+        gpu_type["canonical_name"]: gpu_type["gpu_ram_mb"]
+        for gpu_type in (_get_gpu_types() or [])
+        if gpu_type.get("canonical_name") and gpu_type.get("gpu_ram_mb")
+    }
+
+
+def _per_card_vram_mb(gpu_name):
+    """Per-card VRAM in MB: catalog gpu_ram_mb if populated, else the hardcoded
+    _DEFAULT_GPUS value. None when neither source knows the GPU.
+    """
+    return _catalog_vram_map().get(gpu_name) or _DEFAULT_GPUS.get(gpu_name)
+
+
 def _parse_gpu_spec(token, default_num_gpus):
     """parses the gpu arg into (gpu_name, num_gpus)
     ex. "2x RTX_4090" -> ("RTX 4090", 2)
@@ -72,11 +114,8 @@ def _parse_gpu_spec(token, default_num_gpus):
     if no count per gpu isprovided, uses default num_gpus
     """
 
-    # so users can input "rtx_4090" or "RTX 4090" or "Rtx_4090" and all resolves to "RTX 4090" 
-    canonical = {
-        v.lower(): v for k, v in vars(_query_consts).items()
-        if isinstance(v, str) and not k.startswith("_")
-    }
+    # so users can input "rtx_4090" or "RTX 4090" or "Rtx_4090" and all resolves to "RTX 4090"
+    canonical = _canonical_gpu_names()
 
     token = token.strip()
     # converts "2x RTX_4090" to ("RTX 4090", 2)
@@ -258,7 +297,7 @@ def _pick_num_gpus(gpu_name, extra_filters):
     Falls back to 1 when the template has no such filter or one card
     already satisfies it.
     """
-    per_card = _DEFAULT_GPUS.get(gpu_name)
+    per_card = _per_card_vram_mb(gpu_name)
     if per_card is None:
         return 1
     ops = (extra_filters or {}).get("gpu_total_ram") or {}

--- a/vastai/cli/util.py
+++ b/vastai/cli/util.py
@@ -82,6 +82,7 @@ for key in DIRS.keys():
         os.makedirs(path)
 
 CACHE_FILE = os.path.join(DIRS['temp'], "gpu_names_cache.json")
+GPU_TYPES_CACHE_FILE = os.path.join(DIRS['temp'], "gpu_types_cache.json")
 CACHE_DURATION = timedelta(hours=24)
 
 
@@ -120,6 +121,47 @@ def _get_gpu_names() -> Optional[List[str]]:
         return [
             name.replace(" ", "_").replace("-", "_") for name in gpu_names['gpu_names']
         ]
+    except (TypeError, KeyError):
+        return None
+
+
+def _get_gpu_types() -> Optional[List[dict]]:
+    """Returns the GPU type catalog from /api/v0/gpu_types/, cached for 24 hours.
+
+    Source of truth for canonical GPU names and per-card VRAM. Returns None on
+    any error so callers fall back to the hardcoded constants (never empty).
+    """
+
+    def is_cache_valid() -> bool:
+        """Checks if the cache file exists and is less than 24 hours old."""
+        if not os.path.exists(GPU_TYPES_CACHE_FILE):
+            return False
+        cache_age = datetime.now() - datetime.fromtimestamp(os.path.getmtime(GPU_TYPES_CACHE_FILE))
+        return cache_age < CACHE_DURATION
+
+    if is_cache_valid():
+        try:
+            with open(GPU_TYPES_CACHE_FILE, "r") as file:
+                payload = json.load(file)
+        except (OSError, json.JSONDecodeError):
+            payload = None
+    else:
+        endpoint = "/api/v0/gpu_types/"
+        url = f"{server_url_default}{endpoint}"
+        try:
+            r = requests.get(url, headers={})
+            r.raise_for_status()
+            payload = r.json()
+        except (requests.exceptions.RequestException, ValueError):
+            return None
+        try:
+            with open(GPU_TYPES_CACHE_FILE, "w") as file:
+                json.dump(payload, file)
+        except OSError:
+            pass
+
+    try:
+        return payload['gpu_types']
     except (TypeError, KeyError):
         return None
 


### PR DESCRIPTION
## What
Migrates the `vastai` CLI package off its hardcoded GPU data to the `/api/v0/gpu_types/` catalog, with the existing hardcoded data retained as a backwards-compatible fallback.

- New `_get_gpu_types()` in `cli/util.py` — 24h-cached anonymous fetch, mirrors `_get_gpu_names()`, returns `None` on error.
- `benchmarks.py` resolves canonical GPU names from the **union** of the `query.py` constants and the catalog, and reads per-card VRAM from the catalog's `gpu_ram_mb` with fallback to `_DEFAULT_GPUS`.
- The 4-GPU default sweep set is unchanged (editorial choice, no catalog equivalent).

## Why
Part of the CLN-3375 epic — make the `gpu_types` table the single source of truth and have everything read the public endpoint. Adding a SKU via the admin API then surfaces on the CLI within the cache cycle, with no code change.

## Backwards compatibility
Nothing is deleted. When the catalog is unreachable or a field is null, behavior is identical to today (constants + `_DEFAULT_GPUS`). `gpu_ram_mb` is currently unpopulated, so VRAM falls back to the dict now and auto-upgrades when CLN-3449 backfills it.

## Scope
`vastai/` package only. `vast.py` is untouched — it already fetches GPU names dynamically and carries no constants/VRAM dict.

## Test plan
- New `tests/cli/test_benchmarks_gpu_catalog.py`: union adds SKUs, fallback when catalog unreachable, `_parse_gpu_spec` resolves a catalog-only name, VRAM override / null-fallback / unreachable-fallback / unknown→None.
- Autouse guard in `test_benchmarks_commands.py` keeps the existing suite hermetic (no live HTTP from the new fetch).
- Note: suite not run in the authoring env (no Poetry install there); logic validated via a standalone harness and byte-compile. Please confirm `poetry run pytest tests/cli/` is green in CI.

Jira: CLN-3413
