### PR TITLE
update: refuse to roll back below the XDG layout floor

### DIFF
--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -137,55 +137,70 @@ def fake_uv(install_root):
 )
 class TestPerformUpdate:
     def test_success_swaps_in_new_env(self, install_root, fake_uv):
-        _seed_env(install_root, "1.2.3")
-        perform_update("1.3.0", MANIFEST)
+        _seed_env(install_root, "1.4.0")
+        perform_update("1.5.0", MANIFEST)
 
         # single fixed env, symlink points into it, new version live, no retention
         assert "current/bin/vastai" in os.readlink(str(install_root / "bin" / "vastai"))
         assert (install_root / "current" / "bin" / "vastai").exists()
-        assert "1.3.0" in (install_root / "current" / "bin" / "vastai").read_text()
+        assert "1.5.0" in (install_root / "current" / "bin" / "vastai").read_text()
         assert not (install_root / ".current.new").exists()
         assert not (install_root / "versions").exists()
 
     def test_success_prunes_uv_cache(self, install_root, fake_uv):
-        _seed_env(install_root, "1.2.3")
-        perform_update("1.3.0", MANIFEST)
+        _seed_env(install_root, "1.4.0")
+        perform_update("1.5.0", MANIFEST)
         assert (install_root / "bin" / "cache-pruned").exists()
 
     def test_prune_failure_does_not_fail_the_update(self, install_root, fake_uv):
         # uv errors on `cache prune`; the already-swapped update must still succeed
         fake_uv.write_text(FAKE_UV.replace('touch "$(dirname "$0")/cache-pruned"', "exit 1"))
-        _seed_env(install_root, "1.2.3")
-        perform_update("1.3.0", MANIFEST)
-        assert "1.3.0" in (install_root / "current" / "bin" / "vastai").read_text()
+        _seed_env(install_root, "1.4.0")
+        perform_update("1.5.0", MANIFEST)
+        assert "1.5.0" in (install_root / "current" / "bin" / "vastai").read_text()
 
     def test_build_failure_surfaces_real_error_not_a_fabricated_one(self, install_root):
         # A uv that "succeeds" but never builds the env: the verify step then
         # runs a non-existent .current.new/bin/vastai. The error must name the
         # real missing path, not relabel it the misleading "Required tool not found".
-        _seed_env(install_root, "1.2.3")
+        _seed_env(install_root, "1.4.0")
         uv = install_root / "bin" / "uv"
         uv.write_text("#!/bin/sh\nexit 0\n")  # does nothing — no venv, no install
         uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
 
         with pytest.raises(UpdateError) as exc:
-            perform_update("1.3.0", MANIFEST)
+            perform_update("1.5.0", MANIFEST)
         msg = str(exc.value)
         assert "Required tool not found" not in msg
         assert ".current.new/bin/vastai" in msg
 
     def test_failure_leaves_current_install_untouched(self, install_root):
-        _seed_env(install_root, "1.2.3")  # live install that must survive
+        _seed_env(install_root, "1.4.0")  # live install that must survive
         before = (install_root / "current" / "bin" / "vastai").read_text()
         uv = install_root / "bin" / "uv"
         uv.write_text("#!/bin/sh\nexit 1\n")
         uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
 
         with pytest.raises(UpdateError):
-            perform_update("1.3.0", MANIFEST)
+            perform_update("1.5.0", MANIFEST)
 
         assert (install_root / "current" / "bin" / "vastai").read_text() == before
         assert not (install_root / ".current.new").exists()
+
+    def test_downgrade_below_floor_is_refused_without_touching_disk(self, install_root, fake_uv):
+        _seed_env(install_root, "1.4.0")
+        before = (install_root / "current" / "bin" / "vastai").read_text()
+
+        with pytest.raises(UpdateError, match="1.4.0"):
+            perform_update("1.2.0", MANIFEST)
+
+        assert (install_root / "current" / "bin" / "vastai").read_text() == before
+        assert not (install_root / ".current.new").exists()
+
+    def test_downgrade_to_floor_itself_is_allowed(self, install_root, fake_uv):
+        _seed_env(install_root, "1.5.0")
+        perform_update("1.4.0", MANIFEST)
+        assert "1.4.0" in (install_root / "current" / "bin" / "vastai").read_text()
 
 
 class TestUpdateCommand:

--- a/vastai/cli/selfupdate.py
+++ b/vastai/cli/selfupdate.py
@@ -35,7 +35,7 @@ PIP_UPGRADE_HINT = "pip install --upgrade vastai"
 
 # Oldest version whose bundled selfupdate.py understands this layout
 # (<root>/current + <root>/bin/uv, XDG-based root). Versions before this pin
-# ~/.vastai/env and would install fine but then see themselves as unmanaged,
+# assumed ~/.vastai/env and would install fine but then see themselves as unmanaged,
 # permanently losing self-update until the install is rebuilt from scratch.
 MIN_DOWNGRADE_VERSION = "1.4.0"
 

--- a/vastai/cli/selfupdate.py
+++ b/vastai/cli/selfupdate.py
@@ -33,6 +33,12 @@ DEFAULT_MANIFEST_URL = "https://vast.ai/cli/manifest.json"
 INSTALL_SH_HINT = "curl -fsSL https://vast.ai/install.sh | bash"
 PIP_UPGRADE_HINT = "pip install --upgrade vastai"
 
+# Oldest version whose bundled selfupdate.py understands this layout
+# (<root>/current + <root>/bin/uv, XDG-based root). Versions before this pin
+# ~/.vastai/env and would install fine but then see themselves as unmanaged,
+# permanently losing self-update until the install is rebuilt from scratch.
+MIN_DOWNGRADE_VERSION = "1.4.0"
+
 UPDATE_CHECK_FILE = os.path.join(DIRS['state'], "update_check.json")
 CHECK_INTERVAL_S = 24 * 60 * 60
 NUDGE_TIMEOUT_S = 1.0
@@ -274,6 +280,12 @@ def perform_update(target: str, manifest: dict) -> None:
     which reinstalls. Wheel integrity comes from ``wheel_spec``; we
     additionally confirm the installed version matches ``target``.
     """
+    if version_key(target) < version_key(MIN_DOWNGRADE_VERSION):
+        raise UpdateError(
+            f"Can't roll back to {target}: versions before {MIN_DOWNGRADE_VERSION} "
+            "don't recognize this install's layout and would lose the ability "
+            f"to self-update. The oldest version you can roll back to is {MIN_DOWNGRADE_VERSION}."
+        )
     root = install_root()
     uv = root / "bin" / "uv"
     if not uv.exists():


### PR DESCRIPTION
## Summary
- `vastai update --version X` now refuses `X < 1.4.0` (`MIN_DOWNGRADE_VERSION`), before touching disk.
- Root cause: `is_managed_install()` detects a managed install structurally (no marker file) by checking that the interpreter runs from `<root>/current` next to `<root>/bin/uv` — the layout introduced by the XDG migration (#452). Versions before 1.4.0 have this check hardcoded to the old `~/.vastai/env` layout. Rolling back installs the old version's code into the *new* layout, so it can no longer recognize itself as managed and self-update is permanently lost (reported via internal testing: `vastai update --version 1.2.0` then `vastai update` → "not installed with the managed installer").
- Also fixes a stale pre-existing test assertion (`test_prune_failure_does_not_fail_the_update` checked `install_root/"env"`, which #452 missed renaming to `"current"`) — that test was failing on master independent of this change.

## Test plan
- [x] `poetry run pytest tests/cli/test_update_command.py -v` — 36 passed, including two new tests: refusal below the floor (disk untouched), and the floor version itself still works.