### PR TITLE
Fix: report model_is_loaded status immediately instead of waiting up to 10s

### DIFF
--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -2,10 +2,17 @@
 
 set -e -o pipefail
 
+# Check for force update flag
+FORCE_UPDATE=false
+if [ -f "/.force_update" ]; then
+    echo "Force update flag detected at /.force_update"
+    FORCE_UPDATE=true
+fi
+
 WORKSPACE_DIR="${WORKSPACE_DIR:-/workspace}"
 
 SERVER_DIR="$WORKSPACE_DIR/vast-pyworker"
-ENV_PATH="$WORKSPACE_DIR/worker-env"
+ENV_PATH="${ENV_PATH:-$WORKSPACE_DIR/worker-env}"
 DEBUG_LOG="$WORKSPACE_DIR/debug.log"
 PYWORKER_LOG="$WORKSPACE_DIR/pyworker.log"
 
@@ -47,29 +54,38 @@ JSON
 }
 
 function install_vastai_sdk() {
-    # If SDK_BRANCH is set, install vastai-sdk from the vast-sdk repo at that branch/tag/commit.
+    local uv_flags=()
+    if [ "${USE_SYSTEM_PYTHON:-}" = "true" ]; then
+        uv_flags+=(--system --break-system-packages)
+    fi
+    if [ "$FORCE_UPDATE" = true ]; then
+        uv_flags+=(--force-reinstall)
+        echo "Force reinstalling vastai"
+    fi
+
+    # If SDK_BRANCH is set, install vastai from the vast-cli repo at that branch/tag/commit.
     if [ -n "${SDK_BRANCH:-}" ]; then
         if [ -n "${SDK_VERSION:-}" ]; then
             echo "WARNING: Both SDK_BRANCH and SDK_VERSION are set; using SDK_BRANCH=${SDK_BRANCH}"
         fi
-        echo "Installing vastai-sdk from https://github.com/vast-ai/vast-sdk/ @ ${SDK_BRANCH}"
-        if ! uv pip install "vastai-sdk @ git+https://github.com/vast-ai/vast-sdk.git@${SDK_BRANCH}"; then
-            report_error_and_exit "Failed to install vastai-sdk from vast-ai/vast-sdk@${SDK_BRANCH}"
+        echo "Installing vastai from https://github.com/cemalgnlts/vast-cli/ @ ${SDK_BRANCH}"
+        if ! uv pip install "${uv_flags[@]}" "vastai @ git+https://github.com/cemalgnlts/vast-cli.git@${SDK_BRANCH}"; then
+            report_error_and_exit "Failed to install vastai from cemalgnlts/vast-cli@${SDK_BRANCH}"
         fi
         return 0
     fi
 
     if [ -n "${SDK_VERSION:-}" ]; then
-        echo "Installing vastai-sdk version ${SDK_VERSION}"
-        if ! uv pip install "vastai-sdk==${SDK_VERSION}"; then
-            report_error_and_exit "Failed to install vastai-sdk==${SDK_VERSION}"
+        echo "Installing vastai version ${SDK_VERSION}"
+        if ! uv pip install "${uv_flags[@]}" "vastai==${SDK_VERSION}"; then
+            report_error_and_exit "Failed to install vastai==${SDK_VERSION}"
         fi
         return 0
     fi
 
-    echo "Installing default vastai-sdk"
-    if ! uv pip install vastai-sdk; then
-        report_error_and_exit "Failed to install vastai-sdk"
+    echo "Installing default vastai"
+    if ! uv pip install "${uv_flags[@]}" vastai; then
+        report_error_and_exit "Failed to install vastai"
     fi
 }
 
@@ -90,7 +106,8 @@ echo_var DEBUG_LOG
 echo_var PYWORKER_LOG
 echo_var MODEL_LOG
 
