### PR TITLE
feat(update): prune uv cache after successful self-update

### DIFF
--- a/docs/install-design.md
+++ b/docs/install-design.md
@@ -157,6 +157,10 @@ retargeting, no retention/GC, no offline-instant-rollback guarantee.
   expected version before swapping. Latest installs the manifest's hash-pinned
   release wheel; `--version` pins use the PyPI pin (uv: TLS + index hashes).
   The uv binary itself comes from the manifest sha256 at install time.
+- After a successful swap, best-effort `uv cache prune`: envs are hardlinked
+  out of uv's user-global cache, which otherwise accumulates every version's
+  wheels forever. Prune, never clean — the cache is shared with any other uv
+  on the machine — and a prune failure never fails the completed update.
 
 ### Same-method discipline
 pip installs (which fail the managed-install check) get the correct

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -101,7 +101,8 @@ class TestIsManagedInstall:
         assert is_managed_install() is False
 
 
-# Fake uv: `uv venv DIR ...` and `uv pip install --python PY ... vastai==VER`
+# Fake uv: `uv venv DIR ...`, `uv pip install --python PY ... vastai==VER`,
+# and `uv cache prune` (drops a marker next to itself).
 FAKE_UV = """#!/bin/sh
 set -e
 if [ "$1" = "venv" ]; then
@@ -115,6 +116,8 @@ elif [ "$1" = "pip" ]; then
     bindir="$(dirname "$py")"
     printf '#!/bin/sh\\necho "%s"\\n' "${last#vastai==}" > "$bindir/vastai"
     chmod +x "$bindir/vastai"
+elif [ "$1" = "cache" ]; then
+    touch "$(dirname "$0")/cache-pruned"
 fi
 """
 
@@ -143,6 +146,18 @@ class TestPerformUpdate:
         assert "1.3.0" in (install_root / "env" / "bin" / "vastai").read_text()
         assert not (install_root / ".env.new").exists()
         assert not (install_root / "versions").exists()
+
+    def test_success_prunes_uv_cache(self, install_root, fake_uv):
+        _seed_env(install_root, "1.2.3")
+        perform_update("1.3.0", MANIFEST)
+        assert (install_root / "bin" / "cache-pruned").exists()
+
+    def test_prune_failure_does_not_fail_the_update(self, install_root, fake_uv):
+        # uv errors on `cache prune`; the already-swapped update must still succeed
+        fake_uv.write_text(FAKE_UV.replace('touch "$(dirname "$0")/cache-pruned"', "exit 1"))
+        _seed_env(install_root, "1.2.3")
+        perform_update("1.3.0", MANIFEST)
+        assert "1.3.0" in (install_root / "env" / "bin" / "vastai").read_text()
 
     def test_build_failure_surfaces_real_error_not_a_fabricated_one(self, install_root):
         # A uv that "succeeds" but never builds the env: the verify step then

--- a/vastai/cli/selfupdate.py
+++ b/vastai/cli/selfupdate.py
@@ -202,6 +202,20 @@ def _run(cmd, *, env=None):
         raise UpdateError(f"Could not run {' '.join(cmd)}: {e}")
 
 
+def _prune_uv_cache(uv: Path, env: dict) -> None:
+    """Best-effort prune of uv's cache after a successful swap.
+
+    Each update hardlinks the new env out of the cache, so the cache
+    accumulates every version's wheels forever unless pruned. Prune (not
+    clean): the cache is the user-global one, shared with any other uv on
+    the machine. The update already succeeded — never fail because of this.
+    """
+    try:
+        _run([uv, "cache", "prune", "--quiet"], env=env)
+    except UpdateError:
+        pass
+
+
 def _link_binaries(root: Path) -> None:
     """Point bin/<name> at the fixed env/bin/<name> for each shipped console
     script. The target path is constant across updates (always ``env/``), so
@@ -274,3 +288,4 @@ def perform_update(target: str, manifest: dict) -> None:
     os.replace(new_dir, env_dir)
     _link_binaries(root)
     shutil.rmtree(old_dir, ignore_errors=True)
+    _prune_uv_cache(uv, uv_env)


### PR DESCRIPTION
## Why

Each `vastai update` builds a fresh env hardlinked out of uv's user-global cache (`~/.cache/uv`), and nothing ever prunes that cache — it accumulates every version's wheels forever (724M on a dogfood machine, vs 146M for the env itself). This follows the Homebrew/rustup pattern: cleanup piggybacks on the update the user already ran.

## What

- After a successful swap, `perform_update` runs a best-effort `uv cache prune`.
- **Prune, never clean** — the cache is shared with any other uv on the machine; prune only removes unreferenced entries.
- **A prune failure never fails the completed update** (rustup once shipped an updater that panicked in its own cleanup step; guard against that class).
- Design doc updated; tests cover both the prune-on-success and prune-failure-is-ignored paths.

## Verified

End-to-end against a sandbox install root with real uv: update to 1.2.2 built/verified/swapped, then the prune reclaimed 234M from the shared cache (860M → 626M).

Known limitation, accepted as-is for now: uv cache commands take a lock, so a concurrently running uv process can make the prune wait (astral-sh/uv#16112). The update itself has already completed by that point.