### PR TITLE
fix(release): auto-generate 'What's Changed' on GitHub Releases

### DIFF
--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -176,7 +176,7 @@ def attach_release(tag, manifest_dir, *, dry):
                             capture_output=True, text=True).returncode == 0
     if not exists:
         run(["gh", "release", "create", tag, "--title", tag,
-             "--notes", f"{PACKAGE} {tag.lstrip('v')}"], dry=dry)
+             "--notes", f"{PACKAGE} {tag.lstrip('v')}", "--generate-notes"], dry=dry)
     else:
         log(f"release {tag} exists — updating assets")
     run(["gh", "release", "upload", tag, "--clobber",


### PR DESCRIPTION
## What

Add `--generate-notes` to the `gh release create` call in `scripts/publish_release.py`.

## Why

New GitHub Releases were published with only a bare `vastai <version>` body. This adds
GitHub's auto-generated "What's Changed" section — merged PRs, new contributors, and the
full changelog diff link — on top of that header line.

## How

```diff
  run(["gh", "release", "create", tag, "--title", tag,
-      "--notes", f"{PACKAGE} {tag.lstrip('v')}"], dry=dry)
+      "--notes", f"{PACKAGE} {tag.lstrip('v')}", "--generate-notes"], dry=dry)
```

`--notes` stays as the title line; `--generate-notes` appends the changelog below it.

## Notes

- Only affects the **create** path. Existing releases still take the `else` branch and
  only get assets re-uploaded — reruns won't overwrite release notes.
- Dry-run output is unchanged.
