### PR TITLE
installer: Rosetta 2 detection

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -133,6 +133,12 @@ detect_platform() {
         aarch64|arm64) [ "$os" = "DARWIN" ] && arch="ARM64" || arch="AARCH64" ;;
         *) die "unsupported architecture: $arch — install with pip instead: pip install vastai" ;;
     esac
+    # An x86_64 shell under Rosetta 2 reports the emulated arch; install the
+    # native arm64 build instead. (sysctl key absent on Intel Macs → empty → no-op.)
+    if [ "$os" = "DARWIN" ] && [ "$arch" = "X86_64" ] \
+        && [ "$(sysctl -n sysctl.proc_translated 2>/dev/null || true)" = "1" ]; then
+        arch="ARM64"
+    fi
     if [ "$os" = "LINUX" ]; then
         if is_musl; then
             libc="_MUSL"


### PR DESCRIPTION
Small hardening item for the installer, borrowed from a comparison with the Claude Code installer.

## Rosetta 2 detection (`scripts/install.sh`)

An ARM Mac running an x86_64 shell (Rosetta) previously got the x86_64 uv/CPython — works, but emulated. `detect_platform` now checks `sysctl -n sysctl.proc_translated` on Darwin x86_64 and switches to `DARWIN_ARM64` for the native build. The sysctl key is absent on Intel Macs, so the probe is empty there and it's a no-op; guarded with `|| true` per the script's `set -e` conventions.

## Testing

- `tests/installer/run_tests.sh` — 8 passed, 0 failed (Rosetta branch is Darwin-only; Linux behavior unchanged)