-if [ -e "$MODEL_LOG" ]; then
+ROTATE_MODEL_LOG="${ROTATE_MODEL_LOG:-false}"
+if [ "$ROTATE_MODEL_LOG" = "true" ] && [ -e "$MODEL_LOG" ]; then
     echo "Rotating model log at $MODEL_LOG to $MODEL_LOG.old"
     if ! cat "$MODEL_LOG" >> "$MODEL_LOG.old"; then
         report_error_and_exit "Failed to rotate model log"
@@ -111,8 +128,21 @@ if ! grep -q "VAST" /etc/environment; then
     fi
 fi
 
-if [ ! -d "$ENV_PATH" ]
-then
+if [ "${USE_SYSTEM_PYTHON:-}" = "true" ]; then
+    echo "Using system Python: $(which python3)"
+    if ! which uv > /dev/null 2>&1; then
+        if ! curl -LsSf https://astral.sh/uv/install.sh | sh; then
+            report_error_and_exit "Failed to install uv package manager"
+        fi
+        if [[ -f ~/.local/bin/env ]]; then
+            if ! source ~/.local/bin/env; then
+                report_error_and_exit "Failed to source uv environment"
+            fi
+        fi
+    fi
+    install_vastai_sdk
+    touch ~/.no_auto_tmux
+elif [ ! -d "$ENV_PATH" ]; then
     echo "setting up venv"
     if ! which uv; then
         if ! curl -LsSf https://astral.sh/uv/install.sh | sh; then
@@ -131,10 +161,27 @@ then
         if ! git clone "${PYWORKER_REPO:-https://github.com/vast-ai/pyworker}" "$SERVER_DIR"; then
             report_error_and_exit "Failed to clone pyworker repository"
         fi
+    elif [ "$FORCE_UPDATE" = true ]; then
+        echo "Force updating pyworker repository"
+        if ! (cd "$SERVER_DIR" && git fetch --all); then
+            report_error_and_exit "Failed to fetch pyworker repository updates"
+        fi
     fi
     if [[ -n ${PYWORKER_REF:-} ]]; then
-        if ! (cd "$SERVER_DIR" && git checkout "$PYWORKER_REF"); then
-            report_error_and_exit "Failed to checkout pyworker reference: $PYWORKER_REF"
+        if [ "$FORCE_UPDATE" = true ]; then
+            echo "Force updating to pyworker reference: $PYWORKER_REF"
+            if ! (cd "$SERVER_DIR" && git checkout "$PYWORKER_REF" && git pull); then
+                report_error_and_exit "Failed to force update pyworker reference: $PYWORKER_REF"
+            fi
+        else
+            if ! (cd "$SERVER_DIR" && git checkout "$PYWORKER_REF"); then
+                report_error_and_exit "Failed to checkout pyworker reference: $PYWORKER_REF"
+            fi
+        fi
+    elif [ "$FORCE_UPDATE" = true ]; then
+        echo "Force updating pyworker to latest"
+        if ! (cd "$SERVER_DIR" && git pull); then
+            report_error_and_exit "Failed to pull latest pyworker changes"
         fi
     fi
 
@@ -161,11 +208,44 @@ else
             report_error_and_exit "Failed to source uv environment"
         fi
     fi
-    if ! source "$WORKSPACE_DIR/worker-env/bin/activate"; then
+    if ! source "$ENV_PATH/bin/activate"; then
         report_error_and_exit "Failed to activate existing virtual environment"
     fi
     echo "environment activated"
     echo "venv: $VIRTUAL_ENV"
