### PR TITLE
fix(release): eliminate the manifest/PyPI propagation race

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,8 +31,10 @@ jobs:
           poetry config pypi-token.pypi "$PYPI_API_TOKEN"
           poetry publish --build
       # Installer side: hash the just-built dist/ wheel, render the manifest,
-      # and attach manifest.{json,env} + install.sh to the GitHub Release. The
-      # vast.ai redirects serve releases/latest/download/*, so this is the deploy.
+      # and attach wheel + manifest.{json,env} + install.sh to a draft Release
+      # published only once fully populated (installs fetch the wheel from the
+      # Release, not PyPI). The vast.ai redirects serve
+      # releases/latest/download/*, so this is the deploy.
       - name: publish installer manifest + release assets
         env:
           GH_TOKEN: ${{ github.token }}
@@ -89,4 +91,10 @@ jobs:
           grep -q 'Vast.ai CLI installer' /tmp/install.sh
           grep -qx "LATEST=$VERSION" /tmp/manifest.env
           python3 -c "import json; d=json.load(open('/tmp/manifest.json')); assert d['latest']=='$VERSION', d['latest']"
-          echo "release assets for $VERSION are attached, parse, and match"
+          # Confirm the wheel installers will fetch is live and byte-correct.
+          WHEEL_URL="$(sed -n 's/^WHEEL_URL=//p' /tmp/manifest.env)"
+          WHEEL_SHA="$(sed -n 's/^WHEEL_SHA256=//p' /tmp/manifest.env)"
+          test -n "$WHEEL_URL" && test -n "$WHEEL_SHA"
+          curl -fsSL --retry 3 "$WHEEL_URL" -o /tmp/release.whl
+          echo "$WHEEL_SHA  /tmp/release.whl" | sha256sum -c -
+          echo "release assets for $VERSION are attached, parse, match, and the wheel is fetchable + hash-verified"

--- a/docs/install-design.md
+++ b/docs/install-design.md
@@ -39,15 +39,19 @@ The design splits the install into two layers:
 2. Fetch manifest over TLS.
 3. Verify sha256 **before** anything lands in `$ROOT`.
 4. Install + symlink: pinned `uv` provisions managed CPython 3.12 and installs
-   the published PyPI wheel into an isolated venv. **System Python is never
-   used, even if present.**
+   the release wheel — fetched from the same GitHub Release as the manifest
+   and verified against its sha256, so a just-published release is installable
+   immediately (no PyPI index propagation window) — into an isolated venv.
+   **System Python is never used, even if present.**
 
 ### Fail-closed guarantees
 
 - Whole script wrapped in `main()`, invoked on the **last line** — a truncated
   download executes nothing.
 - TLS-only downloads; uv tarball sha256 verified against the manifest before
