### PR TITLE
fix(installer): drop misleading uv 'Activate with' line + minimal output

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,9 +29,9 @@ NO_MODIFY_PATH="${VASTAI_NO_MODIFY_PATH:-}"
 WORKDIR=""
 RC_UPDATED=""
 
-say()  { printf 'vastai-install: %s\n' "$*"; }
-warn() { printf 'vastai-install: warning: %s\n' "$*" >&2; }
-die()  { printf 'vastai-install: error: %s\n' "$*" >&2; exit 1; }
+say()  { printf '  %s\n' "$*"; }
+warn() { printf '  warning: %s\n' "$*" >&2; }
+die()  { printf '  error: %s\n' "$*" >&2; exit 1; }
 
 cleanup() { [ -n "$WORKDIR" ] && rm -rf "$WORKDIR"; }
 trap cleanup EXIT
@@ -162,7 +162,7 @@ install_uv() {
         die "no build available for your platform ($PLATFORM_KEY) — install with pip instead: pip install vastai"
     fi
 
-    say "Downloading runtime bootstrap..."
+    say "Downloading runtime..."
     tarball="$WORKDIR/uv.tar.gz"
     download "$url" "$tarball" progress
     verify_sha "$tarball" "$sha" "uv"
@@ -181,15 +181,23 @@ install_uv() {
 install_version() {
     local version="$1" python_pin="$2" envdir="$ROOT/env" newdir="$ROOT/.env.new"
 
-    say "Installing vastai $version (Python $python_pin, isolated in $ROOT)..."
+    say "Installing vastai $version (Python $python_pin) → $ROOT"
     rm -rf "$newdir"
     export UV_PYTHON_INSTALL_DIR="$ROOT/python"
     export UV_PYTHON_PREFERENCE="only-managed"
-    # Show uv's progress at a TTY, quiet in CI. --relocatable: no hardcoded
-    # build path in shebangs (env/ is renamed into place).
-    local quiet=(--quiet)
-    [ -t 2 ] && quiet=()
-    if ! "$ROOT/bin/uv" venv "$newdir" --python "$python_pin" --relocatable "${quiet[@]}"; then
+    # Provision the managed CPython first — the slow, download-heavy step, so show
+    # its progress at a TTY (quiet in CI). The venv build is then always quiet:
+    # uv venv's own "Activate with: source .../.env.new/..." line is misleading
+    # here — .env.new is renamed to env/ below, and vastai is a symlinked CLI you
+    # run, never a venv you "activate".
+    local pyquiet=(--quiet)
+    [ -t 2 ] && pyquiet=()
+    if ! "$ROOT/bin/uv" python install "$python_pin" "${pyquiet[@]}"; then
+        rm -rf "$newdir"
+        die "could not provision the Python $python_pin runtime"
+    fi
+    # --relocatable: no hardcoded build path in shebangs (env/ is renamed into place).
+    if ! "$ROOT/bin/uv" venv "$newdir" --python "$python_pin" --relocatable --quiet; then
         rm -rf "$newdir"
         die "could not set up the Python $python_pin runtime"
     fi
@@ -316,7 +324,7 @@ main() {
     setup_path
     check_pip_coexistence
 
-    say ""
+    printf '\n'
     say "vastai $version installed to $ROOT"
     say "  Get started:  vastai set api-key YOUR_API_KEY   (https://cloud.vast.ai/manage-keys/?tab=api-keys)"
     say "  Update later: vastai update"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -168,9 +168,15 @@ install_uv() {
     verify_sha "$tarball" "$sha" "uv"
 
     mkdir -p "$WORKDIR/uv-extract"
-    tar -xzf "$tarball" -C "$WORKDIR/uv-extract"
-    local uv_bin
-    uv_bin="$(find "$WORKDIR/uv-extract" -type f -name uv | head -n 1)"
+    tar -xzf "$tarball" -C "$WORKDIR/uv-extract" \
+        || die "could not unpack the runtime — tar+gzip required; install them or use pip: pip install vastai"
+    # Locate the uv binary without depending on `find` (absent on minimal images
+    # like amazonlinux:2023): the tarball is either uv-extract/uv or, more
+    # commonly, uv-extract/<target-triple>/uv.
+    local uv_bin="" cand
+    for cand in "$WORKDIR"/uv-extract/uv "$WORKDIR"/uv-extract/*/uv; do
+        [ -f "$cand" ] && { uv_bin="$cand"; break; }
+    done
     [ -n "$uv_bin" ] || die "uv binary not found in downloaded archive"
     chmod +x "$uv_bin"
     # Nothing lands in $ROOT until the download has been verified.

--- a/scripts/tests/test-install-matrix.sh
+++ b/scripts/tests/test-install-matrix.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Smoke-test scripts/install.sh across an OS matrix in throwaway containers.
+# Mirrors .github/workflows/installer-ci.yml os-matrix (minus macOS, which needs
+# a real runner). Runs THIS checkout's install.sh against the live release
+# manifest, then confirms the installed CLI runs.
+#
+#   scripts/tests/test-install-matrix.sh              # all linux variants
+#   scripts/tests/test-install-matrix.sh alpine       # one variant
+#   TTY=1 scripts/tests/test-install-matrix.sh debian # interactive (test PATH/completion prompt)
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+BASE="https://github.com/vast-ai/vast-cli/releases/latest/download"
+
+# name|image|prep  (tar + coreutils sha256sum/mktemp/uname assumed present in
+# every base image; prep only needs to ensure curl is installed)
+MATRIX=(
+  # --- musl ---
+  "alpine|alpine:latest|apk add --no-cache bash curl"
+  # --- Debian / Ubuntu (glibc) ---
+  "debian-slim|debian:stable-slim|apt-get update -qq && apt-get install -y -qq curl ca-certificates"
+  "debian12|debian:12-slim|apt-get update -qq && apt-get install -y -qq curl ca-certificates"
+  "ubuntu2004|ubuntu:20.04|apt-get update -qq && apt-get install -y -qq curl ca-certificates"  # glibc floor (2.31)
+  "ubuntu2204|ubuntu:22.04|apt-get update -qq && apt-get install -y -qq curl ca-certificates"
+  "ubuntu2404|ubuntu:24.04|apt-get update -qq && apt-get install -y -qq curl ca-certificates"
+  # --- RHEL family (glibc) --- curl-minimal/ca-certs preinstalled; add curl only if absent
+  "fedora|fedora:latest|command -v curl >/dev/null 2>&1 || dnf install -y -q curl"
+  "rocky9|rockylinux:9|command -v curl >/dev/null 2>&1 || dnf install -y -q curl"
+  "alma9|almalinux:9|command -v curl >/dev/null 2>&1 || dnf install -y -q curl"
+  "amazonlinux2023|amazonlinux:2023|dnf install -y -q tar gzip"  # minimal image lacks tar+gzip (the unpacker)
+  # --- rolling / other ---
+  "arch|archlinux:latest|pacman -Sy --noconfirm --needed curl"
+  "opensuse-leap|opensuse/leap:latest|zypper -n install curl"
+)
+
+SELECT="${1:-}"
+DOCKER_FLAGS=(--rm)
+[ -n "${TTY:-}" ] && DOCKER_FLAGS+=(-it)
+
+pass=0 fail=0
+for row in "${MATRIX[@]}"; do
+  IFS='|' read -r name image prep <<<"$row"
+  [ -n "$SELECT" ] && [ "$SELECT" != "$name" ] && continue
+  echo "==================== $name ($image) ===================="
+  if docker run "${DOCKER_FLAGS[@]}" -v "$REPO:/repo" -w /repo \
+      -e VASTAI_CLI_BASE_URL="$BASE" -e VASTAI_NO_MODIFY_PATH="${TTY:+}${TTY:-1}" \
+      "$image" sh -c "$prep
+        bash scripts/install.sh
+        \"\$HOME/.vastai/bin/vastai\" --version"; then
+    echo "PASS $name"; pass=$((pass+1))
+  else
+    echo "FAIL $name"; fail=$((fail+1))
+  fi
+done
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

Two installer UX fixes in `scripts/install.sh`:

1. **Drop the misleading `Activate with: source …/.env.new/…` line.** It was `uv venv`'s own chatter, surfaced because the installer dropped `--quiet` at a TTY. It pointed at `.env.new` — the temp build dir that gets renamed to `env/` — so it was a dead path the instant install finished, and "activate the venv" is the wrong model anyway (`vastai` is a symlinked CLI you run, not an env you enter).

   Fix: split the single `uv venv` into `uv python install <pin>` (non-quiet at a TTY → first-time CPython download still shows a progress bar) followed by `uv venv … --quiet` (always quiet → no more `Creating virtual environment` / `Activate with` lines, on every platform).

2. **Minimal output.** Dropped the `vastai-install:` prefix in favor of a 2-space indent (`warning:`/`error:` kept on stderr for failures); trimmed wording.

### Before
```
vastai-install: Downloading runtime bootstrap...
vastai-install: Installing vastai 1.1.3 (Python 3.12, isolated in /home/u/.vastai)...
Using CPython 3.12.13
Creating virtual environment at: /home/u/.vastai/.env.new
Activate with: source /home/u/.vastai/.env.new/bin/activate   # <- dead path
vastai-install:
vastai-install: vastai 1.1.3 installed to /home/u/.vastai
```

### After
```
  Downloading runtime...
  Installing vastai 1.1.3 (Python 3.12) → /home/u/.vastai

  vastai 1.1.3 installed to /home/u/.vastai
    Get started:  vastai set api-key YOUR_API_KEY   (https://cloud.vast.ai/manage-keys/?tab=api-keys)
    Update later: vastai update
```

## Testing

- `bash -n` clean; all 8 hermetic scenarios pass (fake uv's catch-all absorbs the new `uv python install`; no fixture change, no test asserted on the old prefix).
- Real end-to-end install against the live release manifest: clean output, no `.env.new` residue, `vastai --version` → `1.1.3`.
- `installer-ci.yml` (shellcheck + hermetic + OS matrix) triggers on the `scripts/install.sh` path.