### PR TITLE
feat(update): enable passive upgrade nudge

### DIFF
--- a/docs/install-design.md
+++ b/docs/install-design.md
@@ -165,10 +165,9 @@ Not built in v1.
 
 ## 7. Passive update nudge
 
-> **Status: implemented but disabled.** The call is commented out in
-> `main.py` — updates are manual via `vastai update` for now. Re-enable the
-> two lines when we want the per-command check (the logic and tests below all
-> exist and pass).
+> **Status: enabled.** `notify_update(args)` runs as a post-command hook in
+> `main.py`. Opt out with `VASTAI_NO_UPDATE_CHECK=1` (also off under
+> `--raw`/`CI`/non-TTY).
 
 - After commands: at most **one manifest GET and one stderr line per 24h**, hard
   1s timeout, every failure silent with 24h backoff (offline machines pay ≤1s

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -157,8 +157,11 @@ def main():
         try:
             res = args.func(args)
 
-            # Passive upgrade nudge — disabled for now (manual `vastai update`).
-            # from vastai.cli.selfupdate import notify_update; notify_update(args)
+            # Passive upgrade nudge: best-effort, ≤1 manifest GET + ≤1 stderr
+            # line per 24h, silent when offline/piped/CI. Never raises. Opt out
+            # with VASTAI_NO_UPDATE_CHECK=1. See selfupdate.py and §7.
+            from vastai.cli.selfupdate import notify_update
+            notify_update(args)
 
             if args.raw and res is not None:
                 try:


### PR DESCRIPTION
## What

Enables the passive upgrade nudge that was built earlier but left disabled (`install-design.md §7`). After a command runs, the CLI prints at most one stderr reminder per 24h when a newer `vastai` is available.

- `vastai/cli/main.py` — uncomment the post-command hook (`notify_update(args)`).
- `docs/install-design.md` — `§7` status flipped from "implemented but disabled" → "enabled".

All the logic (`selfupdate.py`) and tests already existed; this just turns it on.

## Behavior (unchanged from the existing implementation)

- **≤1 manifest GET + ≤1 stderr line per 24h**, hard 1s timeout, every failure silent with 24h backoff.
- **Suppressed** under `--raw`, `CI`, non-TTY (piped/redirected), or `VASTAI_NO_UPDATE_CHECK=1`.
- **Method-aware hint:** `vastai update` for managed installs, `pip install --upgrade vastai` for pip installs.
- Never touches stdout; `notify_update()` can never raise into the CLI.
- No telemetry — it's a GET of a static version file.

Example line:
```
↑ vastai 1.2.0 is available (you have 1.1.3). Run `vastai update`.
```

## Testing

- `tests/cli/test_update_command.py` — 28 pass, covering firing when stale, the method-aware hints, once-per-24h throttling, and silence on fetch failure / suppression.
- `main.py` imports `notify_update` cleanly.

## Notes

- README intentionally left unchanged for now (opt-out is documented in `§7`); user-facing README updates will come with the broader install/launch flip.