### PR TITLE
feat(cli): activate vastai update + add release orchestrator and CI

### DIFF
--- a/.github/workflows/installer-ci.yml
+++ b/.github/workflows/installer-ci.yml
@@ -1,0 +1,49 @@
+name: Installer CI
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "scripts/install.sh"
+      - "scripts/dev-install.sh"
+      - "scripts/make_manifest.py"
+      - "scripts/publish_release.py"
+      - "tests/installer/**"
+      - ".github/workflows/installer-ci.yml"
+
+concurrency:
+  group: installer-ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: bash syntax check
+        run: bash -n scripts/install.sh scripts/dev-install.sh tests/installer/run_tests.sh
+      - name: shellcheck
+        run: shellcheck -S style scripts/install.sh scripts/dev-install.sh tests/installer/run_tests.sh
+      - name: python syntax check
+        run: python3 -m py_compile scripts/make_manifest.py scripts/publish_release.py
+
+  hermetic-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: run install.sh hermetic scenarios (no external network)
+        run: tests/installer/run_tests.sh
+
+  release-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: make_manifest renders (validates uv pin + sha fetch)
+        run: |
+          touch dummy.whl
+          python3 scripts/make_manifest.py --version 0.0.0 --wheel dummy.whl --out /tmp/m
+          grep -q '^LATEST=0.0.0$' /tmp/m/manifest.env
+          python3 -c "import json; json.load(open('/tmp/m/manifest.json'))"
+      - name: publish_release dry-runs (local + ci)
+        run: |
+          python3 scripts/publish_release.py 0.0.0 --dry-run --yes
+          python3 scripts/publish_release.py 0.0.0 --ci --dry-run

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -7,6 +7,8 @@ jobs:
   build_and_publish_vastai:
     name: Publish vastai
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # publish_release.py creates/updates the GitHub Release
     steps:
       - name: checkout code
         uses: actions/checkout@v4
@@ -28,6 +30,15 @@ jobs:
         run: |
           poetry config pypi-token.pypi "$PYPI_API_TOKEN"
           poetry publish --build
+      # Installer side: hash the just-built dist/ wheel, render the manifest,
+      # and attach manifest.{json,env} + install.sh to the GitHub Release. The
+      # vast.ai redirects serve releases/latest/download/*, so this is the deploy.
+      - name: publish installer manifest + release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          python3 scripts/publish_release.py "$VERSION" --ci --yes --skip-verify
 
   build_and_publish_vastai_sdk:
     name: Publish vastai-sdk
@@ -58,3 +69,38 @@ jobs:
         run: |
           poetry config pypi-token.pypi "$PYPI_API_TOKEN_SDK"
           poetry publish --build
+
+  # Prove a fresh machine can install the release we just published — the whole
+  # promise of the installer. Pulls install.sh + manifest from the Release
+  # assets (vast.ai redirects aren't required), so it works during dark launch.
+  installer_smoke_test:
+    name: Installer smoke test (${{ matrix.os }})
+    needs: build_and_publish_vastai
+    # Non-blocking canary: PyPI + assets are already published by the time this
+    # runs, so a red/flaky smoke shouldn't mark the release failed. Drop once
+    # the installer is launched and we want it gating.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]  # add macos-latest once we want Darwin coverage
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: install from the published Release and verify
+        env:
+          VASTAI_CLI_BASE_URL: https://github.com/vast-ai/vast-cli/releases/latest/download
+          VASTAI_NO_MODIFY_PATH: "1"
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Retry: PyPI + Release-asset propagation can lag a few seconds.
+          for attempt in 1 2 3 4 5; do
+            if curl -fsSL "$VASTAI_CLI_BASE_URL/install.sh" -o /tmp/install.sh \
+                && bash /tmp/install.sh; then
+              break
+            fi
+            [ "$attempt" = 5 ] && { echo "install failed after retries"; exit 1; }
+            echo "attempt $attempt failed (propagation?), retrying in 30s..."
+            sleep 30
+          done
+          "$HOME/.vastai/bin/vastai" --version
+          "$HOME/.vastai/bin/vastai" --version | grep -q "$VERSION"

--- a/docs/install-design.md
+++ b/docs/install-design.md
@@ -64,8 +64,7 @@ Everything lives under `~/.vastai` (`VASTAI_INSTALL_DIR` overrides):
 │   ├── vastai   → ../env/bin/vastai   (fixed symlink; target never changes)
 │   └── uv                              (pinned bootstrap engine, internal)
 ├── env/                                (the single active venv — see §6)
