### PR TITLE
feat(cli): two-stage tab completion + installer completion/progress UX

### DIFF
--- a/docs/install-design.md
+++ b/docs/install-design.md
@@ -51,8 +51,8 @@ The design splits the install into two layers:
 - Runs as root without complaint (no shared prefix — everything lands in the
   invoking user's `$HOME/.vastai`), since fresh VMs/containers are commonly root.
 - Unsupported platform or bad hash → exits cleanly pointing at pip.
-- PATH/completion edits only with consent at a real TTY; skippable via
-  `--no-modify-path`.
+- PATH/completion edits default-on at a real TTY (no prompt, like uv/rustup);
+  skippable via `--no-modify-path`, never written non-interactively.
 
 ## 3. On-disk layout
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,7 +5,8 @@
 #
 # Installs a self-contained vastai CLI into ~/.vastai (no Python required on
 # the machine, no sudo, nothing outside ~/.vastai and ~/.local/bin is touched
-# except an optional, consent-gated PATH line in your shell rc).
+# except a PATH/completion block in your shell rc (enabled by default at a real
+# terminal; skip with --no-modify-path; never written non-interactively/CI).
 # Design: install-design.md in https://github.com/vast-ai/vast-cli
 #
 # Options (env vars, or flags after `bash -s --`):
@@ -25,6 +26,7 @@ ROOT="${VASTAI_INSTALL_DIR:-$HOME/.vastai}"
 LOCAL_BIN="$HOME/.local/bin"
 NO_MODIFY_PATH="${VASTAI_NO_MODIFY_PATH:-}"
 WORKDIR=""
+RC_UPDATED=""
 
 say()  { printf 'vastai-install: %s\n' "$*"; }
 warn() { printf 'vastai-install: warning: %s\n' "$*" >&2; }
@@ -37,15 +39,20 @@ need_cmd() {
     command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
 }
 
-# download URL DEST
+# download URL DEST [progress] — non-empty progress shows a bar (TTY only).
 download() {
+    local url="$1" dest="$2" progress="${3:-}"
     if command -v curl >/dev/null 2>&1; then
-        case "$1" in
-            https://*) curl --proto '=https' --tlsv1.2 -fsSL --retry 3 -o "$2" "$1" ;;
-            *)         curl -fsSL --retry 3 -o "$2" "$1" ;;
+        local vflags=(-fsS)
+        [ -n "$progress" ] && [ -t 2 ] && vflags=(-f --progress-bar)
+        case "$url" in
+            https://*) curl --proto '=https' --tlsv1.2 "${vflags[@]}" -L --retry 3 -o "$dest" "$url" ;;
+            *)         curl "${vflags[@]}" -L --retry 3 -o "$dest" "$url" ;;
         esac
     elif command -v wget >/dev/null 2>&1; then
-        wget -qO "$2" "$1"
+        local wflags=(-q)
+        [ -n "$progress" ] && [ -t 2 ] && wflags=(-q --show-progress)
+        wget "${wflags[@]}" -O "$dest" "$url"
     else
         die "need curl or wget to download files"
     fi
@@ -104,16 +111,8 @@ detect_platform() {
     PLATFORM_KEY="${os}_${arch}${libc}"
 }
 
-# is_interactive — can we prompt? (/dev/tty may exist yet be unopenable)
+# is_interactive — is there a real terminal? (/dev/tty may exist yet be unopenable)
 is_interactive() { ( : < /dev/tty > /dev/tty; ) 2>/dev/null; }
