### PR TITLE
installer: follow XDG Base Directory Specification

### DIFF
--- a/.github/workflows/installer-ci.yml
+++ b/.github/workflows/installer-ci.yml
@@ -117,10 +117,10 @@ jobs:
             "${{ matrix.image }}" sh -c '
               ${{ matrix.prep }}
               VASTAI_PIP_SPEC="$(ls dist/vastai-*.whl)" bash scripts/install.sh
-              "$HOME/.vastai/bin/vastai" --version
+              "$HOME/.local/share/vastai/bin/vastai" --version
             '
       - name: install natively (macOS)
         if: ${{ !matrix.image }}
         run: |
           VASTAI_PIP_SPEC="$(ls dist/vastai-*.whl)" bash scripts/install.sh
-          "$HOME/.vastai/bin/vastai" --version
+          "$HOME/.local/share/vastai/bin/vastai" --version

--- a/.github/workflows/installer-ci.yml
+++ b/.github/workflows/installer-ci.yml
@@ -117,10 +117,10 @@ jobs:
             "${{ matrix.image }}" sh -c '
               ${{ matrix.prep }}
               VASTAI_PIP_SPEC="$(ls dist/vastai-*.whl)" bash scripts/install.sh
-              "$HOME/.local/share/vastai/bin/vastai" --version
+              "${XDG_DATA_HOME:-$HOME/.local/share}/vastai/bin/vastai" --version
             '
       - name: install natively (macOS)
         if: ${{ !matrix.image }}
         run: |
           VASTAI_PIP_SPEC="$(ls dist/vastai-*.whl)" bash scripts/install.sh
-          "$HOME/.local/share/vastai/bin/vastai" --version
+          "${XDG_DATA_HOME:-$HOME/.local/share}/vastai/bin/vastai" --version