-├── python/                             (uv-managed CPython 3.12, shared)
-└── install-receipt.json
+└── python/                             (uv-managed CPython 3.12, shared)
 ```
 
 - The venv is built **relocatable** (`uv venv --relocatable`) so its
@@ -80,11 +79,15 @@ Everything lives under `~/.vastai` (`VASTAI_INSTALL_DIR` overrides):
 - Throwaway state lives in `~/.cache/vastai` (update-check throttle).
 - Uninstall: `rm -rf ~/.vastai ~/.local/bin/vastai`.
 
-### `install-receipt.json`
+### Detecting a managed install
 
-Ground truth that `vastai update` uses to know it owns the install. Records
-`method`, `version`, `previous_version`, `python`, `installed_at`. **pip
-installs have no receipt and are never touched by the updater.**
+`vastai update` decides "do I own this install?" **structurally**, not from a
+marker file: a managed CLI runs from `~/.vastai/env` with a sibling
+`~/.vastai/bin/uv`. That's ground truth — `sys.prefix` can't drift or be
+hand-copied the way a receipt file could. **pip installs run from elsewhere,
+fail the check, and are never touched by the updater.** Either misdetection
+fails safe (a wrong "managed" hits "no bin/uv" and aborts cleanly; a wrong
+"pip" just points you at pip), so no on-disk receipt is needed.
 
 ## 4. Hosting (decided)
 
@@ -114,7 +117,7 @@ breakage is possible from un-hosting.
 ## 5. Single channel (latest only)
 
 There is one channel: whatever `releases/latest` points at. No `stable`/`beta`/
-`canary` split, no per-channel manifests, no channel field in the receipt. If a
+`canary` split, no per-channel manifests, no channel tracking. If a
 staged-rollout lever is ever wanted, a second manifest file served at a
 different path is the natural seam — but it is explicitly **not** pursued now.
 
@@ -148,9 +151,9 @@ costs nothing extra on top of single-version (the mechanism already exists for
 pinning).
 
 ### Same-method discipline
-pip installs (no receipt) get the correct `pip install --upgrade vastai` hint
-and exit — **never shell out to a guessed pip.** Matches uv's behavior
-(self-update disabled when installed another way).
+pip installs (which fail the managed-install check) get the correct
+`pip install --upgrade vastai` hint and exit — **never shell out to a guessed
+pip.** Matches uv's behavior (self-update disabled when installed another way).
 
 ### Optional later: download cache
 A cache of the last few wheels at `~/.cache/vastai/` would make a re-pin/
@@ -159,6 +162,11 @@ oldest, a miss simply re-fetches, no "don't delete what's running" invariant.
 Not built in v1.
 
 ## 7. Passive update nudge
+
+> **Status: implemented but disabled.** The call is commented out in
+> `main.py` — updates are manual via `vastai update` for now. Re-enable the
+> two lines when we want the per-command check (the logic and tests below all
+> exist and pass).
 
 - After commands: at most **one manifest GET and one stderr line per 24h**, hard
   1s timeout, every failure silent with 24h backoff (offline machines pay ≤1s
@@ -233,11 +241,12 @@ until launch.
 1. **PR 1 (this PR):** installer scripts, manifest generator, hermetic tests,
    dormant `vastai update` implementation + unit tests, this doc. **No-op for
    the existing CLI** — `main.py` and workflows untouched.
-2. **PR 2 (activation):** register `update` + nudge in `main.py`; add the
-   `scripts/publish_release.py` orchestrator (§13) and the release-CI wiring
-   that calls it (attach `manifest.{json,env}` + `install.sh` to the GitHub
-   Release; post-publish install smoke test on clean ubuntu/macos runners;
-   shellcheck + hermetic-test job on PRs).
+2. **PR 2 (activation):** register the `update` command in `main.py` (the
+   passive nudge is wired but left **commented out** — manual `vastai update`
+   only for now, §7); add the `scripts/publish_release.py` orchestrator (§13)
+   and the release-CI wiring that calls it (attach `manifest.{json,env}` +
+   `install.sh` to the GitHub Release; post-publish install smoke test on a
+   clean ubuntu runner — macOS deferred; shellcheck + hermetic-test job on PRs).
 3. **Tag a release** so `releases/latest` assets exist.
 4. **Deploy the `vast_landing` redirects** — the activation point.
 5. **Internal testing:** TTY checklist (consent prompts, nudge UX, offline
@@ -246,10 +255,11 @@ until launch.
    update` and a `--version` downgrade.
 6. **Launch:** flip README to split install (CLI via installer, SDK via pip).
 
-## 13. Release runbook (manual until the activation PR automates it)
+## 13. Release runbook
 