-
-# ask_yn PROMPT — returns 0 on yes
-ask_yn() {
-    local reply
-    printf '%s [y/N] ' "$1" > /dev/tty
-    read -r reply < /dev/tty || reply=""
-    case "$reply" in y|Y|yes|YES) return 0 ;; *) return 1 ;; esac
-}
 
 rc_file_for_shell() {
     case "$(basename "${SHELL:-}")" in
@@ -133,7 +132,7 @@ install_uv() {
 
     say "Downloading runtime bootstrap..."
     tarball="$WORKDIR/uv.tar.gz"
-    download "$url" "$tarball"
+    download "$url" "$tarball" progress
     verify_sha "$tarball" "$sha" "uv"
 
     mkdir -p "$WORKDIR/uv-extract"
@@ -154,11 +153,15 @@ install_version() {
     rm -rf "$newdir"
     export UV_PYTHON_INSTALL_DIR="$ROOT/python"
     export UV_PYTHON_PREFERENCE="only-managed"
-    # --relocatable: shebangs must not hardcode the build path (env is renamed into place).
-    if ! "$ROOT/bin/uv" venv "$newdir" --python "$python_pin" --relocatable --quiet; then
+    # Show uv's progress at a TTY, quiet in CI. --relocatable: no hardcoded
+    # build path in shebangs (env/ is renamed into place).
+    local quiet=(--quiet)
+    [ -t 2 ] && quiet=()
+    if ! "$ROOT/bin/uv" venv "$newdir" --python "$python_pin" --relocatable "${quiet[@]}"; then
         rm -rf "$newdir"
         die "could not set up the Python $python_pin runtime"
     fi
+    # pip install stays quiet always — the per-package "+ pkg==ver" list is noise.
     local spec="${VASTAI_PIP_SPEC:-vastai==$version}"
     if ! "$ROOT/bin/uv" pip install --python "$newdir/bin/python" --quiet "$spec"; then
         rm -rf "$newdir"
@@ -180,6 +183,22 @@ install_version() {
     done
 }
 
+# generate_completions — precompute static completion scripts in $ROOT/share so
+# the rc just sources a file (no register-python-argcomplete spawn per shell).
+generate_completions() {
+    local rpa="$ROOT/bin/register-python-argcomplete" sh out
+    [ -x "$rpa" ] || return 0
+    mkdir -p "$ROOT/share"
+    for sh in bash zsh; do
+        out="$ROOT/share/vastai-completion.$sh"
+        if "$rpa" -s "$sh" vastai >"$out.tmp" 2>/dev/null && [ -s "$out.tmp" ]; then
+            mv -f "$out.tmp" "$out"
+        else
+            rm -f "$out.tmp"
+        fi
+    done
+}
+
 setup_path() {
     mkdir -p "$LOCAL_BIN"
     link_swap "$ROOT/bin/vastai" "$LOCAL_BIN/vastai"
@@ -188,24 +207,34 @@ setup_path() {
         *":$LOCAL_BIN:"*) PATH_OK=1 ;;
         *) PATH_OK="" ;;
     esac
-    [ -n "$PATH_OK" ] && return 0
 
-    local rc_file marker block
+    # rc block: completion always (sources the static script); PATH export only
+    # if $LOCAL_BIN isn't already on PATH — so we never skip completion on PATH_OK.
+    local rc_file shell_name marker completion comp_file path_line block
     rc_file="$(rc_file_for_shell)"
+    shell_name="$(basename "${SHELL:-}")"
     marker="# >>> vastai installer >>>"
+    comp_file="$ROOT/share/vastai-completion.$shell_name"
+    completion="[ -f \"$comp_file\" ] && source \"$comp_file\"  # vastai tab completion"
+    if [ -n "$PATH_OK" ]; then
+        path_line=""
+    else
+        path_line="export PATH=\"\$HOME/.local/bin:\$PATH\"
+"
+    fi
     block="$marker
-export PATH=\"\$HOME/.local/bin:\$PATH\"
-eval \"\$('$ROOT/bin/register-python-argcomplete' vastai 2>/dev/null)\" 2>/dev/null || true
+${path_line}${completion}
 # <<< vastai installer <<<"
 
     if [ -n "$rc_file" ] && [ -f "$rc_file" ] && grep -qF "$marker" "$rc_file"; then
         return 0  # already configured; takes effect in new shells
     fi
 
-    if [ -z "$NO_MODIFY_PATH" ] && [ -n "$rc_file" ] && is_interactive \
-        && ask_yn "Add $LOCAL_BIN to PATH and enable tab completion in $rc_file?"; then
+    # Default-on, no prompt — but never edit rc under --no-modify-path or
+    # without a TTY (CI/pipes); there we just print the block.
+    if [ -z "$NO_MODIFY_PATH" ] && [ -n "$rc_file" ] && is_interactive; then
         printf '\n%s\n' "$block" >> "$rc_file"
-        say "Updated $rc_file (takes effect in new shells)."
+        RC_UPDATED=1
     else
         say "To finish setup, add this to your shell rc file:"
         printf '\n%s\n\n' "$block"
@@ -251,6 +280,7 @@ main() {
 
     install_uv
     install_version "$version" "$python_pin"
+    generate_completions
     setup_path
     check_pip_coexistence
 
@@ -258,6 +288,9 @@ main() {
     say "vastai $version installed to $ROOT"
     say "  Get started:  vastai set api-key YOUR_API_KEY   (https://cloud.vast.ai/manage-keys/)"
     say "  Update later: vastai update"
+    if [ -n "$RC_UPDATED" ]; then
+        say "  Tab completion: start a new shell, then type 'vastai <TAB>'"
+    fi
 }
 
 main "$@"

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -1,7 +1,10 @@
 """Tests for vastai/cli/parser.py — apwrap, command registration, parse_args."""
 
 import pytest
-from vastai.cli.parser import apwrap, argument, hidden_aliases, MyWideHelpFormatter
+from vastai.cli.parser import (
+    apwrap, argument, hidden_aliases, MyWideHelpFormatter,
+    build_command_maps, two_stage_command_completions,
+)
 
 
 class TestArgument:
@@ -148,3 +151,81 @@ class TestCliParserReadOnlyCommands:
     def test_parse_readonly_command(self, cli_parser, argv):
         args = cli_parser.parse_args(argv)
         assert callable(args.func)
+
+
+def _completion_parser():
+    p = apwrap()
+
+    @p.command(argument("--quiet", action="store_true"), help="show instances")
+    def show__instances(args):
+        pass
+
+    @p.command(help="show env vars")
+    def show__env_vars(args):
+        pass
+
+    @p.command(help="create an instance")
+    def create__instance(args):
+        pass
+
+    @p.command(argument("--check", action="store_true"), help="self update")
+    def update(args):
+        pass
+
+    return p
+
+
+class TestBuildCommandMaps:
+    def test_splits_verbs_objects_and_singles(self):
+        verbs, verb_objs, singles = build_command_maps(_completion_parser().parser)
+        assert {"show", "create"} <= verbs
+        assert verb_objs["show"] == {"instances", "env-vars"}
+        assert verb_objs["create"] == {"instance"}
+        # bare command + the auto-registered "help" land in singles, not verbs
+        assert "update" in singles and "update" not in verbs
+
+
+class TestTwoStageCompletions:
+    def setup_method(self):
+        self.maps = build_command_maps(_completion_parser().parser)
+
+    def _complete(self, comp_words, prefix):
+        return two_stage_command_completions(comp_words, prefix, *self.maps)
+
+    def test_first_word_offers_verbs_and_singles(self):
+        cands, merged = self._complete(["vastai"], "")
+        assert merged is None
+        assert {"show", "create", "update"} <= set(cands)
+
+    def test_first_word_narrows_by_prefix(self):
+        cands, _ = self._complete(["vastai"], "sh")
+        assert cands == ["show"]
+
+    def test_object_stage_lists_only_that_verbs_objects(self):
+        cands, merged = self._complete(["vastai", "show"], "")
+        assert merged is None
+        assert cands == ["env-vars", "instances"]  # sorted, no "create" leakage
+
+    def test_object_stage_has_no_escaped_space(self):
+        cands, _ = self._complete(["vastai", "show"], "")
+        assert all(" " not in c and "\\" not in c for c in cands)
+
+    def test_object_stage_narrows_by_prefix(self):
+        cands, _ = self._complete(["vastai", "show"], "env")
+        assert cands == ["env-vars"]
+
+    def test_bare_command_delegates_not_object_stage(self):
+        # "update" is a single command, not a verb -> delegate (no object list)
+        cands, merged = self._complete(["vastai", "update"], "--")
+        assert cands is None
+        assert merged == ["vastai", "update"]
+
+    def test_flag_stage_fuses_verb_object_into_one_token(self):
+        cands, merged = self._complete(["vastai", "show", "instances"], "--")
+        assert cands is None
+        assert merged == ["vastai", "show instances"]
+
+    def test_flag_stage_never_fuses_across_a_flag(self):
+        cands, merged = self._complete(["vastai", "show", "--help"], "")
+        assert cands is None
+        assert merged == ["vastai", "show", "--help"]  # unchanged

--- a/tests/installer/run_tests.sh
+++ b/tests/installer/run_tests.sh
@@ -184,11 +184,29 @@ test_rc_safety() { # never edits shell rc non-interactively; marker idempotent
     assert "rc untouched when marker present" cmp -s "$SB_HOME/.bashrc" "$SB/before"
 }
 
+test_completion_when_path_ok() { # PATH already set -> still wires completion, omits PATH export
+    new_sandbox pathok
+    run_install "PATH=$SB_HOME/.local/bin:$PATH" || { cat "$SB_OUT"; return 1; }
+    assert "still wires tab completion" out_contains "vastai-completion" &&
+    assert "omits redundant PATH export" [ "$(grep -c 'export PATH' "$SB_OUT")" -eq 0 ]
+}
+
+test_completion_files_generated() { # static completion scripts precomputed under share/
+    new_sandbox compgen
+    run_install || { cat "$SB_OUT"; return 1; }
+    assert "bash completion file present" [ -s "$SB_ROOT/share/vastai-completion.bash" ] &&
+    assert "zsh completion file present" [ -s "$SB_ROOT/share/vastai-completion.zsh" ] &&
+    assert "rc block sources the static file, not a per-startup eval" \
+        out_contains "source .*vastai-completion" &&
+    assert "no per-startup register-python-argcomplete eval" \
+        [ "$(grep -c 'eval.*register-python-argcomplete' "$SB_OUT")" -eq 0 ]
+}
+
 # ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 
-ALL_TESTS=(fresh_install pinned_reinstall checksum_abort truncation_guard rc_safety)
+ALL_TESTS=(fresh_install pinned_reinstall checksum_abort truncation_guard rc_safety completion_when_path_ok completion_files_generated)
 SELECTED=("${@:-${ALL_TESTS[@]}}")
 
 mkdir -p "$FIXTURES"

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -111,9 +111,27 @@ def main():
     # Tab completion
     try:
         import argcomplete
+        import argparse
 
         from typing import List, Optional
+        from vastai.cli.parser import build_command_maps, two_stage_command_completions
         class MyAutocomplete(argcomplete.CompletionFinder):
+            # Two-stage (verb -> object) completion over the flat "verb object"
+            # subparser names. Logic in parser.py (pure + unit-tested).
+            def _command_maps(self):
+                cached = getattr(self, "_cmd_maps", None)
+                if cached is None:
+                    cached = self._cmd_maps = build_command_maps(self._parser)
+                return cached
+
+            def _get_completions(self, comp_words, cword_prefix, cword_prequote, last_wordbreak_pos):
+                verbs, verb_objs, singles = self._command_maps()
+                cands, merged = two_stage_command_completions(
+                    comp_words, cword_prefix, verbs, verb_objs, singles)
+                if cands is not None:
+                    return cands
+                return super()._get_completions(merged, cword_prefix, cword_prequote, last_wordbreak_pos)
+
             def quote_completions(self, completions: List[str], cword_prequote: str, last_wordbreak_pos: Optional[int]) -> List[str]:
                 pre = super().quote_completions(completions, cword_prequote, last_wordbreak_pos)
                 return sorted(pre, key=lambda x: x.startswith('-'))

--- a/vastai/cli/parser.py
+++ b/vastai/cli/parser.py
@@ -39,6 +39,48 @@ def complete_sshkeys(prefix=None, action=None, parser=None, parsed_args=None):
     return [str(m) for m in Path.home().joinpath('.ssh').glob('*.pub')]
 
 
+# ---------------------------------------------------------------------------
+# Two-stage (verb -> object) command-name completion
+#
+# Pure, unit-testable helpers that turn the flat "verb object" subparser names
+# into staged completion. The argcomplete adapter in cli/main.py calls them.
+# ---------------------------------------------------------------------------
+
+def build_command_maps(parser):
+    """Derive (verbs, verb_objs, singles) from a parser's subparser names."""
+    names = []
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            names = list(action.choices.keys())
+            break
+    verbs, verb_objs, singles = set(), {}, set()
+    for name in names:
+        verb, sep, obj = name.partition(" ")
+        if sep:
+            verbs.add(verb)
+            verb_objs.setdefault(verb, set()).add(obj)
+        else:
+            singles.add(verb)
+    return verbs, verb_objs, singles
+
+
+def two_stage_command_completions(comp_words, cword_prefix, verbs, verb_objs, singles):
+    """Stage command-name completion. Returns (candidates, merged): candidates is
+    the verb/object list, or None to delegate flag completion using merged."""
+    n = len(comp_words)
+    if n == 1:  # completing the verb / bare command
+        return sorted(c for c in (verbs | singles) if c.startswith(cword_prefix)), None
+    if n == 2 and comp_words[1] in verbs:  # completing the object for a verb
+        objs = verb_objs.get(comp_words[1], set())
+        return sorted(o for o in objs if o.startswith(cword_prefix)), None
+    # Past the command name: fuse "verb object" so the right subparser is found.
+    # Never fuse across a flag, mirroring apwrap.parse_args.
+    merged = comp_words
+    if n >= 3 and comp_words[1] in verbs and not comp_words[2].startswith("-"):
+        merged = [comp_words[0], comp_words[1] + " " + comp_words[2]] + list(comp_words[3:])
+    return None, merged
+
+
 def set_completers(instance_machine_fn=None, instance_fn=None):
     """
     Wire up the tab-completion functions.  Called once from the CLI


### PR DESCRIPTION
Makes tab completion work out of the box for `curl | bash` installs, fixes the completion UX, and shows install progress.

**Installer** (`scripts/install.sh`)
- Tab completion **on by default** at a TTY — no prompt (uv/rustup-style); skippable via `--no-modify-path`, never written in CI/pipes.
- rc sources a **static** completion script under `~/.vastai/share/` (no per-shell `register-python-argcomplete` spawn).
- Shows download/install **progress** at a TTY, hides the noisy per-package list, prints a completion hint.

**Completion** (`cli/parser.py` pure helpers + thin argcomplete adapter in `cli/main.py`)
- Two-stage `verb → object`: `vastai <TAB>` → **~45 verbs** (was ~155); `vastai show <TAB>` → only `show`'s objects, no `show\ ` escaping; per-command flags now complete (`--quiet`, …).

**Tests:** +9 parser unit tests, +installer hermetic cases — 7/7 hermetic + 343 CLI pass.

---

```console
$ curl -fsSL https://vast.ai/install.sh | bash
vastai-install: Downloading runtime bootstrap...
######################################################################## 100.0%
vastai-install: Installing vastai 1.1.1 (Python 3.12, isolated in ~/.vastai)...
   cpython-3.12.13-linux-x86_64-gnu ━━━━━━━━━━━━━━━━━━━━━━━ 32.56 MiB/32.56 MiB
   Using CPython 3.12.13
vastai-install:
vastai-install: vastai 1.1.1 installed to ~/.vastai
vastai-install:   Get started:  vastai set api-key YOUR_API_KEY   (https://cloud.vast.ai/manage-keys/)
vastai-install:   Update later: vastai update
vastai-install:   Tab completion: start a new shell, then type 'vastai <TAB>'
```