--- a/docs/install-design.md
+++ b/docs/install-design.md
@@ -53,7 +53,8 @@ The design splits the install into two layers:
   via the `#sha256=` URL fragment. (Version-pinned installs fall back to the
   PyPI pin: uv's TLS + index hashes.)
 - Runs as root without complaint (no shared prefix — everything lands in the
-  invoking user's `$HOME/.vastai`), since fresh VMs/containers are commonly root.
+  invoking user's `$HOME/.local/share/vastai`), since fresh VMs/containers are
+  commonly root.
 - Unsupported platform, **glibc older than the floor** (2.31 — Ubuntu 20.04+/
   Debian 11+), or bad hash → exits cleanly pointing at pip, before anything
   lands in `$ROOT`.
@@ -61,7 +62,7 @@ The design splits the install into two layers:
   skippable via `--no-modify-path`, never written non-interactively.
 - pip coexistence: pip stays the channel for the Python SDK, and its package
   ships a `vastai` script too — the `vastai` *command* belongs to the managed
-  install. The rc gets one constant line sourcing `~/.vastai/env.sh` (the
+  install. The rc gets one constant line sourcing `<data-root>/env.sh` (the
   rustup/uv pattern), which prepends `~/.local/bin` unless already first — so
   precedence is asserted at every shell startup and a later pip install is
   out-ranked without any re-run. rc files are append-only, never rewritten;
@@ -70,35 +71,57 @@ The design splits the install into two layers:
 
 ## 3. On-disk layout
 
-Everything lives under `~/.vastai` (`VASTAI_INSTALL_DIR` overrides):
+Layout follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/)
+instead of a single ad hoc dotfolder. Four roots, each independently
+overridable by the standard `XDG_*` variable, plus `VASTAI_INSTALL_DIR` as a
+dedicated override for the program root (also the sandboxing knob the
+hermetic tests use):
+
+| Purpose | Default | Override |
+|---|---|---|
+| Program (venv, bootstrap engine, managed CPython) | `~/.local/share/vastai` | `VASTAI_INSTALL_DIR`, else `$XDG_DATA_HOME` |
+| Config (e.g. `vast_api_key`) | `~/.config/vastai` | `$XDG_CONFIG_HOME` |
+| Cache (disposable, regenerable) | `~/.cache/vastai` | `$XDG_CACHE_HOME` |
+| State (update-check throttle) | `~/.local/state/vastai` | `$XDG_STATE_HOME` |
+| Binary symlink | `~/.local/bin/vastai` | (fixed — always here, matches every other XDG-aware CLI) |
 
 ```
-~/.vastai/
+~/.local/share/vastai/            ($XDG_DATA_HOME/vastai, or $VASTAI_INSTALL_DIR)
 ├── bin/
-│   ├── vastai   → ../env/bin/vastai   (fixed symlink; target never changes)
-│   └── uv                              (pinned bootstrap engine, internal)
-├── env/                                (the single active venv — see §6)
-├── env.sh                              (sourced by the rc line: PATH precedence + completion)
-└── python/                             (uv-managed CPython 3.12, shared)
+│   ├── vastai   → ../current/bin/vastai   (fixed symlink; target never changes)
+│   └── uv                                  (pinned bootstrap engine, internal)
+├── current/                                (the single active venv — see §6)
+├── env.sh                                  (sourced by the rc line: PATH precedence + completion)
+└── python/                                 (uv-managed CPython 3.12, shared)
+
+~/.config/vastai/                 vast_api_key, etc. — untouched by install/uninstall
+~/.cache/vastai/                  disposable (e.g. a future download cache, §6)
+~/.local/state/vastai/            update_check.json (throttle timestamp)
 ```
 
 - The venv is built **relocatable** (`uv venv --relocatable`) so its
   entry-point shebangs don't hardcode the build path — that's what lets an
-  update build in a temp dir and rename `env/` into place (§6).
-- `bin/vastai` is a **fixed** symlink into `env/`; it is created once and never
-  retargeted (the `env/` path is constant). `~/.local/bin/vastai` →
-  `~/.vastai/bin/vastai` puts it on PATH.
-- Config lives in `~/.config/vastai` (e.g. `vast_api_key`) — **untouched** by
-  install/uninstall. Switching install methods keeps auth; uninstalling keeps
-  the key.
-- Throwaway state lives in `~/.cache/vastai` (update-check throttle).
-- Uninstall: `rm -rf ~/.vastai ~/.local/bin/vastai`.
+  update build in a temp dir and rename `current/` into place (§6).
+- `bin/vastai` is a **fixed** symlink into `current/`; it is created once and
+  never retargeted (the `current/` path is constant). `~/.local/bin/vastai` →
+  `<data-root>/bin/vastai` puts it on PATH.
+- Config lives in `~/.config/vastai` — **untouched** by install/uninstall.
+  Switching install methods keeps auth; uninstalling keeps the key.
+- Throwaway state (update-check throttle) lives in `~/.local/state/vastai`,
+  separate from the disposable-cache directory — it's a small persistent
+  marker, not something safe to evict on a whim the way a cache entry is.
+- Uninstall: `rm -rf ~/.local/share/vastai ~/.local/bin/vastai` (config,
+  cache, and state are left alone, same as before).
+
+This is a directory-naming change only — see §14 for why it does **not**
+reopen the single-active-install decision in §6: `current/` still names the
+one active venv, not a slot in a retained version tree.
 
 ### Detecting a managed install
 
 `vastai update` decides "do I own this install?" **structurally**, not from a
-marker file: a managed CLI runs from `~/.vastai/env` with a sibling
-`~/.vastai/bin/uv`. That's ground truth — `sys.prefix` can't drift or be
+marker file: a managed CLI runs from `<data-root>/current` with a sibling
+`<data-root>/bin/uv`. That's ground truth — `sys.prefix` can't drift or be
 hand-copied the way a receipt file could. **pip installs run from elsewhere,
 fail the check, and are never touched by the updater.** Either misdetection
 fails safe (a wrong "managed" hits "no bin/uv" and aborts cleanly; a wrong
@@ -144,10 +167,11 @@ retargeting, no retention/GC, no offline-instant-rollback guarantee.
 
 ### Behavior
 - **Single active install.** Update = build-new-then-swap, never mutate in
-  place destructively: build a fresh venv in a temp dir (`.env.new`) → verify →
-  atomically rename over `env/`. An interrupted update only ever dirties the
-  temp dir; the live `env/` is touched by two renames (~instant) and can never
-  be left half-written. **This is the one safety property worth preserving.**
+  place destructively: build a fresh venv in a temp dir (`.current.new`) →
+  verify → atomically rename over `current/`. An interrupted update only ever
+  dirties the temp dir; the live `current/` is touched by two renames
+  (~instant) and can never be left half-written. **This is the one safety
+  property worth preserving.**
 - `vastai update` — installs the manifest's latest.
 - `vastai update --version X` — installs/pins a specific version. **Downgrade
   and forward-pin are the identical code path**; rollback is just "don't forbid
@@ -219,7 +243,10 @@ is.
 ## 10. Env knobs
 
 - `VASTAI_VERSION` — pin version (also the rollback/downgrade mechanism).
-- `VASTAI_INSTALL_DIR` — override `~/.vastai`.
+- `VASTAI_INSTALL_DIR` — override the program root (default `$XDG_DATA_HOME/vastai`,
+  i.e. `~/.local/share/vastai`).
+- `XDG_DATA_HOME` / `XDG_CONFIG_HOME` / `XDG_CACHE_HOME` / `XDG_STATE_HOME` —
+  standard XDG overrides for the program/config/cache/state roots (§3).
 - `VASTAI_CLI_BASE_URL` — manifest origin (dev/release verification).
 - `VASTAI_PIP_SPEC` — dev/CI: install from a local wheel path/URL.
 - `VASTAI_GLIBC_FLOOR` — override the minimum-glibc gate (default 2.31).
@@ -286,7 +313,7 @@ gh release upload v1.0.14 --clobber \
 # verify the real user path before walking away
 VASTAI_CLI_BASE_URL=https://github.com/vast-ai/vast-cli/releases/latest/download \
     bash scripts/install.sh
-~/.vastai/bin/vastai --version
+~/.local/share/vastai/bin/vastai --version
 ```
 
 Rules the automation must enforce (a human must remember for now):
@@ -321,8 +348,18 @@ manual runbook above is the break-glass fallback.
 
 - Canonical URL `https://vast.ai/install.sh`; hosting via `vast_landing` 307
   redirects → GitHub Release assets.
-- Program in `~/.vastai`, config in `~/.config/vastai`, throwaway state in
-  `~/.cache/vastai`.
+- **Layout follows the XDG Base Directory Specification (CLN ticket, this
+  PR):** program in `~/.local/share/vastai` (`current/` the single active
+  venv), config in `~/.config/vastai`, cache in `~/.cache/vastai`, update-check
+  state in `~/.local/state/vastai`, binary symlinked at `~/.local/bin/vastai`
+  — each root independently overridable via the standard `XDG_*` variable
+  (§3, §10). This was a pure directory-naming migration off the original
+  single `~/.vastai` dotfolder: it deliberately does **not** revisit the
+  single-active-install decision below — `current/` is still one active venv,
+  not a slot in a version tree. Config/cache placement was already
+  XDG-correct before this change (via the `xdg` package); state is the only
+  new root, split out of cache because a throttle timestamp is small,
+  persistent, and not safe to treat as disposable the way a download cache is.
 - Managed runtime pinned to CPython 3.12 (independent of the wheel's `>=3.10`
   for pip users); bumps roll out as manifest changes.
 - Bootstrap engine: pinned `uv` behind the manifest seam — replaceable without

--- a/docs/install-design.md
+++ b/docs/install-design.md
@@ -110,8 +110,10 @@ hermetic tests use):
 - Throwaway state (update-check throttle) lives in `~/.local/state/vastai`,
   separate from the disposable-cache directory — it's a small persistent
   marker, not something safe to evict on a whim the way a cache entry is.
-- Uninstall: `rm -rf ~/.local/share/vastai ~/.local/bin/vastai` (config,
-  cache, and state are left alone, same as before).
+- Uninstall: `rm -rf "$XDG_DATA_HOME/vastai" ~/.local/bin/vastai` (default
+  `$XDG_DATA_HOME` is `~/.local/share`; use whatever `VASTAI_INSTALL_DIR`/
+  `XDG_DATA_HOME` you installed with, if overridden. Config, cache, and state
+  are left alone, same as before).
 
 This is a directory-naming change only — see §14 for why it does **not**
 reopen the single-active-install decision in §6: `current/` still names the

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -18,7 +18,9 @@
 #   python3 -m http.server 8901 --directory DIR &
 #   VASTAI_MANIFEST_URL=http://127.0.0.1:8901/manifest.json vastai update --check
 #
-# Uninstall: rm -rf ~/.local/share/vastai ~/.local/bin/vastai
+# Uninstall: rm -rf "$XDG_DATA_HOME/vastai" ~/.local/bin/vastai
+#            (default XDG_DATA_HOME is ~/.local/share; use whatever
+#            VASTAI_INSTALL_DIR/XDG_DATA_HOME you installed with, if overridden)
 
 set -euo pipefail
 

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -8,8 +8,8 @@
 #
 # Renders the same release manifest CI would publish (real uv checksums from
 # GitHub), then runs scripts/install.sh against it via file:// — everything
-# else is exactly the production path: installs to ~/.vastai, links
-# ~/.local/bin/vastai, consent-gated PATH edit, real PyPI download.
+# else is exactly the production path: installs to ~/.local/share/vastai,
+# links ~/.local/bin/vastai, consent-gated PATH edit, real PyPI download.
 #
 # --from-source builds the working tree with poetry and installs that wheel
 # through the same path, so unreleased features (e.g. `vastai update`) can be
@@ -18,7 +18,7 @@
 #   python3 -m http.server 8901 --directory DIR &
 #   VASTAI_MANIFEST_URL=http://127.0.0.1:8901/manifest.json vastai update --check
 #
-# Uninstall: rm -rf ~/.vastai ~/.local/bin/vastai
+# Uninstall: rm -rf ~/.local/share/vastai ~/.local/bin/vastai
 
 set -euo pipefail
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,27 +3,32 @@
 #
 #   curl -fsSL https://vast.ai/install.sh | bash
 #
-# Installs a self-contained vastai CLI into ~/.vastai (no Python required on
-# the machine, no sudo, nothing outside ~/.vastai and ~/.local/bin is touched
-# except one setup line in your shell rc (enabled by default at a real
-# terminal; skip with --no-modify-path; never written non-interactively/CI).
+# Installs a self-contained vastai CLI following the XDG Base Directory
+# Specification (no Python required on the machine, no sudo): the program
+# lives under $XDG_DATA_HOME/vastai (default ~/.local/share/vastai), state
+# under $XDG_STATE_HOME/vastai (default ~/.local/state/vastai), and the
+# binary is symlinked into ~/.local/bin. Nothing outside those directories is
+# touched except one setup line in your shell rc (enabled by default at a
+# real terminal; skip with --no-modify-path; never written non-interactively/CI).
 # Design: install-design.md in https://github.com/vast-ai/vast-cli
 #
 # Options (env vars, or flags after `bash -s --`):
 #   VASTAI_VERSION=1.2.3       install a specific version (default: latest)
-#   VASTAI_INSTALL_DIR=DIR     install root (default: ~/.vastai)
+#   VASTAI_INSTALL_DIR=DIR     install root (default: $XDG_DATA_HOME/vastai)
 #   VASTAI_CLI_BASE_URL=URL    manifest base (default: https://vast.ai/cli)
 #   VASTAI_NO_MODIFY_PATH=1    never edit shell rc files  (flag: --no-modify-path)
 #   VASTAI_PIP_SPEC=...        what to install instead of vastai==VERSION
 #                              (dev/CI only: e.g. a local wheel path)
 #   VASTAI_GLIBC_FLOOR=2.31    minimum glibc; below this, bail to pip
 #
-# Uninstall:  rm -rf ~/.vastai ~/.local/bin/vastai
+# Uninstall:  rm -rf ~/.local/share/vastai ~/.local/bin/vastai
+#             (config in ~/.config/vastai and cache/state are left alone)
 
 set -euo pipefail
 
 BASE_URL="${VASTAI_CLI_BASE_URL:-https://vast.ai/cli}"
-ROOT="${VASTAI_INSTALL_DIR:-$HOME/.vastai}"
+XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+ROOT="${VASTAI_INSTALL_DIR:-$XDG_DATA_HOME/vastai}"
 LOCAL_BIN="$HOME/.local/bin"
 NO_MODIFY_PATH="${VASTAI_NO_MODIFY_PATH:-}"
 WORKDIR=""
@@ -193,7 +198,7 @@ install_uv() {
 
 install_version() {
     local version="$1" python_pin="$2" wheel_url="${3:-}" wheel_sha="${4:-}"
-    local envdir="$ROOT/env" newdir="$ROOT/.env.new"
+    local envdir="$ROOT/current" newdir="$ROOT/.current.new"
 
     say "Installing vastai $version (Python $python_pin) → $ROOT"
     rm -rf "$newdir"
@@ -201,9 +206,9 @@ install_version() {
     export UV_PYTHON_PREFERENCE="only-managed"
     # Provision the managed CPython first — the slow, download-heavy step, so show
     # its progress at a TTY (quiet in CI). The venv build is then always quiet:
-    # uv venv's own "Activate with: source .../.env.new/..." line is misleading
-    # here — .env.new is renamed to env/ below, and vastai is a symlinked CLI you
-    # run, never a venv you "activate".
+    # uv venv's own "Activate with: source .../.current.new/..." line is misleading
+    # here — .current.new is renamed to current/ below, and vastai is a symlinked
+    # CLI you run, never a venv you "activate".
     # ${arr[@]+...} guard: bash 3.2 (macOS default) treats an empty array as
     # unset under `set -u`, so a bare "${pyquiet[@]}" would abort the install.
     # --no-bin: the venv finds the interpreter via UV_PYTHON_INSTALL_DIR;
@@ -214,7 +219,7 @@ install_version() {
         rm -rf "$newdir"
         die "could not provision the Python $python_pin runtime"
     fi
-    # --relocatable: no hardcoded build path in shebangs (env/ is renamed into place).
+    # --relocatable: no hardcoded build path in shebangs (current/ is renamed into place).
     if ! "$ROOT/bin/uv" venv "$newdir" --python "$python_pin" --relocatable --quiet; then
         rm -rf "$newdir"
         die "could not set up the Python $python_pin runtime"
@@ -235,15 +240,15 @@ install_version() {
         || { rm -rf "$newdir"; die "installed CLI failed its smoke test"; }
 
     # Swap built env in via renames; an interrupted build can't break the live env.
-    rm -rf "$ROOT/.env.old"
-    [ -d "$envdir" ] && mv "$envdir" "$ROOT/.env.old"
+    rm -rf "$ROOT/.current.old"
+    [ -d "$envdir" ] && mv "$envdir" "$ROOT/.current.old"
     mv "$newdir" "$envdir"
-    rm -rf "$ROOT/.env.old"
+    rm -rf "$ROOT/.current.old"
 
-    # Fixed-target symlinks (env/ path is constant); never retargeted on update.
+    # Fixed-target symlinks (current/ path is constant); never retargeted on update.
     local name
     for name in vastai serve-vast-deployment register-python-argcomplete; do
-        [ -e "$envdir/bin/$name" ] && link_swap "../env/bin/$name" "$ROOT/bin/$name"
+        [ -e "$envdir/bin/$name" ] && link_swap "../current/bin/$name" "$ROOT/bin/$name"
     done
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,8 +21,11 @@
 #                              (dev/CI only: e.g. a local wheel path)
 #   VASTAI_GLIBC_FLOOR=2.31    minimum glibc; below this, bail to pip
 #
-# Uninstall:  rm -rf ~/.local/share/vastai ~/.local/bin/vastai
-#             (config in ~/.config/vastai and cache/state are left alone)
+# Uninstall:  rm -rf "$XDG_DATA_HOME/vastai" ~/.local/bin/vastai
+#             (default XDG_DATA_HOME is ~/.local/share; use whatever
+#             VASTAI_INSTALL_DIR/XDG_DATA_HOME you installed with, if
+#             overridden. Config in ~/.config/vastai and cache/state are
+#             left alone.)
 
 set -euo pipefail
 

--- a/scripts/tests/test-install-matrix.sh
+++ b/scripts/tests/test-install-matrix.sh
@@ -46,7 +46,7 @@ for row in "${MATRIX[@]}"; do
       -e VASTAI_CLI_BASE_URL="$BASE" -e VASTAI_NO_MODIFY_PATH="${TTY:+}${TTY:-1}" \
       "$image" sh -c "$prep
         bash scripts/install.sh
-        \"\$HOME/.local/share/vastai/bin/vastai\" --version"; then
+        \"\${XDG_DATA_HOME:-\$HOME/.local/share}/vastai/bin/vastai\" --version"; then
     echo "PASS $name"; pass=$((pass+1))
   else
     echo "FAIL $name"; fail=$((fail+1))

--- a/scripts/tests/test-install-matrix.sh
+++ b/scripts/tests/test-install-matrix.sh
@@ -46,7 +46,7 @@ for row in "${MATRIX[@]}"; do
       -e VASTAI_CLI_BASE_URL="$BASE" -e VASTAI_NO_MODIFY_PATH="${TTY:+}${TTY:-1}" \
       "$image" sh -c "$prep
         bash scripts/install.sh
-        \"\$HOME/.vastai/bin/vastai\" --version"; then
+        \"\$HOME/.local/share/vastai/bin/vastai\" --version"; then
     echo "PASS $name"; pass=$((pass+1))
   else
     echo "FAIL $name"; fail=$((fail+1))

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -84,7 +84,7 @@ def _seed_env(root, version):
 
 
 class TestIsManagedInstall:
-    def test_true_when_running_from_env_next_to_uv(self, install_root, monkeypatch):
+    def test_true_when_running_from_current_next_to_uv(self, install_root, monkeypatch):
         (install_root / "current").mkdir()
         (install_root / "bin" / "uv").write_text("")
         monkeypatch.setattr(sys, "prefix", str(install_root / "current"))

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -75,8 +75,8 @@ def install_root(tmp_path, monkeypatch):
 
 
 def _seed_env(root, version):
-    """Create a live env/ with a runnable vastai (a prior install to replace)."""
-    bindir = root / "env" / "bin"
+    """Create a live current/ with a runnable vastai (a prior install to replace)."""
+    bindir = root / "current" / "bin"
     bindir.mkdir(parents=True)
     exe = bindir / "vastai"
     exe.write_text(f"#!/bin/sh\necho '{version}'\n")
@@ -85,9 +85,9 @@ def _seed_env(root, version):
 
 class TestIsManagedInstall:
     def test_true_when_running_from_env_next_to_uv(self, install_root, monkeypatch):
-        (install_root / "env").mkdir()
+        (install_root / "current").mkdir()
         (install_root / "bin" / "uv").write_text("")
-        monkeypatch.setattr(sys, "prefix", str(install_root / "env"))
+        monkeypatch.setattr(sys, "prefix", str(install_root / "current"))
         assert is_managed_install() is True
 
     def test_false_for_pip_install(self, install_root, monkeypatch):
@@ -96,8 +96,8 @@ class TestIsManagedInstall:
         assert is_managed_install() is False
 
     def test_false_when_uv_missing(self, install_root, monkeypatch):
-        (install_root / "env").mkdir()  # env present but no bin/uv
-        monkeypatch.setattr(sys, "prefix", str(install_root / "env"))
+        (install_root / "current").mkdir()  # current present but no bin/uv
+        monkeypatch.setattr(sys, "prefix", str(install_root / "current"))
         assert is_managed_install() is False
 
 
@@ -138,16 +138,16 @@ class TestPerformUpdate:
         perform_update("1.3.0", MANIFEST)
 
         # single fixed env, symlink points into it, new version live, no retention
-        assert "env/bin/vastai" in os.readlink(str(install_root / "bin" / "vastai"))
-        assert (install_root / "env" / "bin" / "vastai").exists()
-        assert "1.3.0" in (install_root / "env" / "bin" / "vastai").read_text()
-        assert not (install_root / ".env.new").exists()
+        assert "current/bin/vastai" in os.readlink(str(install_root / "bin" / "vastai"))
+        assert (install_root / "current" / "bin" / "vastai").exists()
+        assert "1.3.0" in (install_root / "current" / "bin" / "vastai").read_text()
+        assert not (install_root / ".current.new").exists()
         assert not (install_root / "versions").exists()
 
     def test_build_failure_surfaces_real_error_not_a_fabricated_one(self, install_root):
         # A uv that "succeeds" but never builds the env: the verify step then
-        # runs a non-existent .env.new/bin/vastai. The error must name the real
-        # missing path, not relabel it the misleading "Required tool not found".
+        # runs a non-existent .current.new/bin/vastai. The error must name the
+        # real missing path, not relabel it the misleading "Required tool not found".
         _seed_env(install_root, "1.2.3")
         uv = install_root / "bin" / "uv"
         uv.write_text("#!/bin/sh\nexit 0\n")  # does nothing — no venv, no install
@@ -157,11 +157,11 @@ class TestPerformUpdate:
             perform_update("1.3.0", MANIFEST)
         msg = str(exc.value)
         assert "Required tool not found" not in msg
-        assert ".env.new/bin/vastai" in msg
+        assert ".current.new/bin/vastai" in msg
 
     def test_failure_leaves_current_install_untouched(self, install_root):
         _seed_env(install_root, "1.2.3")  # live install that must survive
-        before = (install_root / "env" / "bin" / "vastai").read_text()
+        before = (install_root / "current" / "bin" / "vastai").read_text()
         uv = install_root / "bin" / "uv"
         uv.write_text("#!/bin/sh\nexit 1\n")
         uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
@@ -169,8 +169,8 @@ class TestPerformUpdate:
         with pytest.raises(UpdateError):
             perform_update("1.3.0", MANIFEST)
 
-        assert (install_root / "env" / "bin" / "vastai").read_text() == before
-        assert not (install_root / ".env.new").exists()
+        assert (install_root / "current" / "bin" / "vastai").read_text() == before
+        assert not (install_root / ".current.new").exists()
 
 
 class TestUpdateCommand:
@@ -185,7 +185,7 @@ class TestUpdateCommand:
         assert "Update available: 1.3.0" in capsys.readouterr().out
 
     def test_pip_install_refused_with_hint(self, parse_argv, capsys):
-        # not a managed install (interpreter isn't under ~/.vastai/env)
+        # not a managed install (interpreter isn't under the data root's current/)
         args = parse_argv(["update"])
         with patch("vastai.cli.commands.update.is_managed_install", return_value=False):
             assert args.func(args) == 1

--- a/tests/installer/run_tests.sh
+++ b/tests/installer/run_tests.sh
@@ -139,21 +139,32 @@ out_lacks()    { ! grep -qa "$1" "$SB_OUT"; }
 test_fresh_install() { # happy path: fixed env symlink, runnable CLI, managed layout
     new_sandbox fresh
     run_install || { cat "$SB_OUT"; return 1; }
-    assert "vastai symlink -> env bin" \
-        [ "$(readlink "$SB_ROOT/bin/vastai")" = "../env/bin/vastai" ] &&
+    assert "vastai symlink -> current bin" \
+        [ "$(readlink "$SB_ROOT/bin/vastai")" = "../current/bin/vastai" ] &&
     assert "installed CLI runs" [ "$("$SB_ROOT/bin/vastai" --version)" = "1.2.3" ] &&
-    assert "managed-install markers present (env/ + bin/uv)" \
-        [ -d "$SB_ROOT/env" ] && [ -x "$SB_ROOT/bin/uv" ] &&
+    assert "managed-install markers present (current/ + bin/uv)" \
+        [ -d "$SB_ROOT/current" ] && [ -x "$SB_ROOT/bin/uv" ] &&
     assert "local bin link exists" [ -L "$SB_HOME/.local/bin/vastai" ]
 }
 
-test_pinned_reinstall() { # VASTAI_VERSION pin replaces env in place, no retention
+test_pinned_reinstall() { # VASTAI_VERSION pin replaces current in place, no retention
     new_sandbox reinstall
     run_install || { cat "$SB_OUT"; return 1; }
     run_install VASTAI_VERSION=0.9.9 || { cat "$SB_OUT"; return 1; }
     assert "pinned version live" [ "$("$SB_ROOT/bin/vastai" --version)" = "0.9.9" ] &&
     assert "single active install, no version retention" [ ! -e "$SB_ROOT/versions" ] &&
-    assert "no leftover temp env" [ ! -e "$SB_ROOT/.env.new" ]
+    assert "no leftover temp env" [ ! -e "$SB_ROOT/.current.new" ]
+}
+
+test_xdg_data_home_default() { # no VASTAI_INSTALL_DIR -> installs under $XDG_DATA_HOME/vastai
+    new_sandbox xdgdata
+    local xdg_data="$SB/xdgdata"
+    env "HOME=$SB_HOME" "XDG_DATA_HOME=$xdg_data" "VASTAI_CLI_BASE_URL=$SERVER/good" \
+        "SHELL=/bin/bash" "VASTAI_NO_MODIFY_PATH=1" \
+        bash "$INSTALL_SH" >"$SB_OUT" 2>&1 </dev/null || { cat "$SB_OUT"; return 1; }
+    assert "installed under \$XDG_DATA_HOME/vastai/current" [ -d "$xdg_data/vastai/current" ] &&
+    assert "installed CLI runs" [ "$("$xdg_data/vastai/bin/vastai" --version)" = "1.2.3" ] &&
+    assert "local bin link exists" [ -L "$SB_HOME/.local/bin/vastai" ]
 }
 
 test_wheel_url_install() { # latest installs the manifest's hash-pinned release wheel
@@ -338,7 +349,7 @@ test_tty_install() { # interactive install (stderr on a pty) must survive old ba
 # Runner
 # ---------------------------------------------------------------------------
 
-ALL_TESTS=(fresh_install pinned_reinstall wheel_url_install wheel_url_pin_fallback checksum_abort truncation_guard glibc_floor rc_safety env_sh pip_shadowing pip_shadowing_quiet pip_shadowing_rerun completion_files_generated tty_install)
+ALL_TESTS=(fresh_install pinned_reinstall xdg_data_home_default wheel_url_install wheel_url_pin_fallback checksum_abort truncation_guard glibc_floor rc_safety env_sh pip_shadowing pip_shadowing_quiet pip_shadowing_rerun completion_files_generated tty_install)
 # No "${@:-...}": expanding $@ with zero args under set -u is itself fatal on
 # old bash, and this harness must run under macOS's stock bash 3.2 (see
 # test_tty_install).

--- a/tests/installer/run_tests.sh
+++ b/tests/installer/run_tests.sh
@@ -136,7 +136,7 @@ out_lacks()    { ! grep -qa "$1" "$SB_OUT"; }
 # Scenarios
 # ---------------------------------------------------------------------------
 
-test_fresh_install() { # happy path: fixed env symlink, runnable CLI, managed layout
+test_fresh_install() { # happy path: fixed current symlink, runnable CLI, managed layout
     new_sandbox fresh
     run_install || { cat "$SB_OUT"; return 1; }
     assert "vastai symlink -> current bin" \

--- a/vastai/cli/selfupdate.py
+++ b/vastai/cli/selfupdate.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 import requests
 
-from vastai.cli.util import DIRS, VERSION
+from vastai.cli.util import DATA_HOME, DIRS, VERSION
 
 DEFAULT_MANIFEST_URL = "https://vast.ai/cli/manifest.json"
 INSTALL_SH_HINT = "curl -fsSL https://vast.ai/install.sh | bash"
@@ -50,10 +50,24 @@ class UpdateError(Exception):
 # ---------------------------------------------------------------------------
 
 def install_root() -> Path:
+    """Where the managed install lives.
+
+    Prefers ground truth from where this interpreter is actually running: if
+    we're already inside a managed install (``<root>/current`` next to
+    ``<root>/bin/uv``), that's authoritative and immune to
+    $VASTAI_INSTALL_DIR/$XDG_DATA_HOME differing between install time and
+    now — e.g. a custom install dir that isn't set in the current shell would
+    otherwise make a real managed install look unmanaged. Only when we're
+    *not* currently running from one (a pip install checking
+    ``is_managed_install``) do we fall back to computing where a managed
+    install would live.
+    """
+    prefix = Path(sys.prefix).resolve()
+    if prefix.name == "current" and (prefix.parent / "bin" / "uv").exists():
+        return prefix.parent
     if os.environ.get("VASTAI_INSTALL_DIR"):
-        return Path(os.environ["VASTAI_INSTALL_DIR"])
-    data_home = os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share")
-    return Path(data_home) / "vastai"
+        return Path(os.environ["VASTAI_INSTALL_DIR"]).expanduser()
+    return Path(DATA_HOME) / "vastai"
 
 
 def is_managed_install() -> bool:

--- a/vastai/cli/selfupdate.py
+++ b/vastai/cli/selfupdate.py
@@ -1,12 +1,13 @@
 """Self-update engine for the managed (curl | bash) CLI install.
 
-Layout (docs/install-design.md): everything under $VASTAI_INSTALL_DIR
-(default ~/.vastai) — a single active venv at env/, with bin/vastai a fixed
-symlink into it. Updating rebuilds env/ in place (build temp → verify → swap);
-there is no version retention.
+Layout (docs/install-design.md, XDG Base Directory Specification): the
+install root defaults to $XDG_DATA_HOME/vastai (~/.local/share/vastai),
+override with $VASTAI_INSTALL_DIR — a single active venv at current/, with
+bin/vastai a fixed symlink into it. Updating rebuilds current/ in place
+(build temp → verify → swap); there is no version retention.
 
 "Managed install?" is detected structurally (``is_managed_install``): a managed
-CLI runs from ~/.vastai/env with a sibling ~/.vastai/bin/uv. That's ground
+CLI runs from <root>/current with a sibling <root>/bin/uv. That's ground
 truth — no on-disk marker to drift or hand-copy. pip installs fail the check
 and the updater never touches them.
 
@@ -32,7 +33,7 @@ DEFAULT_MANIFEST_URL = "https://vast.ai/cli/manifest.json"
 INSTALL_SH_HINT = "curl -fsSL https://vast.ai/install.sh | bash"
 PIP_UPGRADE_HINT = "pip install --upgrade vastai"
 
-UPDATE_CHECK_FILE = os.path.join(DIRS['temp'], "update_check.json")
+UPDATE_CHECK_FILE = os.path.join(DIRS['state'], "update_check.json")
 CHECK_INTERVAL_S = 24 * 60 * 60
 NUDGE_TIMEOUT_S = 1.0
 
@@ -49,20 +50,23 @@ class UpdateError(Exception):
 # ---------------------------------------------------------------------------
 
 def install_root() -> Path:
-    return Path(os.environ.get("VASTAI_INSTALL_DIR") or Path.home() / ".vastai")
+    if os.environ.get("VASTAI_INSTALL_DIR"):
+        return Path(os.environ["VASTAI_INSTALL_DIR"])
+    data_home = os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share")
+    return Path(data_home) / "vastai"
 
 
 def is_managed_install() -> bool:
     """True iff this CLI was installed by the managed installer.
 
     Detected from where the interpreter actually runs: a managed CLI lives in
-    ``<root>/env`` next to ``<root>/bin/uv``. Ground truth, no marker file.
+    ``<root>/current`` next to ``<root>/bin/uv``. Ground truth, no marker file.
     pip installs run from elsewhere and fail the check.
     """
     try:
         root = install_root()
         return (
-            Path(sys.prefix).resolve() == (root / "env").resolve()
+            Path(sys.prefix).resolve() == (root / "current").resolve()
             and (root / "bin" / "uv").exists()
         )
     except Exception:
@@ -203,16 +207,17 @@ def _run(cmd, *, env=None):
 
 
 def _link_binaries(root: Path) -> None:
-    """Point bin/<name> at the fixed env/bin/<name> for each shipped console
-    script. The target path is constant across updates (always ``env/``), so
-    this is not symlink *retargeting* — just (re)creating stable links."""
+    """Point bin/<name> at the fixed current/bin/<name> for each shipped
+    console script. The target path is constant across updates (always
+    ``current/``), so this is not symlink *retargeting* — just (re)creating
+    stable links."""
     for name in MANAGED_BINARIES:
-        if not (root / "env" / "bin" / name).exists():
+        if not (root / "current" / "bin" / name).exists():
             continue
         link, tmp = root / "bin" / name, root / "bin" / f".{name}.tmp"
         if tmp.is_symlink() or tmp.exists():
             tmp.unlink()
-        os.symlink(Path("..") / "env" / "bin" / name, tmp)
+        os.symlink(Path("..") / "current" / "bin" / name, tmp)
         os.replace(tmp, link)
 
 
@@ -247,7 +252,7 @@ def perform_update(target: str, manifest: dict) -> None:
         raise UpdateError(f"Bootstrap tool missing at {uv}.\nRe-run the installer: {INSTALL_SH_HINT}")
 
     python_pin = (manifest.get("install") or {}).get("python") or "3.12"
-    env_dir, new_dir, old_dir = root / "env", root / ".env.new", root / ".env.old"
+    env_dir, new_dir, old_dir = root / "current", root / ".current.new", root / ".current.old"
     shutil.rmtree(new_dir, ignore_errors=True)
 
     uv_env = dict(os.environ,
@@ -267,7 +272,7 @@ def perform_update(target: str, manifest: dict) -> None:
         shutil.rmtree(new_dir, ignore_errors=True)
         raise
 
-    # Swap via two renames (~instant); a crash mid-build only dirties .env.new.
+    # Swap via two renames (~instant); a crash mid-build only dirties .current.new.
     shutil.rmtree(old_dir, ignore_errors=True)
     if env_dir.exists():
         os.replace(env_dir, old_dir)

--- a/vastai/cli/util.py
+++ b/vastai/cli/util.py
@@ -64,7 +64,8 @@ try:
 
     DIRS = {
         'config': xdg.xdg_config_home(),
-        'temp': xdg.xdg_cache_home()
+        'temp': xdg.xdg_cache_home(),
+        'state': xdg.xdg_state_home(),
     }
 
 except Exception:
@@ -74,6 +75,7 @@ except Exception:
     DIRS = {
         'config': os.path.join(_home, '.config'),
         'temp': os.path.join(_home, '.cache'),
+        'state': os.path.join(_home, '.local', 'state'),
     }
 
 for key in DIRS.keys():

--- a/vastai/cli/util.py
+++ b/vastai/cli/util.py
@@ -67,6 +67,11 @@ try:
         'temp': xdg.xdg_cache_home(),
         'state': xdg.xdg_state_home(),
     }
+    # Not part of DIRS: DIRS entries are this CLI's own runtime data and get
+    # auto-created below regardless of install method. DATA_HOME is where a
+    # *managed install* lives (selfupdate.install_root()) — a pip install
+    # must never side-effect that directory into existence just by running.
+    DATA_HOME = xdg.xdg_data_home()
 
 except Exception:
     # Reasonable defaults.
@@ -77,6 +82,7 @@ except Exception:
         'temp': os.path.join(_home, '.cache'),
         'state': os.path.join(_home, '.local', 'state'),
     }
+    DATA_HOME = os.path.join(_home, '.local', 'share')
 
 for key in DIRS.keys():
     DIRS[key] = path = os.path.join(DIRS[key], APP_NAME)


### PR DESCRIPTION
## Summary
- Migrates the managed CLI installer's on-disk layout from a single ad hoc `~/.vastai` dotfolder to the XDG Base Directory Specification: program root `$XDG_DATA_HOME/vastai` (default `~/.local/share/vastai`), config `$XDG_CONFIG_HOME/vastai` (already correct, unchanged), cache `$XDG_CACHE_HOME/vastai` (already correct, unchanged), and a new state root `$XDG_STATE_HOME/vastai` (default `~/.local/state/vastai`) for the update-check throttle file.
- Pure directory-naming migration — deliberately does **not** reopen the existing single-active-install decision (`docs/install-design.md` §6/§14): the active venv directory is just renamed `env/` → `current/`, still one active install, no version tree/GC.
- `scripts/install.sh` and `vastai/cli/selfupdate.py` updated accordingly; `vastai/cli/util.py` gained `DIRS['state']`.
- `docs/install-design.md` rewritten (§3 on-disk layout, §10 env knobs, §13 runbook, §14 decisions log) to document the new layout and the rationale for keeping the single-active-install model.

Ref: CLN-3562

## Test plan
- [x] `tests/installer/run_tests.sh` — all 15 hermetic scenarios pass, including a new `xdg_data_home_default` test asserting the default install path resolves under `$XDG_DATA_HOME` with no `VASTAI_INSTALL_DIR` set
- [x] `poetry run pytest tests/cli/test_update_command.py` — all 32 tests pass
- [x] Manual local install via `scripts/dev-install.sh --from-source` against a real `~/.vastai` removal: confirmed the new layout (`~/.local/share/vastai/{current,bin,python,share,env.sh}`), the `vastai` binary runs and reports the correct version, `is_managed_install()`/`install_root()` resolve correctly from inside the installed venv, and no `~/.vastai` is recreated