-PyPI publishing stays automated (`python-publish.yml` on tag push). Manual for
-now is the installer side. ~10 min:
+A release is triggered by pushing a `vX.Y.Z` tag — `python-publish.yml` then
+publishes to PyPI and attaches the installer assets via `publish_release.py
+--ci`. The manual equivalent, for reference / break-glass (~10 min):
 
 ```bash
 git tag v1.0.14 && git push origin v1.0.14         # existing CI publishes to PyPI
@@ -276,19 +286,22 @@ Rules the automation must enforce (a human must remember for now):
 - **Upload `install.sh` from the tagged commit**, not a dirty working tree.
 - Once redirects are live, **the asset upload *is* the deploy** — verify immediately.
 
-### Planned: `scripts/publish_release.py` (one orchestrator, human + CI)
+### `scripts/publish_release.py` (one orchestrator, human + CI)
 
 The four rules above are exactly the things a human forgets, so the runbook
-collapses into a single script — built as **one orchestrator both a human and
-CI invoke**, so the dangerous steps have one implementation, not a local copy
-plus a divergent YAML copy. Slated for **PR 2 (activation)**, not this PR, since
-it is activation machinery (keeps this PR a no-op for the existing CLI).
+collapses into a single script — **one orchestrator both a human and CI invoke**,
+so the dangerous steps have one implementation, not a local copy plus a
+divergent YAML copy.
 
 ```bash
 scripts/publish_release.py 1.0.14            # local: tag → wait for PyPI → manifest → gh release → verify
 scripts/publish_release.py 1.0.14 --ci       # CI: hash dist/*.whl → manifest → attach (tag/poll skipped)
 scripts/publish_release.py 1.0.14 --dry-run  # print every action, touch nothing
 ```
+
+The version is always explicit (it's the tag the deployer chose). Computing the
+next version from the latest tag (`major|minor|patch`) is deliberately left out
+for now — pick the version when you tag.
 
 It wraps the existing `make_manifest.py` (no duplicated logic) and differs only
 by context:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -104,8 +104,7 @@ detect_platform() {
     PLATFORM_KEY="${os}_${arch}${libc}"
 }
 
-# is_interactive — can we prompt the user? (stdin is the pipe under curl|bash,
-# and /dev/tty may exist yet be unopenable when there's no controlling terminal)
+# is_interactive — can we prompt? (/dev/tty may exist yet be unopenable)
 is_interactive() { ( : < /dev/tty > /dev/tty; ) 2>/dev/null; }
 
 # ask_yn PROMPT — returns 0 on yes
@@ -128,8 +127,9 @@ install_uv() {
     local url sha tarball
     url="$(manifest_get "UV_URL_$PLATFORM_KEY")"
     sha="$(manifest_get "UV_SHA256_$PLATFORM_KEY")"
-    [ -n "$url" ] && [ -n "$sha" ] \
-        || die "no build available for your platform ($PLATFORM_KEY) — install with pip instead: pip install vastai"
+    if [ -z "$url" ] || [ -z "$sha" ]; then
+        die "no build available for your platform ($PLATFORM_KEY) — install with pip instead: pip install vastai"
+    fi
 
     say "Downloading runtime bootstrap..."
     tarball="$WORKDIR/uv.tar.gz"
@@ -154,8 +154,7 @@ install_version() {
     rm -rf "$newdir"
     export UV_PYTHON_INSTALL_DIR="$ROOT/python"
     export UV_PYTHON_PREFERENCE="only-managed"
-    # --relocatable: entry-point shebangs must not hardcode the build path, so
-    # the venv still works after it's renamed from .env.new into place.
+    # --relocatable: shebangs must not hardcode the build path (env is renamed into place).
     if ! "$ROOT/bin/uv" venv "$newdir" --python "$python_pin" --relocatable --quiet; then
         rm -rf "$newdir"
         die "could not set up the Python $python_pin runtime"
@@ -168,8 +167,7 @@ install_version() {
     "$newdir/bin/vastai" --version >/dev/null \
         || { rm -rf "$newdir"; die "installed CLI failed its smoke test"; }
 
-    # Single active install: swap the freshly built env in. The live env is
-    # only touched by renames, so an interrupted build never breaks it.
+    # Swap built env in via renames; an interrupted build can't break the live env.
     rm -rf "$ROOT/.env.old"
     [ -d "$envdir" ] && mv "$envdir" "$ROOT/.env.old"
     mv "$newdir" "$envdir"
@@ -180,25 +178,6 @@ install_version() {
     for name in vastai serve-vast-deployment register-python-argcomplete; do
         [ -e "$envdir/bin/$name" ] && link_swap "../env/bin/$name" "$ROOT/bin/$name"
     done
-}
-
-write_receipt() {
-    local version="$1" python_pin="$2" previous="null"
-    if [ -f "$ROOT/install-receipt.json" ]; then
-        previous="$(sed -n 's/.*"version": *"\([^"]*\)".*/"\1"/p' "$ROOT/install-receipt.json" | head -n 1)"
-        [ -n "$previous" ] || previous="null"
-    fi
-    cat > "$ROOT/install-receipt.json" <<EOF
-{
-  "method": "installer",
-  "installer_version": "1",
-  "version": "$version",
-  "previous_version": $previous,
-  "python": "cpython-$python_pin",
-  "artifact": "pypi-wheel",
-  "installed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-}
-EOF
 }
 
 setup_path() {
@@ -265,12 +244,13 @@ main() {
     [ "$schema" = "1" ] || die "manifest schema '$schema' not understood by this installer; get the latest from https://vast.ai/install.sh"
     latest="$(manifest_get LATEST)"
     python_pin="$(manifest_get PYTHON)"
-    [ -n "$latest" ] && [ -n "$python_pin" ] || die "malformed release manifest"
+    if [ -z "$latest" ] || [ -z "$python_pin" ]; then
+        die "malformed release manifest"
+    fi
     version="${VASTAI_VERSION:-$latest}"
 
     install_uv
     install_version "$version" "$python_pin"
-    write_receipt "$version" "$python_pin"
     setup_path
     check_pip_coexistence
 

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Publish a Vast CLI release: tag → manifest → attach Release assets → verify.
+
+One orchestrator for both humans and CI (docs/install-design.md §13). The
+deterministic core (manifest rendering) lives in make_manifest.py; this wraps
+it with the release steps and the guardrails the manual runbook can't enforce
+by itself.
+
+    # local (manual window): tag, wait for PyPI, build+attach manifest, verify
+    python scripts/publish_release.py 1.0.14
+
+    # CI (on tag push): tag already pushed, wheel already in dist/
+    python scripts/publish_release.py 1.0.14 --ci
+
+    # see every action without doing anything
+    python scripts/publish_release.py 1.0.14 --dry-run
+
+Local vs --ci differ only in: who pushes the tag (you / the trigger), where the
+wheel comes from (PyPI poll / dist/), and gh auth (your creds / GITHUB_TOKEN).
+
+stdlib only — must run on a bare CI python with no project deps installed.
+Requires `git`, `gh`, and `pip` on PATH; `bash` for the verify step.
+"""
+
+import argparse
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+MAKE_MANIFEST = REPO_ROOT / "scripts" / "make_manifest.py"
+PACKAGE = "vastai"
+RELEASE_BASE_URL = "https://github.com/vast-ai/vast-cli/releases/latest/download"
+PYPI_POLL_TIMEOUT_S = 15 * 60
+PYPI_POLL_INTERVAL_S = 15
+
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+([.\-+].+)?$")
+
+
+class ReleaseError(Exception):
+    pass
+
+
+def log(msg):
+    print(f"publish-release: {msg}", flush=True)
+
+
+def run(cmd, *, dry, capture=False, check=True, env=None):
+    """Run a command (or just print it under --dry-run)."""
+    printable = " ".join(str(c) for c in cmd)
+    if dry:
+        log(f"[dry-run] {printable}")
+        return None
+    log(f"$ {printable}")
+    try:
+        return subprocess.run(
+            [str(c) for c in cmd], check=check, env=env,
+            capture_output=capture, text=True,
+        )
+    except FileNotFoundError:
+        raise ReleaseError(f"required tool not found: {cmd[0]}")
+    except subprocess.CalledProcessError as e:
+        detail = (e.stderr or e.stdout or "").strip() if capture else ""
+        raise ReleaseError(f"command failed: {printable}" + (f"\n{detail}" if detail else ""))
+
+
+def confirm(prompt, *, assume_yes, dry):
+    if assume_yes or dry:
+        return True
+    if not sys.stdin.isatty():
+        raise ReleaseError(f"{prompt} (no TTY; pass --yes to proceed non-interactively)")
+    return input(f"{prompt} [y/N] ").strip().lower() in ("y", "yes")
+
+
+# ---------------------------------------------------------------------------
+# Steps
+# ---------------------------------------------------------------------------
+
+def check_clean_tree(dry):
+    out = run(["git", "status", "--porcelain"], dry=False, capture=True)
+    if out.stdout.strip():
+        if dry:
+            log("[dry-run] working tree is dirty (would abort in a real run)")
+        else:
+            raise ReleaseError("working tree is dirty — commit or stash before releasing")
+
+
+def tag_exists(tag):
+    local = subprocess.run(["git", "rev-parse", "-q", "--verify", f"refs/tags/{tag}"],
+                           capture_output=True, text=True)
+    if local.returncode == 0:
+        return True
+    remote = subprocess.run(["git", "ls-remote", "--tags", "origin", tag],
+                            capture_output=True, text=True)
+    return bool(remote.stdout.strip())
+
+
+def ensure_tag_pushed(tag, *, assume_yes, dry):
+    """Create + push the tag (triggers the PyPI publish workflow). Idempotent."""
+    if tag_exists(tag):
+        log(f"{tag} already exists — skipping tag/push (re-run or CI trigger)")
+        return
+    if not confirm(f"Tag and push {tag}? This triggers the PyPI publish.",
+                   assume_yes=assume_yes, dry=dry):
+        raise ReleaseError("aborted before tagging")
+    run(["git", "tag", tag], dry=dry)
+    run(["git", "push", "origin", tag], dry=dry)
+
+
+def wait_for_pypi(version, dry):
+    """Poll PyPI until the version is downloadable."""
+    url = f"https://pypi.org/pypi/{PACKAGE}/{version}/json"
+    if dry:
+        log(f"[dry-run] poll {url} until available")
+        return
+    log(f"waiting for {PACKAGE}=={version} on PyPI ...")
+    start = time.monotonic()
+    while True:
+        try:
+            with urllib.request.urlopen(url, timeout=10) as r:
+                if r.status == 200:
+                    log(f"{PACKAGE}=={version} is live on PyPI")
+                    return
+        except Exception:
+            pass
+        if time.monotonic() - start > PYPI_POLL_TIMEOUT_S:
+            raise ReleaseError(f"timed out waiting for {PACKAGE}=={version} on PyPI")
+        time.sleep(PYPI_POLL_INTERVAL_S)
+
+
+def resolve_wheel(version, workdir, *, ci, dry):
+    """Return the path to the wheel to hash.
+
+    --ci: the wheel poetry just built/published is in dist/ — hash those exact
+    bytes. Local: download the published wheel from PyPI.
+    """
+    if ci:
+        matches = sorted(glob.glob(str(REPO_ROOT / "dist" / f"{PACKAGE}-{version}-*.whl")))
+        if matches:
+            return matches[0]
+        if dry:
+            log(f"[dry-run] would hash dist/{PACKAGE}-{version}-*.whl")
+            return f"dist/{PACKAGE}-{version}-<built>.whl"
+        raise ReleaseError(f"--ci: no dist/{PACKAGE}-{version}-*.whl (run poetry publish --build first)")
+    if dry:
+        log(f"[dry-run] pip download {PACKAGE}=={version} into {workdir}")
+        return str(Path(workdir) / f"{PACKAGE}-{version}-py3-none-any.whl")
+    run(["pip", "download", f"{PACKAGE}=={version}", "--no-deps", "-d", workdir],
+        dry=False, capture=True)
+    matches = sorted(glob.glob(str(Path(workdir) / f"{PACKAGE}-{version}-*.whl")))
+    if not matches:
+        raise ReleaseError(f"could not download {PACKAGE}=={version} wheel from PyPI")
+    return matches[0]
+
+
+def render_manifest(version, wheel, outdir, *, dry):
+    run([sys.executable, MAKE_MANIFEST, "--version", version,
+         "--wheel", wheel, "--out", outdir], dry=dry, capture=True)
+
+
+def attach_release(tag, manifest_dir, *, dry):
+    """Create the Release (if missing) and upload the three assets."""
+    if dry:
+        log(f"[dry-run] gh release create/view {tag}; "
+            f"gh release upload {tag} --clobber manifest.json manifest.env install.sh")
+        return
+    exists = subprocess.run(["gh", "release", "view", tag],
+                            capture_output=True, text=True).returncode == 0
+    if not exists:
+        run(["gh", "release", "create", tag, "--title", tag,
+             "--notes", f"{PACKAGE} {tag.lstrip('v')}"], dry=dry)
+    else:
+        log(f"release {tag} exists — updating assets")
+    run(["gh", "release", "upload", tag, "--clobber",
+         str(Path(manifest_dir) / "manifest.json"),
+         str(Path(manifest_dir) / "manifest.env"),
+         str(INSTALL_SH)], dry=dry)
+
+
+def verify_install(version, *, dry):
+    """Install from the just-published Release URL into a throwaway root."""
+    if dry:
+        log(f"[dry-run] install from {RELEASE_BASE_URL} and check --version == {version}")
+        return
+    with tempfile.TemporaryDirectory() as root:
+        env = dict(os.environ,
+                   VASTAI_CLI_BASE_URL=RELEASE_BASE_URL,
+                   VASTAI_INSTALL_DIR=root,
+                   VASTAI_NO_MODIFY_PATH="1")
+        run(["bash", str(INSTALL_SH)], dry=False, env=env, capture=True)
+        out = run([str(Path(root) / "bin" / "vastai"), "--version"], dry=False, capture=True)
+        got = (out.stdout or "").strip()
+        if version not in got:
+            raise ReleaseError(f"verify failed: installed CLI reports {got!r}, expected {version}")
+        log(f"verified: a fresh install from the Release reports {got}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("version", help="release version, no leading v (e.g. 1.0.14)")
+    ap.add_argument("--ci", action="store_true",
+                    help="CI mode: tag already pushed, hash the wheel in dist/ (no PyPI poll)")
+    ap.add_argument("--dry-run", action="store_true", help="print every action, change nothing")
+    ap.add_argument("--yes", action="store_true", help="skip confirmation prompts")
+    ap.add_argument("--skip-verify", action="store_true",
+                    help="skip the post-publish install check (CI runs it as a separate matrix job)")
+    args = ap.parse_args()
+
+    version, dry, ci = args.version, args.dry_run, args.ci
+    tag = f"v{version}"
+    if not VERSION_RE.match(version):
+        ap.error(f"version {version!r} is not X.Y.Z[suffix]")
+
+    try:
+        if ci:
+            log(f"CI release for {tag} (tag already pushed; wheel from dist/)")
+        else:
+            check_clean_tree(dry)
+            ensure_tag_pushed(tag, assume_yes=args.yes, dry=dry)
+            wait_for_pypi(version, dry)
+
+        with tempfile.TemporaryDirectory() as workdir:
+            wheel = resolve_wheel(version, workdir, ci=ci, dry=dry)
+            log(f"hashing wheel: {wheel}")
+            render_manifest(version, wheel, workdir, dry=dry)
+            if not confirm(f"Attach manifest + install.sh to GitHub Release {tag}?",
+                           assume_yes=args.yes or ci, dry=dry):
+                raise ReleaseError("aborted before publishing the Release")
+            attach_release(tag, workdir, dry=dry)
+
+        if args.skip_verify:
+            log("skipping verify (--skip-verify)")
+        else:
+            verify_install(version, dry=dry)
+
+        log(f"done — {tag} published" + (" (dry-run, nothing changed)" if dry else ""))
+        return 0
+    except ReleaseError as e:
+        print(f"publish-release: error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -1,9 +1,8 @@
-"""Tests for the (dormant) `vastai update` command and self-update machinery.
+"""Tests for the `vastai update` command and self-update machinery.
 
-The command is not registered in vastai.cli.main yet; tests/conftest.py
-imports it onto the test parser. Coverage focuses on the core invariants:
-atomic swap/rollback safety, the pip-install refusal, exit-code contract,
-and the nudge's silence guarantees (offline, throttled, suppressed).
+Coverage focuses on the core invariants: atomic swap safety, structural
+managed-install detection, the pip-install refusal, exit-code contract, and
+the nudge's silence guarantees (offline, throttled, suppressed).
 """
 
 import os
@@ -16,8 +15,7 @@ import pytest
 
 from vastai.cli import selfupdate
 from vastai.cli.selfupdate import (
-    UpdateError, is_newer, version_key, read_receipt, write_receipt,
-    perform_update,
+    UpdateError, is_newer, version_key, is_managed_install, perform_update,
 )
 
 MANIFEST = {
@@ -54,13 +52,6 @@ def install_root(tmp_path, monkeypatch):
     return root
 
 
-@pytest.fixture
-def managed_receipt(install_root):
-    receipt = {"method": "installer", "version": "1.2.3", "previous_version": None}
-    write_receipt(receipt)
-    return receipt
-
-
 def _seed_env(root, version):
     """Create a live env/ with a runnable vastai (a prior install to replace)."""
     bindir = root / "env" / "bin"
@@ -70,12 +61,22 @@ def _seed_env(root, version):
     exe.chmod(exe.stat().st_mode | stat.S_IXUSR)
 
 
-def test_receipt_never_raises(install_root):
-    assert read_receipt() is None  # missing
-    (install_root / "install-receipt.json").write_text("{not json")
-    assert read_receipt() is None  # corrupt
-    write_receipt({"method": "installer", "version": "1.0.0"})
-    assert read_receipt() == {"method": "installer", "version": "1.0.0"}
+class TestIsManagedInstall:
+    def test_true_when_running_from_env_next_to_uv(self, install_root, monkeypatch):
+        (install_root / "env").mkdir()
+        (install_root / "bin" / "uv").write_text("")
+        monkeypatch.setattr(sys, "prefix", str(install_root / "env"))
+        assert is_managed_install() is True
+
+    def test_false_for_pip_install(self, install_root, monkeypatch):
+        # interpreter runs from somewhere else (a pip/venv install)
+        monkeypatch.setattr(sys, "prefix", str(install_root.parent / "some-venv"))
+        assert is_managed_install() is False
+
+    def test_false_when_uv_missing(self, install_root, monkeypatch):
+        (install_root / "env").mkdir()  # env present but no bin/uv
+        monkeypatch.setattr(sys, "prefix", str(install_root / "env"))
+        assert is_managed_install() is False
 
 
 # Fake uv: `uv venv DIR ...` and `uv pip install --python PY ... vastai==VER`
@@ -110,22 +111,18 @@ def fake_uv(install_root):
            "these tests execute shell-script fakes",
 )
 class TestPerformUpdate:
-    def test_success_swaps_in_new_env(self, install_root, managed_receipt, fake_uv):
+    def test_success_swaps_in_new_env(self, install_root, fake_uv):
         _seed_env(install_root, "1.2.3")
-        perform_update("1.3.0", MANIFEST, receipt=managed_receipt)
+        perform_update("1.3.0", MANIFEST)
 
-        # single fixed env, symlink points into it, no version retention
+        # single fixed env, symlink points into it, new version live, no retention
         assert "env/bin/vastai" in os.readlink(str(install_root / "bin" / "vastai"))
         assert (install_root / "env" / "bin" / "vastai").exists()
+        assert "1.3.0" in (install_root / "env" / "bin" / "vastai").read_text()
         assert not (install_root / ".env.new").exists()
         assert not (install_root / "versions").exists()
-        receipt = read_receipt()
-        assert receipt["version"] == "1.3.0"
-        assert receipt["previous_version"] == "1.2.3"
 
-    def test_failure_leaves_current_install_untouched(
-        self, install_root, managed_receipt
-    ):
+    def test_failure_leaves_current_install_untouched(self, install_root):
         _seed_env(install_root, "1.2.3")  # live install that must survive
         before = (install_root / "env" / "bin" / "vastai").read_text()
         uv = install_root / "bin" / "uv"
@@ -133,11 +130,10 @@ class TestPerformUpdate:
         uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
 
         with pytest.raises(UpdateError):
-            perform_update("1.3.0", MANIFEST, receipt=managed_receipt)
+            perform_update("1.3.0", MANIFEST)
 
         assert (install_root / "env" / "bin" / "vastai").read_text() == before
         assert not (install_root / ".env.new").exists()
-        assert read_receipt()["version"] == "1.2.3"
 
 
 class TestUpdateCommand:
@@ -151,26 +147,29 @@ class TestUpdateCommand:
             assert args.func(args) == 10
         assert "Update available: 1.3.0" in capsys.readouterr().out
 
-    def test_pip_install_refused_with_hint(self, parse_argv, capsys, install_root):
-        args = parse_argv(["update"])  # no receipt under install_root
-        assert args.func(args) == 1
+    def test_pip_install_refused_with_hint(self, parse_argv, capsys):
+        # not a managed install (interpreter isn't under ~/.vastai/env)
+        args = parse_argv(["update"])
+        with patch("vastai.cli.commands.update.is_managed_install", return_value=False):
+            assert args.func(args) == 1
         assert "pip install --upgrade vastai" in capsys.readouterr().err
 
-    def test_version_flag_targets_specific_version(self, parse_argv, managed_receipt):
+    def test_version_flag_targets_specific_version(self, parse_argv):
         args = parse_argv(["update", "--version", "1.2.9"])
-        with patch("vastai.cli.commands.update.fetch_manifest", return_value=MANIFEST), \
+        with patch("vastai.cli.commands.update.is_managed_install", return_value=True), \
+             patch("vastai.cli.commands.update.fetch_manifest", return_value=MANIFEST), \
              patch("vastai.cli.commands.update.perform_update") as mock_update:
             assert args.func(args) == 0
-        mock_update.assert_called_once_with("1.2.9", MANIFEST, receipt=managed_receipt)
+        mock_update.assert_called_once_with("1.2.9", MANIFEST)
 
 
 @pytest.fixture
 def nudge_env(tmp_path, monkeypatch):
     """Environment where the nudge is allowed to fire: tty stderr, no CI,
-    empty install root (not the developer's real ~/.vastai)."""
+    not a managed install (so the hint defaults to pip)."""
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("VASTAI_NO_UPDATE_CHECK", raising=False)
-    monkeypatch.setenv("VASTAI_INSTALL_DIR", str(tmp_path / "no-receipt-root"))
+    monkeypatch.setenv("VASTAI_INSTALL_DIR", str(tmp_path / "root"))
     monkeypatch.setattr(selfupdate, "UPDATE_CHECK_FILE", str(tmp_path / "check.json"))
     monkeypatch.setattr(selfupdate, "VERSION", "1.0.0")
     monkeypatch.setattr(selfupdate, "_stderr_is_tty", lambda: True)
@@ -178,22 +177,29 @@ def nudge_env(tmp_path, monkeypatch):
 
 
 class TestNudge:
-    def test_fires_when_stale_with_method_aware_hint(self, nudge_env, capsys):
+    def test_fires_when_stale_with_pip_hint_for_pip_install(self, nudge_env, capsys):
+        # not a managed install (real interpreter prefix) -> pip hint
         with patch.object(selfupdate, "fetch_manifest", return_value=MANIFEST):
-            selfupdate.maybe_notify_update(nudge_env)
+            selfupdate.notify_update(nudge_env)
         err = capsys.readouterr().err
         assert "1.3.0 is available" in err
-        assert "pip install --upgrade vastai" in err  # no receipt -> pip hint
+        assert "pip install --upgrade vastai" in err
+
+    def test_managed_install_gets_vastai_update_hint(self, nudge_env, capsys):
+        with patch.object(selfupdate, "fetch_manifest", return_value=MANIFEST), \
+             patch.object(selfupdate, "is_managed_install", return_value=True):
+            selfupdate.notify_update(nudge_env)
+        assert "Run `vastai update`" in capsys.readouterr().err
 
     def test_silent_on_fetch_failure(self, nudge_env, capsys):
         with patch.object(selfupdate, "fetch_manifest", side_effect=UpdateError("down")):
-            selfupdate.maybe_notify_update(nudge_env)
+            selfupdate.notify_update(nudge_env)
         assert capsys.readouterr().err == ""
 
     def test_one_check_and_one_notice_per_24h(self, nudge_env, capsys):
         with patch.object(selfupdate, "fetch_manifest", return_value=MANIFEST) as f:
-            selfupdate.maybe_notify_update(nudge_env)
-            selfupdate.maybe_notify_update(nudge_env)
+            selfupdate.notify_update(nudge_env)
+            selfupdate.notify_update(nudge_env)
         assert f.call_count == 1
         assert capsys.readouterr().err.count("is available") == 1
 
@@ -206,10 +212,10 @@ class TestNudge:
     def test_suppressed_makes_no_network_call(self, nudge_env, monkeypatch, capsys, mute):
         mute(monkeypatch, nudge_env)
         with patch.object(selfupdate, "fetch_manifest", return_value=MANIFEST) as f:
-            selfupdate.maybe_notify_update(nudge_env)
+            selfupdate.notify_update(nudge_env)
         assert f.call_count == 0
         assert capsys.readouterr().err == ""
 
     def test_never_raises(self, nudge_env):
         with patch.object(selfupdate, "_load_check_state", side_effect=RuntimeError("boom")):
-            selfupdate.maybe_notify_update(nudge_env)  # must not raise
+            selfupdate.notify_update(nudge_env)  # must not raise

--- a/tests/installer/run_tests.sh
+++ b/tests/installer/run_tests.sh
@@ -131,22 +131,22 @@ out_contains() { grep -q "$1" "$SB_OUT"; }
 # Scenarios
 # ---------------------------------------------------------------------------
 
-test_fresh_install() { # happy path: fixed env symlink, receipt, runnable CLI
+test_fresh_install() { # happy path: fixed env symlink, runnable CLI, managed layout
     new_sandbox fresh
     run_install || { cat "$SB_OUT"; return 1; }
     assert "vastai symlink -> env bin" \
         [ "$(readlink "$SB_ROOT/bin/vastai")" = "../env/bin/vastai" ] &&
     assert "installed CLI runs" [ "$("$SB_ROOT/bin/vastai" --version)" = "1.2.3" ] &&
-    assert "receipt says installer" grep -q '"method": "installer"' "$SB_ROOT/install-receipt.json" &&
+    assert "managed-install markers present (env/ + bin/uv)" \
+        [ -d "$SB_ROOT/env" ] && [ -x "$SB_ROOT/bin/uv" ] &&
     assert "local bin link exists" [ -L "$SB_HOME/.local/bin/vastai" ]
 }
 
-test_pinned_reinstall() { # VASTAI_VERSION pin replaces in place; receipt chains
+test_pinned_reinstall() { # VASTAI_VERSION pin replaces env in place, no retention
     new_sandbox reinstall
     run_install || { cat "$SB_OUT"; return 1; }
     run_install VASTAI_VERSION=0.9.9 || { cat "$SB_OUT"; return 1; }
     assert "pinned version live" [ "$("$SB_ROOT/bin/vastai" --version)" = "0.9.9" ] &&
-    assert "previous chained in receipt" grep -q '"previous_version": "1.2.3"' "$SB_ROOT/install-receipt.json" &&
     assert "single active install, no version retention" [ ! -e "$SB_ROOT/versions" ] &&
     assert "no leftover temp env" [ ! -e "$SB_ROOT/.env.new" ]
 }

--- a/vastai/cli/commands/update.py
+++ b/vastai/cli/commands/update.py
@@ -1,14 +1,9 @@
 """`vastai update` — self-update for managed (curl | bash installer) installs.
 
-NOT YET REGISTERED: intentionally absent from the command imports in
-``vastai.cli.main`` (and from the post-command nudge), so the command does not
-exist in the shipped CLI yet. Activation is a follow-up once the hosted
-manifests are live — see docs/install-design.md. Tests register it via
-tests/conftest.py.
-
-pip installs have no install receipt; for those this command only prints the
-correct pip upgrade instructions and exits non-zero — it never shells out to
-pip, since the CLI cannot know which pip/venv owns its environment.
+pip installs aren't managed by the installer; for those this command only
+prints the correct pip upgrade instructions and exits non-zero — it never
+shells out to pip, since the CLI cannot know which pip/venv owns its
+environment.
 """
 
 import sys
@@ -18,7 +13,7 @@ from vastai.cli.display import deindent
 from vastai.cli.util import VERSION
 from vastai.cli.selfupdate import (
     INSTALL_SH_HINT, PIP_UPGRADE_HINT, UpdateError,
-    fetch_manifest, is_newer, perform_update, read_receipt,
+    fetch_manifest, is_managed_install, is_newer, perform_update,
 )
 from vastai.cli.utils import get_parser as _get_parser
 
@@ -51,8 +46,7 @@ def update(args):
             print(f"vastai {VERSION} is up to date (latest: {latest})")
             return 0
 
-        receipt = read_receipt()
-        if not receipt or receipt.get("method") != "installer":
+        if not is_managed_install():
             print(
                 "This CLI was not installed with the managed installer, so it "
                 f"cannot self-update.\n  Installed via pip? Run: {PIP_UPGRADE_HINT}\n"
@@ -63,12 +57,12 @@ def update(args):
 
         manifest = fetch_manifest()
         target = args.target_version or manifest["latest"]
-        current = receipt.get("version") or VERSION
+        current = VERSION
         if target == current:
             print(f"vastai {current} is already installed.")
             return 0
         print(f"Updating vastai {current} -> {target} ...")
-        perform_update(target, manifest, receipt=receipt)
+        perform_update(target, manifest)
         print(f"Done. vastai is now {target} (roll back with `vastai update --version {current}`).")
         return 0
 

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -79,6 +79,7 @@ def main():
         billing, storage, auth, misc, deployments, metrics,
         benchmarks,
         price_increase,
+        update,
         # clusters,  # cluster/overlay commands disabled for now
     )
 
@@ -137,6 +138,10 @@ def main():
     while True:
         try:
             res = args.func(args)
+
+            # Passive upgrade nudge — disabled for now (manual `vastai update`).
+            # from vastai.cli.selfupdate import notify_update; notify_update(args)
+
             if args.raw and res is not None:
                 try:
                     print(json.dumps(res, indent=1, sort_keys=True))

--- a/vastai/cli/selfupdate.py
+++ b/vastai/cli/selfupdate.py
@@ -2,9 +2,13 @@
 
 Layout (docs/install-design.md): everything under $VASTAI_INSTALL_DIR
 (default ~/.vastai) — a single active venv at env/, with bin/vastai a fixed
-symlink into it, and install-receipt.json recording how the CLI was installed.
-Updating rebuilds env/ in place (build temp → verify → swap); there is no
-version retention. No receipt means pip owns the install and we never touch it.
+symlink into it. Updating rebuilds env/ in place (build temp → verify → swap);
+there is no version retention.
+
+"Managed install?" is detected structurally (``is_managed_install``): a managed
+CLI runs from ~/.vastai/env with a sibling ~/.vastai/bin/uv. That's ground
+truth — no on-disk marker to drift or hand-copy. pip installs fail the check
+and the updater never touches them.
 
 The passive nudge is throttled to one manifest GET and one notice per 24h,
 capped at 1s, and swallows every failure — the CLI must never get slower or
@@ -18,7 +22,6 @@ import shutil
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
@@ -42,30 +45,28 @@ class UpdateError(Exception):
 
 
 # ---------------------------------------------------------------------------
-# Receipt / manifest / versions
+# Install detection / manifest / versions
 # ---------------------------------------------------------------------------
 
 def install_root() -> Path:
     return Path(os.environ.get("VASTAI_INSTALL_DIR") or Path.home() / ".vastai")
 
 
-def read_receipt():
-    """Install receipt dict, or None for non-managed (pip) installs."""
+def is_managed_install() -> bool:
+    """True iff this CLI was installed by the managed installer.
+
+    Detected from where the interpreter actually runs: a managed CLI lives in
+    ``<root>/env`` next to ``<root>/bin/uv``. Ground truth, no marker file.
+    pip installs run from elsewhere and fail the check.
+    """
     try:
-        with open(install_root() / "install-receipt.json") as f:
-            data = json.load(f)
-        return data if isinstance(data, dict) else None
-    except (OSError, ValueError):
-        return None
-
-
-def write_receipt(receipt: dict) -> None:
-    path = install_root() / "install-receipt.json"
-    tmp = path.with_suffix(".tmp")
-    with open(tmp, "w") as f:
-        json.dump(receipt, f, indent=2)
-        f.write("\n")
-    os.replace(tmp, path)
+        root = install_root()
+        return (
+            Path(sys.prefix).resolve() == (root / "env").resolve()
+            and (root / "bin" / "uv").exists()
+        )
+    except Exception:
+        return False
 
 
 def fetch_manifest(timeout: float = 10.0) -> dict:
@@ -136,15 +137,15 @@ def _stderr_is_tty() -> bool:
         return False
 
 
-def maybe_notify_update(args=None) -> None:
+def notify_update(args=None) -> None:
     """Post-command, best-effort upgrade nudge. Must never raise or block."""
     try:
-        _maybe_notify_update(args)
+        _notify_update(args)
     except Exception:
         pass
 
 
-def _maybe_notify_update(args) -> None:
+def _notify_update(args) -> None:
     suppressed = (
         os.environ.get("VASTAI_NO_UPDATE_CHECK")
         or os.environ.get("CI")
@@ -172,8 +173,7 @@ def _maybe_notify_update(args) -> None:
     if now - state.get("notified_at", 0) <= CHECK_INTERVAL_S:
         return
 
-    receipt = read_receipt()
-    hint = "vastai update" if receipt and receipt.get("method") == "installer" else PIP_UPGRADE_HINT
+    hint = "vastai update" if is_managed_install() else PIP_UPGRADE_HINT
     arrow = "↑" if "utf" in (sys.stderr.encoding or "").lower() else "*"
     print(
         f"{arrow} vastai {latest} is available (you have {VERSION}). Run `{hint}`.",
@@ -212,7 +212,7 @@ def _link_binaries(root: Path) -> None:
         os.replace(tmp, link)
 
 
-def perform_update(target: str, manifest: dict, *, receipt: dict) -> None:
+def perform_update(target: str, manifest: dict) -> None:
     """Install ``target`` into a fresh env, verify it, then swap it in.
 
     Single active install (the deno model): the new env is built in a temp dir
@@ -235,8 +235,7 @@ def perform_update(target: str, manifest: dict, *, receipt: dict) -> None:
                   UV_PYTHON_INSTALL_DIR=str(root / "python"),
                   UV_PYTHON_PREFERENCE="only-managed")
     try:
-        # --relocatable: entry-point shebangs must not hardcode the build path,
-        # so the venv still works after .env.new is renamed into place.
+        # --relocatable: shebangs must not hardcode the build path (env is renamed into place).
         _run([uv, "venv", new_dir, "--python", python_pin, "--relocatable", "--quiet"], env=uv_env)
         _run([uv, "pip", "install", "--python", new_dir / "bin" / "python",
               "--quiet", f"vastai=={target}"], env=uv_env)
@@ -249,19 +248,10 @@ def perform_update(target: str, manifest: dict, *, receipt: dict) -> None:
         shutil.rmtree(new_dir, ignore_errors=True)
         raise
 
-    # Swap: the live env is only ever touched by these two renames (~instant);
-    # a crash mid-build dirties .env.new, never the running install.
+    # Swap via two renames (~instant); a crash mid-build only dirties .env.new.
     shutil.rmtree(old_dir, ignore_errors=True)
     if env_dir.exists():
         os.replace(env_dir, old_dir)
     os.replace(new_dir, env_dir)
     _link_binaries(root)
     shutil.rmtree(old_dir, ignore_errors=True)
-
-    receipt = dict(receipt)
-    receipt.update(
-        version=target,
-        previous_version=receipt.get("version"),
-        installed_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
-    )
-    write_receipt(receipt)


### PR DESCRIPTION
## Summary

Activation follow-up to the installer PR (#419). Turns on `vastai update`, adds the release tooling + CI that produces installer assets, and switches managed-install detection to a structural check. **Still dark** — the per-command nudge is disabled and the `vast.ai/install.sh` redirect isn't deployed, so nothing is user-facing until a release is tagged and the redirects go live.

- **`vastai update` registered** in `main.py`. The passive upgrade nudge is wired but **left commented out** — updates are manual via `vastai update` for now (uncommenting two lines re-enables it later). For pip installs the command prints the `pip install --upgrade vastai` hint and exits; it never shells out to a guessed pip.
- **Structural managed-install detection** — replaced the on-disk `install-receipt.json` with `is_managed_install()` (the CLI runs from `~/.vastai/env` next to `~/.vastai/bin/uv`). Ground truth, can't drift; removes the receipt write from `install.sh` and the read/version/previous fields. Either misdetection fails safe.
- **`scripts/publish_release.py`** — one release orchestrator for humans and CI (stdlib-only). Takes an explicit version, renders the manifest via `make_manifest.py`, and attaches `manifest.{json,env}` + `install.sh` to the GitHub Release. `--ci` (hash `dist/` wheel, skip tag/poll), `--dry-run`, guardrails.
- **`installer-ci.yml`** (PR gate) — shellcheck + bash/py syntax, the hermetic installer harness, and `make_manifest`/`publish_release` dry-runs, on PRs touching installer files.
- **`python-publish.yml`** (release wiring) — after the existing PyPI publish, runs `publish_release.py --ci` to attach the installer assets, then a `continue-on-error` ubuntu smoke test that installs from the Release and checks `--version`.

```
git tag vX.Y.Z ─► python-publish.yml ─► PyPI publish ─► publish_release.py --ci
                                                          (attach manifest + install.sh to Release)
                                                                    └─► smoke test (install from Release, non-blocking)
```

## Testing

- 334 unit tests (update command, structural detection, nudge logic); full PR-gate green locally.
- Hermetic installer harness (5 no-network scenarios) + real `dev-install.sh --from-source` (real uv/CPython/PyPI): install → managed-detect → `update --version` swap → pip-refusal.
- **Real end-to-end on live GitHub + PyPI:** uploaded the generated assets to a throwaway pre-release, fetched `install.sh` from the Release URL, and installed `vastai==1.0.13` from the hosted manifest → `vastai --version` = 1.0.13 (throwaway release deleted after). This is the exact CI smoke-test path, validated manually.
- Only the live `tag → token-authed CI attach` runs for the first time on a real release — de-risked: PyPI publish runs *before* the attach, and the smoke test is non-blocking.

## Notes

- **Requires `contents: write`** for the release job's `gh release upload` — confirm `Settings → Actions → General → Workflow permissions` allows write, or the asset-attach step 403s (PyPI publish still succeeds, since it runs first).
- Rollout: merge → tag a release (`vastai update` ships; Releases start carrying installer assets) → deploy the `vast_landing` redirects to make `curl … | bash` live. README stays pip-only until launch.