+
+    # Handle force update for existing environment
+    if [ "$FORCE_UPDATE" = true ]; then
+        echo "Performing force update on existing environment"
+
+        if [[ -d $SERVER_DIR ]]; then
+            echo "Force updating pyworker repository"
+            if ! (cd "$SERVER_DIR" && git fetch --all); then
+                report_error_and_exit "Failed to fetch pyworker repository updates"
+            fi
+
+            if [[ -n ${PYWORKER_REF:-} ]]; then
+                echo "Force updating to pyworker reference: $PYWORKER_REF"
+                if ! (cd "$SERVER_DIR" && git checkout "$PYWORKER_REF" && git pull); then
+                    report_error_and_exit "Failed to force update pyworker reference: $PYWORKER_REF"
+                fi
+            else
+                echo "Force updating pyworker to latest"
+                if ! (cd "$SERVER_DIR" && git pull); then
+                    report_error_and_exit "Failed to pull latest pyworker changes"
+                fi
+            fi
+        fi
+
+        install_vastai_sdk
+    fi
+fi
+
+# Remove force update flag after successful update
+if [ "$FORCE_UPDATE" = true ]; then
+    echo "Removing force update flag"
+    rm -f "/.force_update"
+    echo "Force update completed successfully"
 fi
 
 if [ "$USE_SSL" = true ]; then
@@ -203,15 +283,50 @@ EOF
         report_error_and_exit "Failed to generate SSL certificate request"
     fi
 
-    if ! curl --header 'Content-Type: application/octet-stream' \
-        --data-binary @/etc/instance.csr \
-        -X \
-        POST "https://console.vast.ai/api/v0/sign_cert/?instance_id=$CONTAINER_ID" > /etc/instance.crt; then
-        report_error_and_exit "Failed to sign SSL certificate"
-    fi
+    max_retries=5
+    retry_delay=2
+    for attempt in $(seq 1 "$max_retries"); do
+        http_code=$(curl -sS -o /etc/instance.crt -w '%{http_code}' \
+            --header 'Content-Type: application/octet-stream' \
+            --data-binary @/etc/instance.csr \
+            -X POST "https://console.vast.ai/api/v0/sign_cert/?instance_id=$CONTAINER_ID")
+        if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+            break
+        fi
+        echo "SSL cert signing attempt $attempt/$max_retries failed (HTTP $http_code)"
+        if [ "$attempt" -eq "$max_retries" ]; then
+            report_error_and_exit "Failed to sign SSL certificate after $max_retries attempts (HTTP $http_code)"
+        fi
+        sleep "$retry_delay"
+        retry_delay=$((retry_delay * 2))
+    done
 fi
 
 export REPORT_ADDR WORKER_PORT USE_SSL UNSECURED
+
+# ─── SDK Deployment Mode ───────────────────────────────────────────────
+if [ "$IS_DEPLOYMENT" = "true" ]; then
+    echo "=== SDK Deployment Mode ==="
+    echo "DEPLOYMENT_ID: $DEPLOYMENT_ID"
+
+    DEPLOY_DIR="/workspace/deployment"
+    mkdir -p "$DEPLOY_DIR"
+
+    VAST_API_BASE="${VAST_API_BASE:-https://console.vast.ai}"
+
+    # Download deployment code, retrying until the blob is available on S3.
+    # The s3_key exists in the DB as soon as the deployment is created, but the
+    # actual upload may still be in flight from the client side.
+
+    # Install SDK (uses the install_vastai_sdk function which supports SDK_BRANCH/SDK_VERSION)
+    install_vastai_sdk
+    # Run deployment in serve mode
+    export VAST_DEPLOYMENT_MODE=serve
+    echo "Starting deployment: python3 $DEPLOY_DIR/deployment.py"
+    serve-vast-deployment
+    exit $?
+fi
+# ─── End SDK Deployment Mode ───────────────────────────────────────────
 
 if ! cd "$SERVER_DIR"; then
     report_error_and_exit "Failed to cd into SERVER_DIR: $SERVER_DIR"
@@ -224,19 +339,19 @@ set +e
 PY_STATUS=1
 
 if [ -f "$SERVER_DIR/worker.py" ]; then
-    echo "trying worker.py"
+    echo "Running worker.py"
     python3 -m "worker" |& tee -a "$PYWORKER_LOG"
     PY_STATUS=${PIPESTATUS[0]}
 fi
 
 if [ "${PY_STATUS}" -ne 0 ] && [ -f "$SERVER_DIR/workers/$BACKEND/worker.py" ]; then
