### PR TITLE
fix(cli): execute crashes with 'str' object has no attribute 'get'

### DIFF
--- a/vastai/cli/commands/misc.py
+++ b/vastai/cli/commands/misc.py
@@ -77,17 +77,12 @@ def execute(args):
         add_scheduled_job(client, args, json_blob, cli_command, api_endpoint, "PUT", instance_id=args.id)
         return
 
-    if rj.get("success"):
-        for i in range(0, 30):
-            time.sleep(0.3)
-            url = rj["result_url"]
-            r2 = req_lib.get(url)
-            if r2.status_code == 200:
-                filtered_text = r2.text.replace(rj["writeable_path"], '')
-                print(filtered_text)
-                break
-    else:
-        print(rj)
+    # instances_api.execute() already polls the result URL internally and
+    # returns the command's output as a str on success, or the raw response
+    # dict on failure (no result_url). The previous code assumed a dict and
+    # called rj.get("success"), which raised
+    # "'str' object has no attribute 'get'" on the normal success path.
+    print(rj)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`vastai execute <id> <command>` crashes on **every successful invocation** with:

```
AttributeError: 'str' object has no attribute 'get'
```

## Root cause

`vastai/api/instances.py::execute()` already polls the result URL internally and returns the command output as a **str** on success (or the raw response **dict** on failure, when there is no `result_url`).

The CLI handler `vastai/cli/commands/misc.py::execute()` was never updated for this. It still assumes the old dict shape — calling `rj.get("success")` and re-polling `rj["result_url"]` / `rj["writeable_path"]`. On the success path `rj` is a `str`, so `.get()` raises immediately, and the polling loop below it is now dead code (the API layer already polled).

The sibling `logs()` handler in the same file already handles the str return correctly via `isinstance(rj, str)` — `execute()` was simply missed in the refactor.

## What it does

Removes the redundant dict-based polling in the CLI handler and prints what `instances_api.execute()` returns (str output on success, error dict otherwise). One file changed, −11 / +6.

## Test plan

Verified against current `master` (before vs. after the change):

| Command | Before | After |
| --- | --- | --- |
| `vastai execute <id> 'ls /workspace/...'` | crash | prints listing |
| `vastai execute <id> 'du -d1 -h /workspace/...'` | crash | prints usage |

The crash is in command-independent code (after the result is fetched), so it affects every successful `execute`, including `rm`.