### PR TITLE
fix(cli): drop rollback hint from update success message

### DIFF
--- a/docs/install-design.md
+++ b/docs/install-design.md
@@ -144,14 +144,6 @@ retargeting, no retention/GC, no offline-instant-rollback guarantee.
   expected version before swapping; wheel integrity comes from uv (TLS + PyPI
   hashes), the uv binary itself from the manifest sha256 at install time.
 
-### Why keep `--version` rollback at all
-We release **daily**, so bad releases ship fairly often. Without a `--version`
-escape hatch a user who pulls a broken daily can only "uninstall, reinstall, and
-hope latest is fixed" — useless mid-incident. `--version` lets them pin to
-yesterday's known-good. It is cheap insurance *because* we release daily, and it
-costs nothing extra on top of single-version (the mechanism already exists for
-pinning).
-
 ### Same-method discipline
 pip installs (which fail the managed-install check) get the correct
 `pip install --upgrade vastai` hint and exit — **never shell out to a guessed

--- a/vastai/cli/commands/update.py
+++ b/vastai/cli/commands/update.py
@@ -67,7 +67,7 @@ def update(args):
             return 0
         print(f"Updating vastai {current} -> {target} ...")
         perform_update(target, manifest)
-        print(f"Done. vastai is now {target} (roll back with `vastai update --version {current}`).")
+        print(f"Done. vastai is now {target}.")
         return 0
 
     except UpdateError as e:


### PR DESCRIPTION
Removes the `(roll back with vastai update --version X)` suffix from the post-update message. Rollback is still documented in the `--version` flag help and the command epilog.

Before:
```
Done. vastai is now 1.2.0 (roll back with `vastai update --version 1.1.3`).
```

After:
```
Done. vastai is now 1.2.0.
```