### PR TITLE
update: show the upgrade nudge before command output, not after

### DIFF
--- a/docs/install-design.md
+++ b/docs/install-design.md
@@ -201,11 +201,12 @@ Not built in v1.
 
 ## 7. Passive update nudge
 
-> **Status: enabled.** `notify_update(args)` runs as a post-command hook in
-> `main.py`. Opt out with `VASTAI_NO_UPDATE_CHECK=1` (also off under
+> **Status: enabled.** `notify_update(args)` runs as a pre-command hook in
+> `main.py`, before the command's own output, so it's never buried underneath
+> it. Opt out with `VASTAI_NO_UPDATE_CHECK=1` (also off under
 > `--raw`/`CI`/non-TTY).
 
-- After commands: at most **one manifest GET and one stderr line per 24h**, hard
+- Before commands: at most **one manifest GET and one stderr line per 24h**, hard
   1s timeout, every failure silent with 24h backoff (offline machines pay ≤1s
   once/day).
 - Suppressed under `--raw`, `CI`, non-TTY, or `VASTAI_NO_UPDATE_CHECK=1`.

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -272,6 +272,13 @@ class TestNudge:
         assert "1.3.0 is available" in err
         assert "pip install --upgrade vastai" in err
 
+    def test_trailing_blank_line_separates_it_from_command_output(self, nudge_env, capsys):
+        # runs pre-command now, so a blank line keeps it from running into
+        # whatever the command prints next
+        with patch.object(selfupdate, "fetch_manifest", return_value=MANIFEST):
+            selfupdate.notify_update(nudge_env)
+        assert capsys.readouterr().err.endswith("\n\n")
+
     def test_managed_install_gets_vastai_update_hint(self, nudge_env, capsys):
         with patch.object(selfupdate, "fetch_manifest", return_value=MANIFEST), \
              patch.object(selfupdate, "is_managed_install", return_value=True):

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -143,6 +143,13 @@ def main():
 
     args = parser.parse_args()
 
+    # Passive upgrade nudge: best-effort, ≤1 manifest GET + ≤1 stderr line per
+    # 24h, silent when offline/piped/CI. Never raises. Opt out with
+    # VASTAI_NO_UPDATE_CHECK=1. Runs first so it's visible before any command
+    # output, not buried after it. See selfupdate.py and §7.
+    from vastai.cli.selfupdate import notify_update
+    notify_update(args)
+
     # API key resolution
     if args.api_key is api_key_guard:
         key_file = TFAKEY_FILE if os.path.exists(TFAKEY_FILE) else APIKEY_FILE
@@ -156,12 +163,6 @@ def main():
     while True:
         try:
             res = args.func(args)
-
-            # Passive upgrade nudge: best-effort, ≤1 manifest GET + ≤1 stderr
-            # line per 24h, silent when offline/piped/CI. Never raises. Opt out
-            # with VASTAI_NO_UPDATE_CHECK=1. See selfupdate.py and §7.
-            from vastai.cli.selfupdate import notify_update
-            notify_update(args)
 
             if args.raw and res is not None:
                 try:

--- a/vastai/cli/selfupdate.py
+++ b/vastai/cli/selfupdate.py
@@ -162,7 +162,7 @@ def _stderr_is_tty() -> bool:
 
 
 def notify_update(args=None) -> None:
-    """Post-command, best-effort upgrade nudge. Must never raise or block."""
+    """Pre-command, best-effort upgrade nudge. Must never raise or block."""
     try:
         _notify_update(args)
     except Exception:
@@ -199,8 +199,9 @@ def _notify_update(args) -> None:
 
     hint = "vastai update" if is_managed_install() else PIP_UPGRADE_HINT
     arrow = "↑" if "utf" in (sys.stderr.encoding or "").lower() else "*"
+    # Trailing blank line separates the nudge from the command output that follows it.
     print(
-        f"{arrow} vastai {latest} is available (you have {VERSION}). Run `{hint}`.",
+        f"{arrow} vastai {latest} is available (you have {VERSION}). Run `{hint}`.\n",
         file=sys.stderr,
     )
     state["notified_at"] = now


### PR DESCRIPTION
## Summary
- `notify_update(args)` now runs right after arg parsing in `main.py`, before `args.func(args)` executes — previously it ran after the command's own output, right before exit, so it was easy to miss below a long result.
- The nudge line now has a trailing blank line so it stays visually separated from whatever the command prints next (confirmed live: `vastai show instances` → nudge → blank line → table).
- Updated `docs/install-design.md` §7 (post-command hook → pre-command hook) and the module comment in `selfupdate.py` to match.

## Test plan
- [x] `poetry run pytest tests/cli/test_update_command.py -v` — 37 passed, including a new test pinning the trailing-blank-line behavior.
- [x] `poetry run pytest tests/cli -q` — 365 passed, no regressions from moving the call site.