-    echo "trying workers.${BACKEND}.worker"
+    echo "Running workers.${BACKEND}.worker"
     python3 -m "workers.${BACKEND}.worker" |& tee -a "$PYWORKER_LOG"
     PY_STATUS=${PIPESTATUS[0]}
 fi
 
 if [ "${PY_STATUS}" -ne 0 ] && [ -f "$SERVER_DIR/workers/$BACKEND/server.py" ]; then
-    echo "trying workers.${BACKEND}.server"
+    echo "Running workers.${BACKEND}.server"
     python3 -m "workers.${BACKEND}.server" |& tee -a "$PYWORKER_LOG"
     PY_STATUS=${PIPESTATUS[0]}
 fi
@@ -250,4 +365,4 @@ if [ "${PY_STATUS}" -ne 0 ]; then
     report_error_and_exit "PyWorker exited with status ${PY_STATUS}"
 fi
 
-echo "launching PyWorker server done"
+echo "PyWorker bootstrap complete"

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -68,9 +68,9 @@ function install_vastai_sdk() {
         if [ -n "${SDK_VERSION:-}" ]; then
             echo "WARNING: Both SDK_BRANCH and SDK_VERSION are set; using SDK_BRANCH=${SDK_BRANCH}"
         fi
-        echo "Installing vastai from https://github.com/cemalgnlts/vast-cli/ @ ${SDK_BRANCH}"
-        if ! uv pip install "${uv_flags[@]}" "vastai @ git+https://github.com/cemalgnlts/vast-cli.git@${SDK_BRANCH}"; then
-            report_error_and_exit "Failed to install vastai from cemalgnlts/vast-cli@${SDK_BRANCH}"
+        echo "Installing vastai from https://github.com/vast-ai/vast-cli/ @ ${SDK_BRANCH}"
+        if ! uv pip install "${uv_flags[@]}" "vastai @ git+https://github.com/vast-ai/vast-cli.git@${SDK_BRANCH}"; then
+            report_error_and_exit "Failed to install vastai from vast-ai/vast-cli@${SDK_BRANCH}"
         fi
         return 0
     fi

--- a/vastai/serverless/server/lib/metrics.py
+++ b/vastai/serverless/server/lib/metrics.py
@@ -157,6 +157,7 @@ class Metrics:
         )
         self.system_metrics.model_is_loaded = True
         self.model_metrics.max_throughput = max_throughput
+        self.update_pending = True
 
     def _model_errored(self, error_msg: str) -> None:
         self.model_metrics.set_errored(error_msg)


### PR DESCRIPTION
Hi,

This commit reduces the serverless cold start time by ~10 seconds.

Additionally, I've updated the legacy `scripts/start_server.sh` file to match the one at [vast-ai/pyworker/main/start_server.sh](https://www.google.com/search?q=https://github.com/vast-ai/pyworker/blob/main/start_server.sh).

`_model_loaded()` sets `model_is_loaded=True` but doesn't set `update_pending`,
so `_send_metrics_loop` can wait up to 10s before notifying `report_addr`.
This adds `update_pending = True` to push the status on the next tick (~1s).

**Example**
**Before commit template**: [cloud.vast.ai/?ref_id=404507&creator_id=404507&name=Qwen3.5 9B - Slow](https://cloud.vast.ai/?ref_id=404507&creator_id=404507&name=Qwen3.5%209B%20-%20Slow)
**After commit template**: [cloud.vast.ai/?ref_id=404507&creator_id=404507&name=Qwen3.5 9B - Fast](https://cloud.vast.ai/?ref_id=404507&creator_id=404507&name=Qwen3.5%209B%20-%20Fast)

**Example request template**
```bash
curl -o /dev/null -s -w "%{time_total} seconds" --request POST \
  --url https://openai.vast.ai/$ENDPOINT/chat/completions \
  --header 'authorization: Bearer $API_KEY' \
  --header 'content-type: application/json' \
  --data '{"messages": [{ "role": "user", "content": "1 + 1 = ?" }]}'
```

**Before commit**: 17 - 20 seconds
**After commit**: 7.9 - 10 seconds