-  unpacking. (Wheel integrity is delegated to uv: TLS + PyPI hashes.)
+  unpacking. The wheel is hash-pinned too: uv verifies the manifest's sha256
+  via the `#sha256=` URL fragment. (Version-pinned installs fall back to the
+  PyPI pin: uv's TLS + index hashes.)
 - Runs as root without complaint (no shared prefix — everything lands in the
   invoking user's `$HOME/.vastai`), since fresh VMs/containers are commonly root.
 - Unsupported platform, **glibc older than the floor** (2.31 — Ubuntu 20.04+/
@@ -141,8 +145,9 @@ retargeting, no retention/GC, no offline-instant-rollback guarantee.
   downgrades," reusing the same install-and-swap. There is no separate rollback
   machinery and no kept-on-disk previous version.
 - Verification mirrors the installer: confirm the new env runs and reports the
-  expected version before swapping; wheel integrity comes from uv (TLS + PyPI
-  hashes), the uv binary itself from the manifest sha256 at install time.
+  expected version before swapping. Latest installs the manifest's hash-pinned
+  release wheel; `--version` pins use the PyPI pin (uv: TLS + index hashes).
+  The uv binary itself comes from the manifest sha256 at install time.
 
 ### Why keep `--version` rollback at all
 We release **daily**, so bad releases ship fairly often. Without a `--version`
@@ -232,9 +237,11 @@ is what CI users will reach for by analogy to uv.
 wheel. Pins the `uv` version and embeds per-platform sha256 fetched from uv's
 release assets — no floating tags anywhere in the supply chain. `install.type`
 is the seam that lets a frozen binary replace the wheel later with zero
-user-facing change; a future `wheel_url` field would let the CLI ship faster
-than the PyPI `vastai` package (attach the wheel to the Release, point installs
-there) — not enabled yet, one pipeline at a time.
+user-facing change. `wheel_url` points installs of `latest` at the wheel on
+the same Release — drafted, fully populated, then published, so a manifest
+can never advertise a version installers can't fetch. `--no-wheel-url` omits
+the field (dev manifests from a placeholder wheel); consumers fall back to
+the PyPI version pin, as do `--version` pins and pre-`wheel_url` releases.
 
 ## 12. Rollout (dark launch)
 

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -27,6 +27,7 @@ tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
 from_source=""
+manifest_flags=()
 passthrough=()
 for arg in "$@"; do
     case "$arg" in
@@ -48,13 +49,15 @@ else
     # Default to the latest released tag: that's what the hosted manifest will say.
     version="${VASTAI_VERSION:-$(git -C "$repo" describe --tags --abbrev=0 | sed 's/^v//')}"
     wheel="$tmp/dummy.whl"
-    # install.sh never reads the wheel hash (uv verifies PyPI downloads itself),
-    # so a dummy wheel is fine for manifest rendering here.
+    # A dummy wheel can't yield a truthful wheel URL/sha; --no-wheel-url makes
+    # install.sh fall back to the PyPI version pin (uv verifies those itself).
     touch "$wheel"
+    manifest_flags=(--no-wheel-url)
 fi
 
 python3 "$repo/scripts/make_manifest.py" \
-    --version "$version" --wheel "$wheel" --out "$tmp" >/dev/null
+    --version "$version" --wheel "$wheel" --out "$tmp" \
+    ${manifest_flags[0]+"${manifest_flags[@]}"} >/dev/null
 
 echo "dev-install: simulating hosted installer for vastai $version (manifest in $tmp)"
 VASTAI_CLI_BASE_URL="file://$tmp" VASTAI_VERSION="$version" \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -191,7 +191,8 @@ install_uv() {
 }
 
 install_version() {
-    local version="$1" python_pin="$2" envdir="$ROOT/env" newdir="$ROOT/.env.new"
+    local version="$1" python_pin="$2" wheel_url="${3:-}" wheel_sha="${4:-}"
+    local envdir="$ROOT/env" newdir="$ROOT/.env.new"
 
     say "Installing vastai $version (Python $python_pin) → $ROOT"
     rm -rf "$newdir"
@@ -204,9 +205,11 @@ install_version() {
     # run, never a venv you "activate".
     # ${arr[@]+...} guard: bash 3.2 (macOS default) treats an empty array as
     # unset under `set -u`, so a bare "${pyquiet[@]}" would abort the install.
+    # --no-bin: the venv finds the interpreter via UV_PYTHON_INSTALL_DIR;
+    # shims in ~/.local/bin would only add uv's misleading PATH warning.
     local pyquiet=(--quiet)
     [ -t 2 ] && pyquiet=()
-    if ! "$ROOT/bin/uv" python install "$python_pin" ${pyquiet[@]+"${pyquiet[@]}"}; then
+    if ! "$ROOT/bin/uv" python install "$python_pin" --no-bin ${pyquiet[@]+"${pyquiet[@]}"}; then
         rm -rf "$newdir"
         die "could not provision the Python $python_pin runtime"
     fi
@@ -216,7 +219,13 @@ install_version() {
         die "could not set up the Python $python_pin runtime"
     fi
     # pip install stays quiet always — the per-package "+ pkg==ver" list is noise.
+    # Latest installs the release wheel by URL, hash-verified against the
+    # manifest — no PyPI index propagation window. A pin to any other
+    # version falls back to PyPI (always long-published, so race-free).
     local spec="${VASTAI_PIP_SPEC:-vastai==$version}"
+    if [ -z "${VASTAI_PIP_SPEC:-}" ] && [ -n "$wheel_url" ] && [ -n "$wheel_sha" ]; then
+        spec="vastai @ ${wheel_url}#sha256=${wheel_sha}"
+    fi
     if ! "$ROOT/bin/uv" pip install --python "$newdir/bin/python" --quiet "$spec"; then
         rm -rf "$newdir"
         die "could not install $spec (is the version correct?)"
@@ -332,8 +341,16 @@ main() {
     fi
     version="${VASTAI_VERSION:-$latest}"
 
+    # The wheel URL/sha are truthful only for the version they describe
+    # (LATEST) — used whenever that's what we're installing, pinned or not.
+    local wheel_url="" wheel_sha=""
+    if [ "$version" = "$latest" ]; then
+        wheel_url="$(manifest_get WHEEL_URL)"
+        wheel_sha="$(manifest_get WHEEL_SHA256)"
+    fi
+
     install_uv
-    install_version "$version" "$python_pin"
+    install_version "$version" "$python_pin" "$wheel_url" "$wheel_sha"
     generate_completions
     setup_path
     check_pip_coexistence

--- a/scripts/make_manifest.py
+++ b/scripts/make_manifest.py
@@ -33,6 +33,10 @@ PYTHON_PIN = "3.12"
 UV_VERSION = "0.11.21"
 UV_BASE = f"https://github.com/astral-sh/uv/releases/download/{UV_VERSION}"
 
+# The wheel is attached to the same GitHub Release as this manifest; the URL
+# is per-tag so a manifest never races the next release.
+RELEASE_DOWNLOAD_BASE = "https://github.com/vast-ai/vast-cli/releases/download"
+
 # manifest platform key -> uv release target triple
 UV_TARGETS = {
     "linux-x86_64":       "x86_64-unknown-linux-gnu",
@@ -58,7 +62,7 @@ def fetch_uv_sha(target: str) -> str:
         return r.read().decode().split()[0]
 
 
-def build_manifest(version: str, wheel_sha: str, channel: str) -> dict:
+def build_manifest(version: str, wheel_sha: str, channel: str, wheel_url: str | None) -> dict:
     uv_artifacts = {
         key: {
             "url": f"{UV_BASE}/uv-{target}.tar.gz",
@@ -66,7 +70,7 @@ def build_manifest(version: str, wheel_sha: str, channel: str) -> dict:
         }
         for key, target in UV_TARGETS.items()
     }
-    return {
+    manifest = {
         "schema": SCHEMA,
         "channel": channel,
         "latest": version,
@@ -82,6 +86,9 @@ def build_manifest(version: str, wheel_sha: str, channel: str) -> dict:
             },
         },
     }
+    if wheel_url:
+        manifest["install"]["wheel_url"] = wheel_url
+    return manifest
 
 
 def render_env(manifest: dict) -> str:
@@ -95,6 +102,8 @@ def render_env(manifest: dict) -> str:
         f"WHEEL_SHA256={install['wheel_sha256']}",
         f"UV_VERSION={install['uv']['version']}",
     ]
+    if install.get("wheel_url"):
+        lines.append(f"WHEEL_URL={install['wheel_url']}")
     for key, art in install["uv"]["artifacts"].items():
         env_key = key.upper().replace("-", "_")
         lines.append(f"UV_URL_{env_key}={art['url']}")
@@ -108,6 +117,8 @@ def main() -> int:
     ap.add_argument("--wheel", required=True, help="path (or glob) to the published vastai wheel")
     ap.add_argument("--channel", default="stable")
     ap.add_argument("--out", required=True, help="output directory")
+    ap.add_argument("--no-wheel-url", action="store_true",
+                    help="omit install.wheel_url; consumers fall back to the PyPI version pin")
     args = ap.parse_args()
 
     wheels = sorted(glob.glob(args.wheel))
@@ -115,7 +126,9 @@ def main() -> int:
         print(f"error: --wheel {args.wheel!r} matched {len(wheels)} files, need exactly 1", file=sys.stderr)
         return 1
 
-    manifest = build_manifest(args.version, sha256_file(Path(wheels[0])), args.channel)
+    wheel = Path(wheels[0])
+    wheel_url = None if args.no_wheel_url else f"{RELEASE_DOWNLOAD_BASE}/v{args.version}/{wheel.name}"
+    manifest = build_manifest(args.version, sha256_file(wheel), args.channel, wheel_url)
 
     out = Path(args.out)
     out.mkdir(parents=True, exist_ok=True)

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -166,23 +166,31 @@ def render_manifest(version, wheel, outdir, *, dry):
          "--wheel", wheel, "--out", outdir], dry=dry, capture=True)
 
 
-def attach_release(tag, manifest_dir, *, dry):
-    """Create the Release (if missing) and upload the three assets."""
+def attach_release(tag, manifest_dir, wheel, *, dry):
+    """Create the Release as a draft, upload all assets, then publish it.
+
+    releases/latest ignores drafts, so installers never see a manifest whose
+    wheel isn't fetchable, nor a half-populated latest release.
+    """
     if dry:
-        log(f"[dry-run] gh release create/view {tag}; "
-            f"gh release upload {tag} --clobber manifest.json manifest.env install.sh")
+        log(f"[dry-run] gh release create {tag} --draft; gh release upload {tag} "
+            f"--clobber {Path(wheel).name} manifest.json manifest.env install.sh; "
+            f"gh release edit {tag} --draft=false")
         return
     exists = subprocess.run(["gh", "release", "view", tag],
                             capture_output=True, text=True).returncode == 0
     if not exists:
-        run(["gh", "release", "create", tag, "--title", tag,
+        run(["gh", "release", "create", tag, "--draft", "--title", tag,
              "--notes", f"{PACKAGE} {tag.lstrip('v')}", "--generate-notes"], dry=dry)
     else:
         log(f"release {tag} exists — updating assets")
     run(["gh", "release", "upload", tag, "--clobber",
+         str(wheel),
          str(Path(manifest_dir) / "manifest.json"),
          str(Path(manifest_dir) / "manifest.env"),
          str(INSTALL_SH)], dry=dry)
+    # No-op if already published (re-run); flips a fresh draft live.
+    run(["gh", "release", "edit", tag, "--draft=false"], dry=dry)
 
 
 def verify_install(version, *, dry):
@@ -235,7 +243,7 @@ def main():
             if not confirm(f"Attach manifest + install.sh to GitHub Release {tag}?",
                            assume_yes=args.yes or ci, dry=dry):
                 raise ReleaseError("aborted before publishing the Release")
-            attach_release(tag, workdir, dry=dry)
+            attach_release(tag, workdir, wheel, dry=dry)
 
         if args.skip_verify:
             log("skipping verify (--skip-verify)")

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -16,6 +16,7 @@ import pytest
 from vastai.cli import selfupdate
 from vastai.cli.selfupdate import (
     UpdateError, is_newer, version_key, is_managed_install, perform_update,
+    wheel_spec,
 )
 
 MANIFEST = {
@@ -24,6 +25,27 @@ MANIFEST = {
     "latest": "1.3.0",
     "install": {"type": "pypi-wheel", "package": "vastai", "python": "3.12"},
 }
+
+WHEEL_URL = "https://github.com/vast-ai/vast-cli/releases/download/v1.3.0/vastai-1.3.0-py3-none-any.whl"
+MANIFEST_WITH_WHEEL = {
+    **MANIFEST,
+    "install": {**MANIFEST["install"], "wheel_url": WHEEL_URL, "wheel_sha256": "cafe123"},
+}
+
+
+class TestWheelSpec:
+    def test_latest_installs_the_hash_pinned_release_wheel(self):
+        assert wheel_spec("1.3.0", MANIFEST_WITH_WHEEL) == f"vastai @ {WHEEL_URL}#sha256=cafe123"
+
+    def test_pin_or_rollback_uses_the_pypi_version_pin(self):
+        assert wheel_spec("1.2.0", MANIFEST_WITH_WHEEL) == "vastai==1.2.0"
+
+    def test_manifest_without_wheel_url_falls_back(self):
+        assert wheel_spec("1.3.0", MANIFEST) == "vastai==1.3.0"
+
+    def test_wheel_url_without_sha_falls_back(self):
+        manifest = {**MANIFEST, "install": {**MANIFEST["install"], "wheel_url": WHEEL_URL}}
+        assert wheel_spec("1.3.0", manifest) == "vastai==1.3.0"
 
 
 class TestVersionOrdering:

--- a/tests/installer/run_tests.sh
+++ b/tests/installer/run_tests.sh
@@ -67,15 +67,18 @@ EOF
     UV_SHA="$(sha256_of "$FIXTURES/uv.tar.gz")"
 }
 
-# write_manifest SUBDIR LATEST [SHA]
+# write_manifest SUBDIR LATEST [SHA [WHEEL_URL WHEEL_SHA]]
 write_manifest() {
-    local dir="$FIXTURES/$1" latest="$2" sha="${3:-$UV_SHA}" key
+    local dir="$FIXTURES/$1" latest="$2" sha="${3:-$UV_SHA}"
+    local wheel_url="${4:-}" wheel_sha="${5:-}" key
     mkdir -p "$dir"
     {
         echo "SCHEMA=1"
         echo "CHANNEL=stable"
         echo "LATEST=$latest"
         echo "PYTHON=3.12"
+        [ -n "$wheel_url" ] && echo "WHEEL_URL=$wheel_url"
+        [ -n "$wheel_sha" ] && echo "WHEEL_SHA256=$wheel_sha"
         echo "UV_VERSION=0.0.0-test"
         for key in LINUX_X86_64 LINUX_X86_64_MUSL LINUX_AARCH64 LINUX_AARCH64_MUSL DARWIN_ARM64 DARWIN_X86_64; do
             echo "UV_URL_$key=$SERVER/uv.tar.gz"
@@ -151,6 +154,25 @@ test_pinned_reinstall() { # VASTAI_VERSION pin replaces env in place, no retenti
     assert "pinned version live" [ "$("$SB_ROOT/bin/vastai" --version)" = "0.9.9" ] &&
     assert "single active install, no version retention" [ ! -e "$SB_ROOT/versions" ] &&
     assert "no leftover temp env" [ ! -e "$SB_ROOT/.env.new" ]
+}
+
+test_wheel_url_install() { # latest installs the manifest's hash-pinned release wheel
+    new_sandbox wheelurl
+    write_manifest wheelurl 1.2.3 "" \
+        "http://release.invalid/v1.2.3/vastai-1.2.3-py3-none-any.whl" "cafe123"
+    run_install "VASTAI_CLI_BASE_URL=$SERVER/wheelurl" || { cat "$SB_OUT"; return 1; }
+    assert "uv received the URL+sha spec" \
+        [ "$("$SB_ROOT/bin/vastai" --version)" = "vastai @ http://release.invalid/v1.2.3/vastai-1.2.3-py3-none-any.whl#sha256=cafe123" ]
+}
+
+test_wheel_url_pin_fallback() { # a pinned version must ignore latest's wheel URL
+    new_sandbox wheelpin
+    write_manifest wheelpin 1.2.3 "" \
+        "http://release.invalid/v1.2.3/vastai-1.2.3-py3-none-any.whl" "cafe123"
+    run_install "VASTAI_CLI_BASE_URL=$SERVER/wheelpin" VASTAI_VERSION=0.9.9 \
+        || { cat "$SB_OUT"; return 1; }
+    assert "pin used the plain version spec" \
+        [ "$("$SB_ROOT/bin/vastai" --version)" = "0.9.9" ]
 }
 
 test_checksum_abort() { # tampered artifact -> abort with zero residue
@@ -244,7 +266,7 @@ test_tty_install() { # interactive install (stderr on a pty) must survive old ba
 # Runner
 # ---------------------------------------------------------------------------
 
-ALL_TESTS=(fresh_install pinned_reinstall checksum_abort truncation_guard glibc_floor rc_safety completion_when_path_ok completion_files_generated tty_install)
+ALL_TESTS=(fresh_install pinned_reinstall wheel_url_install wheel_url_pin_fallback checksum_abort truncation_guard glibc_floor rc_safety completion_when_path_ok completion_files_generated tty_install)
 # No "${@:-...}": expanding $@ with zero args under set -u is itself fatal on
 # old bash, and this harness must run under macOS's stock bash 3.2 (see
 # test_tty_install).

--- a/vastai/cli/selfupdate.py
+++ b/vastai/cli/selfupdate.py
@@ -216,6 +216,21 @@ def _link_binaries(root: Path) -> None:
         os.replace(tmp, link)
 
 
+def wheel_spec(target: str, manifest: dict) -> str:
+    """Requirement spec that installs ``target``.
+
+    Latest installs the manifest's release wheel: hash-pinned bytes straight
+    from the GitHub Release, no PyPI propagation window. Other targets are
+    pins/rollbacks to long-published versions, where the PyPI pin is
+    race-free and covers releases that predate wheel_url.
+    """
+    install = manifest.get("install") or {}
+    url, sha = install.get("wheel_url"), install.get("wheel_sha256")
+    if target == manifest.get("latest") and url and sha:
+        return f"vastai @ {url}#sha256={sha}"
+    return f"vastai=={target}"
+
+
 def perform_update(target: str, manifest: dict) -> None:
     """Install ``target`` into a fresh env, verify it, then swap it in.
 
@@ -223,8 +238,8 @@ def perform_update(target: str, manifest: dict) -> None:
     and only swapped over the live one after it verifies, so an interrupted
     update can never leave a half-written or broken ``vastai``. There is no
     version retention — a re-pin or rollback is just ``update --version X``,
-    which reinstalls. Wheel integrity is delegated to uv (TLS + PyPI hashes);
-    we additionally confirm the installed version matches ``target``.
+    which reinstalls. Wheel integrity comes from ``wheel_spec``; we
+    additionally confirm the installed version matches ``target``.
     """
     root = install_root()
     uv = root / "bin" / "uv"
@@ -242,7 +257,7 @@ def perform_update(target: str, manifest: dict) -> None:
         # --relocatable: shebangs must not hardcode the build path (env is renamed into place).
         _run([uv, "venv", new_dir, "--python", python_pin, "--relocatable", "--quiet"], env=uv_env)
         _run([uv, "pip", "install", "--python", new_dir / "bin" / "python",
-              "--quiet", f"vastai=={target}"], env=uv_env)
+              "--quiet", wheel_spec(target, manifest)], env=uv_env)
         installed = (_run([new_dir / "bin" / "vastai", "--version"]).stdout or "").strip()
         if target not in installed:
             raise UpdateError(


### PR DESCRIPTION
## Problem

During the v1.2.0 release a fresh `curl | bash` install failed for a user with:

```
× No solution found when resolving dependencies:
╰─▶ Because there is no version of vastai==1.2.0 and you require vastai==1.2.0, ...
error: could not install vastai==1.2.0 (is the version correct?)
```

Root cause: the release workflow attached the installer manifest (advertising the new version) to the GitHub Release seconds after `poetry publish` returned — while PyPI's CDN-cached simple index, which uv resolves `vastai==VERSION` against, can lag by a minute or more on some edges. Every release had this window; any user installing during it got a hard failure.

## Fix: remove the PyPI dependency for the wheel architecturally

Installs of `latest` no longer touch the PyPI index for vastai at all (this was the design's planned `wheel_url` seam — install-design.md §11):

- **`publish_release.py`** attaches the built wheel to the GitHub Release itself, and publishes atomically: the Release is created as a **draft**, all assets are uploaded, then it's flipped live. `releases/latest` ignores drafts, so installers can never see a manifest whose wheel isn't fetchable — nor a half-populated release.
- **`make_manifest.py`** emits `install.wheel_url` (per-tag URL, so it never races the *next* release) alongside the existing `wheel_sha256`. `--no-wheel-url` omits it (dev-install's dummy-wheel mode); consumers fall back to the PyPI pin.
- **`install.sh`** installs latest via `vastai @ <wheel_url>#sha256=<sha>` — uv fetches the exact release bytes and verifies the hash (mismatch = hard fail; verified against uv 0.11.21 including cache hits). pins to any *other* version fall back to the PyPI version pin, which is race-free there (older versions are long-published).
- **`vastai update`** (selfupdate.py): same split — latest uses the manifest's hash-pinned wheel; pins/rollbacks to other versions use PyPI (also covers releases that predate `wheel_url`).
- **`verify_release_assets` canary** now also fetches the manifest's `wheel_url` and checks its sha256, so every release confirms the exact artifact installers fetch is live and byte-correct.
- Dependencies still resolve from PyPI, but only stable long-published versions — no race there.

Side benefits:
- The vastai wheel is hash-pinned end-to-end from release CI to the user's machine, closing the loop with the already-pinned uv tarballs.
- `uv python install --no-bin` drops the misleading "`~/.local/bin` is not on your PATH ... `uv python update-shell`" warning (the python shims it refers to were unused).

## Testing

- Hermetic installer suite (`tests/installer/run_tests.sh`): 11/11 pass, including two new scenarios — latest installs via the URL+sha spec; a pinned version ignores it.
- `tests/cli/test_update_command.py`: 32 pass, including new `wheel_spec` unit tests (latest→URL spec, pin→PyPI, missing url/sha→fallback).
- uv hash-fragment verification proven live: correct sha installs; wrong sha is rejected, including when the wheel is already in uv's cache.
- End-to-end: real install through `install.sh` with a manifest pointing `WHEEL_URL` at the published 1.2.0 wheel bytes — succeeds and reports 1.2.0.
- `make_manifest.py` renders the real 1.2.0 wheel with a sha256 matching PyPI's digest.
- `publish_release.py --ci --dry-run` shows the new order: build → draft release → upload wheel+manifests → publish.
- Canary sha check validated both ways locally (matching sha passes, wrong sha fails the step).
