### PR TITLE
fix(installer): guard empty array expansion for macOS bash 3.2

### DIFF
--- a/.github/workflows/installer-ci.yml
+++ b/.github/workflows/installer-ci.yml
@@ -27,8 +27,16 @@ jobs:
       - name: python syntax check
         run: python3 -m py_compile scripts/make_manifest.py scripts/publish_release.py
 
+  # macOS matters here beyond os coverage: its stock /bin/bash is 3.2, which
+  # is what test_tty_install needs to catch set -u empty-array regressions
+  # (fatal on bash < 4.4, invisible on Linux CI's modern bash).
   hermetic-tests:
-    runs-on: ubuntu-latest
+    name: hermetic-tests (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: run install.sh hermetic scenarios (no external network)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -202,9 +202,11 @@ install_version() {
     # uv venv's own "Activate with: source .../.env.new/..." line is misleading
     # here — .env.new is renamed to env/ below, and vastai is a symlinked CLI you
     # run, never a venv you "activate".
+    # ${arr[@]+...} guard: bash 3.2 (macOS default) treats an empty array as
+    # unset under `set -u`, so a bare "${pyquiet[@]}" would abort the install.
     local pyquiet=(--quiet)
     [ -t 2 ] && pyquiet=()
-    if ! "$ROOT/bin/uv" python install "$python_pin" "${pyquiet[@]}"; then
+    if ! "$ROOT/bin/uv" python install "$python_pin" ${pyquiet[@]+"${pyquiet[@]}"}; then
         rm -rf "$newdir"
         die "could not provision the Python $python_pin runtime"
     fi

--- a/tests/installer/run_tests.sh
+++ b/tests/installer/run_tests.sh
@@ -18,7 +18,8 @@ PASS=0
 FAIL=0
 
 cleanup() {
-    [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null
+    # The wait reaps the server so bash 3.2 doesn't print "Terminated".
+    [ -n "$SERVER_PID" ] && { kill "$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null; }
     rm -rf "$TESTS_TMP"
 }
 trap cleanup EXIT
@@ -126,6 +127,7 @@ assert() { # assert DESC command...
 }
 
 out_contains() { grep -q "$1" "$SB_OUT"; }
+out_lacks()    { ! grep -qa "$1" "$SB_OUT"; }
 
 # ---------------------------------------------------------------------------
 # Scenarios
@@ -214,12 +216,39 @@ test_completion_files_generated() { # static completion scripts precomputed unde
         [ "$(grep -c 'eval.*register-python-argcomplete' "$SB_OUT")" -eq 0 ]
 }
 
+test_tty_install() { # interactive install (stderr on a pty) must survive old bash
+    # install.sh empties its pyquiet array at a TTY ([ -t 2 ]), and on bash
+    # < 4.4 expanding an empty array under `set -u` is fatal ("pyquiet[@]:
+    # unbound variable") — macOS's stock /bin/bash is 3.2. The other scenarios
+    # never hit this: they run detached from any tty, so the array stays
+    # non-empty. Runs the real installer on a pty via script(1) under
+    # ${VASTAI_TEST_TTY_BASH:-/bin/bash}; the regression guarantee comes from
+    # hosts whose /bin/bash predates 4.4 (the macOS leg of installer CI).
+    new_sandbox tty
+    command -v script >/dev/null 2>&1 || { echo "    (skipped: no script(1))"; return 0; }
+    local tty_bash="${VASTAI_TEST_TTY_BASH:-/bin/bash}"
+    local cmd=(env "HOME=$SB_HOME" "VASTAI_INSTALL_DIR=$SB_ROOT" \
+        "VASTAI_CLI_BASE_URL=$SERVER/good" "SHELL=/bin/bash" \
+        "VASTAI_NO_MODIFY_PATH=1" "$tty_bash" "$INSTALL_SH")
+    case "$(uname -s)" in
+        Darwin*) script -q /dev/null "${cmd[@]}" >"$SB_OUT" 2>&1 </dev/null ;;
+        # util-linux script wants one string; sandbox paths contain no spaces.
+        *)       script -qec "${cmd[*]}" /dev/null >"$SB_OUT" 2>&1 </dev/null ;;
+    esac
+    assert "no set -u explosion at a TTY" out_lacks "unbound variable" &&
+    assert "install completed" out_contains "vastai 1.2.3 installed" &&
+    assert "installed CLI runs" [ "$("$SB_ROOT/bin/vastai" --version)" = "1.2.3" ]
+}
+
 # ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 
-ALL_TESTS=(fresh_install pinned_reinstall checksum_abort truncation_guard glibc_floor rc_safety completion_when_path_ok completion_files_generated)
-SELECTED=("${@:-${ALL_TESTS[@]}}")
+ALL_TESTS=(fresh_install pinned_reinstall checksum_abort truncation_guard glibc_floor rc_safety completion_when_path_ok completion_files_generated tty_install)
+# No "${@:-...}": expanding $@ with zero args under set -u is itself fatal on
+# old bash, and this harness must run under macOS's stock bash 3.2 (see
+# test_tty_install).
+if [ "$#" -gt 0 ]; then SELECTED=("$@"); else SELECTED=("${ALL_TESTS[@]}"); fi
 
 mkdir -p "$FIXTURES"
 start_server


### PR DESCRIPTION
## Problem

Interactive installs on macOS fail:

```
$ curl -fsSL https://vast.ai/install.sh | bash
vastai-install: Installing vastai 1.1.3 (Python 3.12, isolated in /Users/.../.vastai)...
bash: line 192: quiet[@]: unbound variable
```

`install_version` empties the `pyquiet` array when stderr is a TTY (to show uv's Python download progress interactively), then expands it with `"${pyquiet[@]}"`. On bash < 4.4, expanding an empty array under `set -u` is an "unbound variable" error — and macOS pipes `curl | bash` into stock `/bin/bash` 3.2.

The bug needs both **bash 3.2** and **a TTY on stderr**, which is why the `macos-latest` job in installer CI never caught it: CI has no TTY, so the array stays non-empty and the failing path never runs.

## Fix

Use the bash-3.2-safe guard idiom:

```bash
${pyquiet[@]+"${pyquiet[@]}"}
```

which expands to nothing when the array is empty instead of tripping `set -u`. Verified under `bash -u`: empty → no extra args, non-empty → passes `--quiet`. The other arrays in the script (`vflags`, `wflags`) are always non-empty, so this was the only unsafe expansion.

Note: users hit this via the release-attached bootstrap, so the live installer stays broken for interactive macOS installs until the next release re-uploads `install.sh`.