### PR TITLE
installer: point new installs at vastai --help

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -367,6 +367,7 @@ main() {
         say "  Use it now:   start a new shell, or run: export PATH=\"\$HOME/.local/bin:\$PATH\""
     fi
     say "  Get started:  vastai set api-key YOUR_API_KEY   (https://cloud.vast.ai/manage-keys/?tab=api-keys)"
+    say "  All commands: vastai --help"
     say "  Update later: vastai update"
     if [ -n "$RC_UPDATED" ]; then
         say "  Tab completion: start a new shell, then type 'vastai <TAB>'"


### PR DESCRIPTION
## Summary
- The installer's success message tells new users how to set their API key and how to update later, but never mentions discovering the rest of the CLI. Adds a one-line hint pointing at `vastai --help`.

## Test plan
- [x] `tests/installer/run_tests.sh` — all 14 hermetic scenarios pass