### PR TITLE
fix(update): surface the real error on update failure instead of a fabricated one

### DIFF
--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -122,6 +122,21 @@ class TestPerformUpdate:
         assert not (install_root / ".env.new").exists()
         assert not (install_root / "versions").exists()
 
+    def test_build_failure_surfaces_real_error_not_a_fabricated_one(self, install_root):
+        # A uv that "succeeds" but never builds the env: the verify step then
+        # runs a non-existent .env.new/bin/vastai. The error must name the real
+        # missing path, not relabel it the misleading "Required tool not found".
+        _seed_env(install_root, "1.2.3")
+        uv = install_root / "bin" / "uv"
+        uv.write_text("#!/bin/sh\nexit 0\n")  # does nothing — no venv, no install
+        uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
+
+        with pytest.raises(UpdateError) as exc:
+            perform_update("1.3.0", MANIFEST)
+        msg = str(exc.value)
+        assert "Required tool not found" not in msg
+        assert ".env.new/bin/vastai" in msg
+
     def test_failure_leaves_current_install_untouched(self, install_root):
         _seed_env(install_root, "1.2.3")  # live install that must survive
         before = (install_root / "env" / "bin" / "vastai").read_text()

--- a/vastai/cli/selfupdate.py
+++ b/vastai/cli/selfupdate.py
@@ -191,11 +191,15 @@ def _run(cmd, *, env=None):
     cmd = [str(c) for c in cmd]
     try:
         return subprocess.run(cmd, env=env, check=True, capture_output=True, text=True)
-    except FileNotFoundError:
-        raise UpdateError(f"Required tool not found: {cmd[0]}")
     except subprocess.CalledProcessError as e:
-        detail = (e.stderr or "").strip()
-        raise UpdateError(f"Command failed ({' '.join(cmd)})" + (f":\n{detail}" if detail else ""))
+        # Surface the tool's own stderr — that's the real error (e.g. uv's
+        # resolution failure), not a category we invent.
+        detail = (e.stderr or e.stdout or "").strip()
+        raise UpdateError(f"Command failed: {' '.join(cmd)}" + (f"\n{detail}" if detail else ""))
+    except OSError as e:
+        # Carry the actual OSError through (wrong path, missing binary, …)
+        # rather than relabeling everything "Required tool not found".
+        raise UpdateError(f"Could not run {' '.join(cmd)}: {e}")
 
 
 def _link_binaries(root: Path) -> None:


### PR DESCRIPTION
## What

Stop `_run` (`vastai/cli/selfupdate.py`) from rewriting subprocess failures into a fabricated message, and let the real error through.

## Why

When `vastai update` failed mid-build, users saw:

```
Required tool not found: /home/<user>/.vastai/.env.new/bin/vastai
```

That's misleading — it reads like a missing system dependency, but it actually means the freshly-built env didn't produce a `vastai` at the verify step (`selfupdate.py:246`). The old handler caught **any** `FileNotFoundError` and relabeled it `Required tool not found: <cmd[0]>`, discarding the real `OSError` (which already said precisely what was missing).

## How

```diff
-    except FileNotFoundError:
-        raise UpdateError(f"Required tool not found: {cmd[0]}")
     except subprocess.CalledProcessError as e:
-        detail = (e.stderr or "").strip()
-        raise UpdateError(f"Command failed ({' '.join(cmd)})" + (f":\n{detail}" if detail else ""))
+        # Surface the tool's own stderr — that's the real error (e.g. uv's
+        # resolution failure), not a category we invent.
+        detail = (e.stderr or e.stdout or "").strip()
+        raise UpdateError(f"Command failed: {' '.join(cmd)}" + (f"\n{detail}" if detail else ""))
+    except OSError as e:
+        # Carry the actual OSError through (wrong path, missing binary, …)
+        # rather than relabeling everything "Required tool not found".
+        raise UpdateError(f"Could not run {' '.join(cmd)}: {e}")
```

The same failure now reads:

```
Could not run /home/<user>/.vastai/.env.new/bin/vastai --version: [Errno 2] No such file or directory: '...'
```

— true, specific, no invented cause or remedy. The thin `UpdateError` wrapper is kept on purpose: `update.py` relies on it to exit cleanly (no traceback) and `perform_update` relies on it to clean up `.env.new`. We carry the real error *through* it rather than letting a bare exception escape.

## Notes

- This does **not** touch version resolution. The earlier "no version of vastai==X" symptom was a transient, self-healing uv index-cache race (resolves within uv's 10-min `max-age`); a clean-room install confirmed normal users are unaffected, so no change was warranted there.

## Testing

- Added `test_build_failure_surfaces_real_error_not_a_fabricated_one`: a no-op uv leaves the build empty, and the raised error names the real missing `.env.new/bin/vastai` path rather than "Required tool not found".
- Full suite: `tests/cli/test_update_command.py` — 26 passed.
