### PR TITLE
Client/host command classification with role-aware CLI display

### DIFF
--- a/tests/cli/test_auth_commands.py
+++ b/tests/cli/test_auth_commands.py
@@ -119,6 +119,28 @@ class TestSetApiKey:
             assert MockClient.call_args[0][0] == "round-trip-key"
 
 
+class TestSetRole:
+    def test_set_role_host(self, tmp_path, monkeypatch, capsys):
+        role_file = tmp_path / "vast_role"
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(role_file))
+        from vastai.cli.commands.auth import set__role
+        set__role(argparse.Namespace(role="host"))
+        assert role_file.read_text() == "host"
+        assert "host" in capsys.readouterr().out.lower()
+
+    def test_set_role_client(self, tmp_path, monkeypatch, capsys):
+        role_file = tmp_path / "vast_role"
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(role_file))
+        from vastai.cli.commands.auth import set__role
+        set__role(argparse.Namespace(role="client"))
+        assert role_file.read_text() == "client"
+        assert "hidden" in capsys.readouterr().out.lower()
+
+    def test_only_host_and_client_are_valid_choices(self, cli_parser):
+        with pytest.raises(SystemExit):
+            cli_parser.parse_args(["set", "role", "admin"])
+
+
 class TestTfaStatus:
     def test_tfa_status_raw(self, parse_argv, patch_get_client, mock_response, capsys):
         patch_get_client.get.return_value = mock_response(200, {

--- a/tests/cli/test_main_error_handling.py
+++ b/tests/cli/test_main_error_handling.py
@@ -1,0 +1,111 @@
+"""Tests for vastai/cli/main.py — _emit_error's client/host 401 hint (CLN-3582)."""
+
+import argparse
+import io
+from contextlib import redirect_stderr
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from vastai.cli.main import _emit_error
+
+
+def _args(*, raw=False, func=None):
+    return argparse.Namespace(raw=raw, func=func)
+
+
+def _host_command_func(command_name):
+    """A stand-in for args.func: mysignature is the registered subparser."""
+    sp = SimpleNamespace(host_only=True, command_name=command_name)
+    func = lambda a: None  # noqa: E731
+    func.mysignature = sp
+    return func
+
+
+def _client_command_func(command_name):
+    sp = SimpleNamespace(host_only=False, command_name=command_name)
+    func = lambda a: None  # noqa: E731
+    func.mysignature = sp
+    return func
+
+
+class TestHostCommand401Hint:
+    def test_known_command_gets_specific_hint(self):
+        args = _args(func=_host_command_func("show machines"))
+        buf = io.StringIO()
+        with patch("vastai.cli.main.get_role", return_value="client"):
+            with redirect_stderr(buf):
+                _emit_error(args, 401, "no permission")
+        out = buf.getvalue()
+        assert "'show machines' is a host-only command" in out
+        assert "did you mean 'vastai show instances'?" in out
+        assert "set role host" in out
+
+    def test_unknown_command_gets_generic_hint(self):
+        args = _args(func=_host_command_func("dump-logs"))
+        buf = io.StringIO()
+        with patch("vastai.cli.main.get_role", return_value="client"):
+            with redirect_stderr(buf):
+                _emit_error(args, 401, "no permission")
+        out = buf.getvalue()
+        assert "'dump-logs' is a host-only command" in out
+        assert "vastai --help" in out
+
+    def test_host_role_does_not_get_the_hint(self):
+        args = _args(func=_host_command_func("show machines"))
+        buf = io.StringIO()
+        with patch("vastai.cli.main.get_role", return_value="host"):
+            with redirect_stderr(buf):
+                _emit_error(args, 401, "no permission")
+        assert "host-only command" not in buf.getvalue()
+
+    def test_undetected_role_also_gets_the_hint(self):
+        # Client is the default: an unset role is treated the same as
+        # 'client', not 'host' — so the hint still fires.
+        args = _args(func=_host_command_func("show machines"))
+        buf = io.StringIO()
+        with patch("vastai.cli.main.get_role", return_value=None):
+            with redirect_stderr(buf):
+                _emit_error(args, 401, "no permission")
+        assert "host-only command" in buf.getvalue()
+
+    def test_non_host_only_command_does_not_get_the_hint(self):
+        args = _args(func=_client_command_func("show instances"))
+        buf = io.StringIO()
+        with patch("vastai.cli.main.get_role", return_value="client"):
+            with redirect_stderr(buf):
+                _emit_error(args, 401, "no permission")
+        assert "host-only command" not in buf.getvalue()
+
+    def test_2fa_message_takes_precedence_over_the_hint(self):
+        # Even for a host command in the client role, an explicit 2FA error
+        # keeps its own (pre-existing) guidance rather than the new hint.
+        args = _args(func=_host_command_func("show machines"))
+        buf = io.StringIO()
+        with patch("vastai.cli.main.get_role", return_value="client"):
+            with redirect_stderr(buf):
+                _emit_error(args, 401, "Two Factor Authentication required")
+        out = buf.getvalue()
+        assert "tfa login" in out
+        assert "host-only command" not in out
+
+    def test_raw_mode_skips_the_hint_and_emits_json(self):
+        args = _args(raw=True, func=_host_command_func("show machines"))
+        buf = io.StringIO()
+        with patch("vastai.cli.main.get_role", return_value="client"):
+            with redirect_stderr(buf):
+                _emit_error(args, 401, "no permission")
+        out = buf.getvalue()
+        assert "host-only command" not in out
+        assert '"error": true' in out
+
+    def test_no_func_on_args_does_not_crash(self):
+        # Defensive: args without a func attribute (shouldn't happen in
+        # practice, but _emit_error must not blow up on missing state).
+        args = argparse.Namespace(raw=False)
+        buf = io.StringIO()
+        with patch("vastai.cli.main.get_role", return_value="client"):
+            with redirect_stderr(buf):
+                _emit_error(args, 401, "no permission")
+        assert "Failed with error 401" in buf.getvalue()

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -1,9 +1,12 @@
 """Tests for vastai/cli/parser.py — apwrap, command registration, parse_args."""
 
+import argparse
+
 import pytest
 from vastai.cli.parser import (
     apwrap, argument, hidden_aliases, MyWideHelpFormatter,
     build_command_maps, two_stage_command_completions,
+    is_host_only_command,
 )
 
 
@@ -175,6 +178,16 @@ def _completion_parser():
     return p
 
 
+def _completion_parser_with_host_cmd():
+    p = _completion_parser()
+
+    @p.command(help="show host machines", host_only=True)
+    def show__machines(args):
+        pass
+
+    return p
+
+
 class TestBuildCommandMaps:
     def test_splits_verbs_objects_and_singles(self):
         verbs, verb_objs, singles = build_command_maps(_completion_parser().parser)
@@ -183,6 +196,24 @@ class TestBuildCommandMaps:
         assert verb_objs["create"] == {"instance"}
         # bare command + the auto-registered "help" land in singles, not verbs
         assert "update" in singles and "update" not in verbs
+
+    def test_no_role_defaults_to_client_completions(self):
+        # Client is the default: an unset role (no role= passed) hides
+        # host-only commands from completion too, not just 'client'.
+        _, verb_objs, _ = build_command_maps(_completion_parser_with_host_cmd().parser)
+        assert verb_objs["show"] == {"instances", "env-vars"}
+
+    def test_host_role_completes_host_commands(self):
+        _, verb_objs, _ = build_command_maps(
+            _completion_parser_with_host_cmd().parser, role="host"
+        )
+        assert verb_objs["show"] == {"instances", "env-vars", "machines"}
+
+    def test_client_role_hides_host_commands_from_completion(self):
+        _, verb_objs, _ = build_command_maps(
+            _completion_parser_with_host_cmd().parser, role="client"
+        )
+        assert verb_objs["show"] == {"instances", "env-vars"}
 
 
 class TestTwoStageCompletions:
@@ -229,3 +260,151 @@ class TestTwoStageCompletions:
         cands, merged = self._complete(["vastai", "show", "--help"], "")
         assert cands is None
         assert merged == ["vastai", "show", "--help"]  # unchanged
+
+
+class TestIsHostOnlyCommand:
+    """Unit tests for the host-only/not classification (CLN-3582)."""
+
+    def test_explicit_true_wins_over_everything(self):
+        assert is_host_only_command(
+            "search offers", "vastai.cli.commands.machines", explicit=True
+        ) is True
+
+    def test_explicit_false_wins_over_everything(self):
+        assert is_host_only_command(
+            "show earnings", "vastai.cli.commands.machines", explicit=False
+        ) is False
+
+    def test_command_override_wins_over_module_default(self):
+        # 'reports' is flagged host-only despite misc.py being client-facing.
+        assert is_host_only_command("reports", "vastai.cli.commands.misc") is True
+
+    def test_falls_back_to_module_default(self):
+        assert is_host_only_command(
+            "show instances", "vastai.cli.commands.instances"
+        ) is False
+        assert is_host_only_command(
+            "show machines", "vastai.cli.commands.machines"
+        ) is True
+
+    def test_unmapped_module_and_command_defaults_to_visible(self):
+        # No raise, no "unresolved" state: an unmapped module/command is
+        # simply not host-only, so it's never hidden by mistake.
+        assert is_host_only_command("do stuff", "some.made.up.module") is False
+
+
+class TestCommandDecoratorHostOnly:
+    def test_unmapped_module_defaults_to_not_host_only(self):
+        # This test file's module isn't in HOST_ONLY_MODULES — the command
+        # is simply visible, not left in some unresolved state.
+        p = apwrap()
+
+        @p.command(help="show items")
+        def show__items(args):
+            pass
+
+        assert show__items.mysignature.host_only is False
+
+    def test_explicit_host_only_kwarg_is_honored(self):
+        p = apwrap()
+
+        @p.command(help="a host-only test command", host_only=True)
+        def do__hostthing(args):
+            pass
+
+        assert do__hostthing.mysignature.host_only is True
+
+    def test_host_only_auto_prefixes_help_text(self):
+        p = apwrap()
+
+        @p.command(help="do a host thing", host_only=True)
+        def do__hostthing(args):
+            pass
+
+        assert do__hostthing.mysignature_help == "do a host thing"  # stored unprefixed
+        # The rendered help (shown in --help output) carries the [Host] marker.
+        choices_actions = p.subparsers()._choices_actions
+        rendered = next(c.help for c in choices_actions if c.dest == "do hostthing")
+        assert rendered == "[Host] do a host thing"
+
+    def test_non_host_only_does_not_get_host_prefix(self):
+        p = apwrap()
+
+        @p.command(help="a client thing", host_only=False)
+        def show__clientthing(args):
+            pass
+
+        choices_actions = p.subparsers()._choices_actions
+        rendered = {c.dest: c.help for c in choices_actions}
+        assert rendered["show clientthing"] == "a client thing"
+
+
+class TestFullCliHostOnlyCoverage:
+    """Sanity check against the real, fully-populated CLI parser."""
+
+    def _all_choices_actions(self, cli_parser):
+        for a in cli_parser.parser._actions:
+            if isinstance(a, argparse._SubParsersAction):
+                return a
+        raise AssertionError("no subparsers action found")
+
+    def test_client_view_excludes_known_host_only_commands(self, cli_parser):
+        sub_action = self._all_choices_actions(cli_parser)
+        host_only = {
+            pseudo.dest
+            for pseudo in sub_action._choices_actions
+            if getattr(sub_action.choices.get(pseudo.dest), "host_only", False)
+        }
+        assert {"show machines", "list machine", "set min-bid"} <= host_only
+        assert "show instances" not in host_only
+
+
+class TestGroupedHelpRoleFiltering:
+    """--help output hides host-only commands for the client role (CLN-3582)."""
+
+    def _parser_with_host_and_client_cmds(self):
+        p = apwrap(epilog="epilogue text")
+
+        @p.command(help="show instances", host_only=False)
+        def show__instances(args):
+            pass
+
+        @p.command(help="show host machines", host_only=True)
+        def show__machines(args):
+            pass
+
+        return p
+
+    def test_unset_role_defaults_to_client_view(self, monkeypatch):
+        # Client is the default: an unset role hides host-only commands too,
+        # not just an explicit 'client' — see test below for that case.
+        monkeypatch.setattr("vastai.cli.parser.get_role", lambda: None)
+        help_text = self._parser_with_host_and_client_cmds().parser.format_help()
+        assert "show instances" in help_text
+        assert "show machines" not in help_text
+        assert "set role host" in help_text
+
+    def test_host_role_shows_everything(self, monkeypatch):
+        monkeypatch.setattr("vastai.cli.parser.get_role", lambda: "host")
+        help_text = self._parser_with_host_and_client_cmds().parser.format_help()
+        assert "show instances" in help_text
+        assert "show machines" in help_text
+        assert "set role host" not in help_text
+
+    def test_client_role_hides_host_commands_and_shows_footer(self, monkeypatch):
+        monkeypatch.setattr("vastai.cli.parser.get_role", lambda: "client")
+        help_text = self._parser_with_host_and_client_cmds().parser.format_help()
+        assert "show instances" in help_text
+        assert "show machines" not in help_text
+        assert "set role host" in help_text
+
+    def test_client_role_with_no_host_commands_shows_no_footer(self, monkeypatch):
+        monkeypatch.setattr("vastai.cli.parser.get_role", lambda: "client")
+        p = apwrap(epilog="epilogue text")
+
+        @p.command(help="show instances", host_only=False)
+        def show__instances(args):
+            pass
+
+        help_text = p.parser.format_help()
+        assert "set role host" not in help_text

--- a/tests/cli/test_util.py
+++ b/tests/cli/test_util.py
@@ -324,3 +324,31 @@ class TestRequiredInetMbps:
         from vastai.cli.util import required_inet_mbps
         result = required_inet_mbps(183359)
         assert 460.0 < result < 470.0
+
+
+class TestRole:
+    """get_role / set_role_file — the client/host CLI display preference (CLN-3582)."""
+
+    def test_unset_returns_none(self, tmp_path, monkeypatch):
+        from vastai.cli.util import get_role
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(tmp_path / "vast_role"))
+        assert get_role() is None
+
+    def test_set_then_get_round_trips(self, tmp_path, monkeypatch):
+        from vastai.cli.util import get_role, set_role_file
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(tmp_path / "vast_role"))
+        set_role_file("host")
+        assert get_role() == "host"
+
+    def test_invalid_role_raises(self, tmp_path, monkeypatch):
+        from vastai.cli.util import set_role_file
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(tmp_path / "vast_role"))
+        with pytest.raises(ValueError):
+            set_role_file("admin")
+
+    def test_corrupt_file_contents_return_none_not_raise(self, tmp_path, monkeypatch):
+        from vastai.cli.util import get_role
+        role_file = tmp_path / "vast_role"
+        role_file.write_text("garbage\nbinary\x00data")
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(role_file))
+        assert get_role() is None

--- a/vastai/cli/commands/auth.py
+++ b/vastai/cli/commands/auth.py
@@ -221,6 +221,34 @@ def set__api_key(args):
 
 
 # ---------------------------------------------------------------------------
+# set role
+# ---------------------------------------------------------------------------
+
+@parser.command(
+    argument("role", help="'host' or 'client'", choices=["host", "client"]),
+    usage="vastai set role host|client",
+    help="Set host role to view host-only commands",
+    epilog=deindent("""
+        This only changes what --help and tab completion display — every command
+        still runs regardless of role, since the server enforces real permissions.
+
+        Use it to override the detected role — e.g. after your account starts
+        or stops hosting machines.
+    """),
+)
+def set__role(args):
+    """Set the client/host CLI display role."""
+    from vastai.cli.util import set_role_file
+
+    set_role_file(args.role)
+    print(f"CLI role set to '{args.role}'.")
+    if args.role == "client":
+        print("Host-only commands are now hidden from --help and tab completion.")
+    else:
+        print("All commands (client + host) are now shown in --help and tab completion.")
+
+
+# ---------------------------------------------------------------------------
 # Note: set__user and show__user are in billing.py.
 # Note: show__ipaddrs is in billing.py.
 # ---------------------------------------------------------------------------

--- a/vastai/cli/commands/machines.py
+++ b/vastai/cli/commands/machines.py
@@ -73,7 +73,7 @@ INSTANCE_LOG_TAIL_LINES = 1000
     argument("Machine", help="id of machine to display", type=int),
     argument("-q", "--quiet", action="store_true", help="only display numeric ids"),
     usage="vastai show machine ID [OPTIONS]",
-    help="[Host] Show hosted machines",
+    help="Show hosted machines",
 )
 def show__machine(args):
     """Show a machine the host is offering for rent."""
@@ -92,7 +92,7 @@ def show__machine(args):
 @parser.command(
     argument("-q", "--quiet", action="store_true", help="only display numeric ids"),
     usage="vastai show machines [OPTIONS]",
-    help="[Host] Show hosted machines",
+    help="Show hosted machines",
 )
 def show__machines(args):
     """Show the machines user is offering for rent."""
@@ -116,7 +116,7 @@ def show__machines(args):
     argument("-i", "--ids", help="comma separated string of machine_ids for which to get maintenance information", type=str),
     argument("-q", "--quiet", action="store_true", help="only display numeric ids of the machines in maintenance"),
     usage="vastai show maints --ids 'machine_id_1[,machine_id_2,...]' [OPTIONS]",
-    help="[Host] Show maintenance information for host machines",
+    help="Show maintenance information for host machines",
 )
 def show__maints(args):
     """Show the maintenance information for the machines."""
@@ -141,7 +141,7 @@ def show__maints(args):
 
 @parser.command(
     usage="vastai show network-disks",
-    help="[Host] Show network disks associated with your account.",
+    help="Show network disks associated with your account.",
     epilog=deindent("""
         Show network disks associated with your account.
     """)
@@ -242,7 +242,7 @@ def list_machine_impl(args, id):
     argument("-v", "--vol_size", help="Size for volume contract offer. Defaults to half of available disk. Set 0 to not create a volume contract offer.", type=int),
     argument("-z", "--vol_price", help="Price for disk on volume contract offer. Defaults to price_disk. Invalid if vol_size is 0.", type=float),
     usage="vastai list machine ID [options]",
-    help="[Host] list a machine for rent",
+    help="list a machine for rent",
     epilog=deindent("""
         Performs the same action as pressing the "LIST" button on the site https://cloud.vast.ai/host/machines.
         On the end date the listing will expire and your machine will unlist. However any existing client jobs will still remain until ended by their owners.
@@ -277,7 +277,7 @@ def list__machine(args):
     argument("-v", "--vol_size", help="Size for volume contract offer. Defaults to half of available disk. Set 0 to not create a volume contract offer.", type=int),
     argument("-z", "--vol_price", help="Price for disk on volume contract offer. Defaults to price_disk. Invalid if vol_size is 0.", type=float),
     usage="vastai list machines IDs [options]",
-    help="[Host] list machines for rent",
+    help="list machines for rent",
     epilog=deindent("""
         This variant can be used to list or update the listings for multiple machines at once with the same args.
         You could extend the end dates of all your machines using a command combo like this:
@@ -296,7 +296,7 @@ def list__machines(args):
 @parser.command(
     argument("id", help="id of machine to unlist", type=int),
     usage="vastai unlist machine <id>",
-    help="[Host] Unlist a listed machine",
+    help="Unlist a listed machine",
 )
 def unlist__machine(args):
     """Remove machine from list of machines for rent."""
@@ -315,7 +315,7 @@ def unlist__machine(args):
 @parser.command(
     argument("id", help="id of machine to delete", type=int),
     usage="vastai delete machine <id>",
-    help="[Host] Delete machine if the machine is not being used by clients. host jobs on their own machines are disregarded and machine is force deleted.",
+    help="Delete machine if the machine is not being used by clients. host jobs on their own machines are disregarded and machine is force deleted.",
 )
 def delete__machine(args):
     """Delete machine if the machine is not being used by clients."""
@@ -334,7 +334,7 @@ def delete__machine(args):
 @parser.command(
     argument("id", help="id of machine to cleanup", type=int),
     usage="vastai cleanup machine ID [options]",
-    help="[Host] Remove all expired storage instances from the machine, freeing up space",
+    help="Remove all expired storage instances from the machine, freeing up space",
     epilog=deindent("""
         Instances expire on their end date. Expired instances still pay storage fees, but can not start.
         Since hosts are still paid storage fees for expired instances, we do not auto delete them.
@@ -362,7 +362,7 @@ def cleanup__machine(args):
 @parser.command(
     argument("IDs", help="ids of machines", type=int, nargs='+'),
     usage="vastai defragment machines IDs ",
-    help="[Host] Defragment machines",
+    help="Defragment machines",
     epilog=deindent("""
         Defragment some of your machines. This will rearrange GPU assignments to try and make more multi-gpu offers available.
     """),
@@ -389,7 +389,7 @@ def defrag__machines(args):
     argument("id", help="id of machine to set min bid price for", type=int),
     argument("--price", help="per gpu min bid price in $/hour", type=float),
     usage="vastai set min_bid id [--price PRICE]",
-    help="[Host] Set the minimum bid/rental price for a machine",
+    help="Set the minimum bid/rental price for a machine",
     epilog=deindent("""
         Change the current min bid price of machine id to PRICE.
     """),
@@ -417,7 +417,7 @@ def set__min_bid(args):
     argument("--image", help="docker container image to launch", type=str),
     argument("--args", nargs=argparse.REMAINDER, help="list of arguments passed to container launch"),
     usage="vastai set defjob id [--api-key API_KEY] [--price_gpu PRICE_GPU] [--price_inetu PRICE_INETU] [--price_inetd PRICE_INETD] [--image IMAGE] [--args ...]",
-    help="[Host] Create default jobs for a machine",
+    help="Create default jobs for a machine",
     epilog=deindent("""
         Performs the same action as creating a background job at https://cloud.vast.ai/host/create.
     """)
@@ -446,7 +446,7 @@ def set__defjob(args):
 @parser.command(
     argument("id", help="id of machine to remove default instance from", type=int),
     usage="vastai remove defjob id",
-    help="[Host] Delete default jobs",
+    help="Delete default jobs",
 )
 def remove__defjob(args):
     """Delete default jobs for a machine."""
@@ -469,7 +469,7 @@ def remove__defjob(args):
     argument("--duration", help="maintenance duration in hours", type=float),
     argument("--maintenance_category", help="(optional) can be one of [power, internet, disk, gpu, software, other]", type=str, default="not provided"),
     usage="vastai schedule maintenance id [--sdate START_DATE --duration DURATION --maintenance_category MAINTENANCE_CATEGORY]",
-    help="[Host] Schedule upcoming maint window",
+    help="Schedule upcoming maint window",
     epilog=deindent("""
         The proper way to perform maintenance on your machine is to wait until all active contracts have expired or the machine is vacant.
         For unplanned or unscheduled maintenance, use this schedule maint command. That will notify the client that you have to take the machine down and that they should save their work.
@@ -504,7 +504,7 @@ def schedule__maint(args):
 @parser.command(
     argument("id", help="id of machine to cancel maintenance(s) for", type=int),
     usage="vastai cancel maint id",
-    help="[Host] Cancel maint window",
+    help="Cancel maint window",
     epilog=deindent("""
         For deleting a machine's scheduled maintenance window(s), use this cancel maint command.
         Example: vastai cancel maint 8207
@@ -535,7 +535,7 @@ def cancel__maint(args):
     argument("mount_point", help="mount path of disk to add", type=str),
     argument("-d", "--disk_id", help="id of network disk to attach to machines in the cluster", type=int, nargs='?'),
     usage="vastai add network-disk MACHINES MOUNT_PATH [options]",
-    help="[Host] Add Network Disk to Physical Cluster.",
+    help="Add Network Disk to Physical Cluster.",
     epilog=deindent("""
         This variant can be used to add a network disk to a physical cluster.
         When you add a network disk for the first time, you just need to specify the machine(s) and mount_path.
@@ -622,7 +622,7 @@ def collect_instance_log_artifacts(client, instance_id):
         "vastai dump-logs <machine_id> [--instance-id INSTANCE_ID] "
         "[--output-dir DIR] [--include-local-host-artifacts]"
     ),
-    help="[Host] Bundle self-test diagnostics for support",
+    help="Bundle self-test diagnostics for support",
     epilog=deindent("""
         Creates a redacted diagnostic tarball containing CLI-visible self-test
         evidence. If --instance-id is provided, the command also pulls container
@@ -704,7 +704,7 @@ def dump_logs(args):
     argument("--support-bundle-dir", help="Directory for failure diagnostic bundles (default: /tmp)", type=str),
     argument("--no-support-bundle", action="store_true", help="Do not create a diagnostic tarball when the self-test fails"),
     usage="vastai self-test machine <machine_id> [--debugging] [--ignore-requirements] [--test-image IMAGE]",
-    help="[Host] Perform a self-test on the specified machine",
+    help="Perform a self-test on the specified machine",
     epilog=deindent("""
         This command tests if a machine meets specific requirements and
         runs a series of tests to ensure it's functioning correctly.

--- a/vastai/cli/commands/metrics.py
+++ b/vastai/cli/commands/metrics.py
@@ -72,7 +72,7 @@ _GPU_LOCATION_FIELDS = (
     argument("--num-gpus", type=str, choices=["all", "1", "2", "4", "8"], default="all",
              help="Filter by machine GPU-count bucket (1x, 2x, 4x, 8x)"),
     usage="vastai metrics gpu [OPTIONS]",
-    help="[Host] Get current GPU market metrics",
+    help="Get current GPU market metrics",
     epilog=deindent("""
         Get current GPU metrics with counts, usage, performance, and pricing.
         For historical metrics, see the `metrics gpu-trends` command.
@@ -119,7 +119,7 @@ def metrics__gpu(args):
     argument("--full", action="store_true", default=False,
              help="Show all data points instead of sampling ~20"),
     usage="vastai metrics gpu-trends [NAME] [OPTIONS]",
-    help="[Host] Get GPU market history",
+    help="Get GPU market history",
     epilog=deindent("""
         Show GPU supply/demand and pricing trends over time. Defaults to RTX 5090, 4090, 3090
         for the last 24 hours. Requires host or admin access.
@@ -225,7 +225,7 @@ def metrics__gpu_trends(args):
     argument("--gpu", type=str, default=None,
              help="Filter by GPU name (comma-separated list). Underscores are accepted in place of spaces."),
     usage="vastai metrics gpu-locations [OPTIONS]",
-    help="[Host] Get GPU location metrics",
+    help="Get GPU location metrics",
     epilog=deindent("""
         Show geographic locations of GPUs on the platform. Filtering is applied
         client-side — the endpoint returns one shared dataset and the CLI narrows

--- a/vastai/cli/commands/storage.py
+++ b/vastai/cli/commands/storage.py
@@ -658,7 +658,7 @@ def show__volumes(args):
     argument("-e", "--end_date", help="contract offer expiration - the available until date (optional, in unix float timestamp or MM/DD/YYYY format), default 3 months", type=str),
     argument("-s", "--size", help="size of disk space allocated to offer in GB, default %(default)s GB", default=15),
     usage="vastai list volume ID [options]",
-    help="[Host] list disk space for rent as a volume on a machine",
+    help="list disk space for rent as a volume on a machine",
     epilog=deindent("""
         Allocates a section of disk on a machine to be used for volumes.
     """),
@@ -689,7 +689,7 @@ def list__volume(args):
     argument("-e", "--end_date", help="contract offer expiration - the available until date (optional, in unix float timestamp or MM/DD/YYYY format), default 3 months", type=str),
     argument("-s", "--size", help="size of disk space allocated to offer in GB, default %(default)s GB", default=15),
     usage="vastai list volume IDs [options]",
-    help="[Host] list disk space for rent as a volume on machines",
+    help="list disk space for rent as a volume on machines",
     epilog=deindent("""
         Allocates a section of disk on machines to be used for volumes.
     """),
@@ -719,7 +719,7 @@ def list__volumes(args):
     argument("-e", "--end_date", help="contract offer expiration - the available until date (optional, in unix float timestamp or MM/DD/YYYY format), default 1 month", type=str, default=None),
     argument("-s", "--size", help="size of disk space allocated to offer in GB, default %(default)s GB", default=15, type=int),
     usage="vastai list network volume DISK_ID [options]",
-    help="[Host] list disk space for rent as a network volume",
+    help="list disk space for rent as a network volume",
 )
 def list__network_volume(args):
     """List disk space for rent as a network volume."""
@@ -742,7 +742,7 @@ def list__network_volume(args):
 @parser.command(
     argument("id", help="volume ID you want to unlist", type=int),
     usage="vastai unlist volume ID",
-    help="[Host] unlist volume offer",
+    help="unlist volume offer",
 )
 def unlist__volume(args):
     """Unlist a volume offer."""
@@ -760,7 +760,7 @@ def unlist__volume(args):
 @parser.command(
     argument("id", help="id of network volume offer to unlist", type=int),
     usage="vastai unlist network volume OFFER_ID",
-    help="[Host] Unlists network volume offer",
+    help="Unlists network volume offer",
 )
 def unlist__network_volume(args):
     """Unlist a network volume offer."""

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -4,10 +4,13 @@ import os
 import json
 import requests
 
-from vastai.cli.parser import apwrap, argument, MyWideHelpFormatter, set_completers
+from vastai.cli.parser import (
+    apwrap, argument, MyWideHelpFormatter, set_completers,
+    HOST_COMMAND_CLIENT_HINTS,
+)
 from vastai.cli.util import (
     APIKEY_FILE, TFAKEY_FILE, VERSION, server_url_default, api_key_guard,
-    format_key_suffix,
+    format_key_suffix, get_role, is_client_view,
 )
 
 try:
@@ -44,6 +47,18 @@ def _emit_error(args, status_code, message):
                 "For SMS or email, first run 'vastai tfa send-sms' or 'vastai tfa send-email' to get <SECRET>.",
                 file=sys.stderr,
             )
+            return
+
+        sp = getattr(getattr(args, "func", None), "mysignature", None)
+        if sp is not None and getattr(sp, "host_only", False) and is_client_view(get_role()):
+            command_name = getattr(sp, "command_name", "this command")
+            hint = HOST_COMMAND_CLIENT_HINTS.get(command_name)
+            print(file=sys.stderr)
+            if hint:
+                print(f"'{command_name}' is a host-only command — did you mean 'vastai {hint}'?", file=sys.stderr)
+            else:
+                print(f"'{command_name}' is a host-only command. Renting compute? Run 'vastai --help' for client commands.", file=sys.stderr)
+            print("(Hosting on Vast? Run 'vastai set role host' to enable host commands.)", file=sys.stderr)
             return
 
         env = os.environ.get("VAST_API_KEY")
@@ -121,7 +136,8 @@ def main():
             def _command_maps(self):
                 cached = getattr(self, "_cmd_maps", None)
                 if cached is None:
-                    cached = self._cmd_maps = build_command_maps(self._parser)
+                    from vastai.cli.util import get_role
+                    cached = self._cmd_maps = build_command_maps(self._parser, role=get_role())
                 return cached
 
             def _get_completions(self, comp_words, cword_prefix, cword_prequote, last_wordbreak_pos):

--- a/vastai/cli/parser.py
+++ b/vastai/cli/parser.py
@@ -11,6 +11,8 @@ import sys
 import argparse
 from pathlib import Path
 
+from vastai.cli.util import get_role, is_client_view
+
 
 # ---------------------------------------------------------------------------
 # Tab-completion helpers
@@ -46,12 +48,21 @@ def complete_sshkeys(prefix=None, action=None, parser=None, parsed_args=None):
 # into staged completion. The argcomplete adapter in cli/main.py calls them.
 # ---------------------------------------------------------------------------
 
-def build_command_maps(parser):
-    """Derive (verbs, verb_objs, singles) from a parser's subparser names."""
+def build_command_maps(parser, role=None):
+    """Derive (verbs, verb_objs, singles) from a parser's subparser names.
+
+    ``role``: host-only commands are left out of completion unless ``role``
+    is explicitly ``'host'`` (see ``vastai.cli.util.is_client_view``) — client
+    is the default, matching the client --help view (CLN-3582). Display-only,
+    never affects execution.
+    """
     names = []
     for action in parser._actions:
         if isinstance(action, argparse._SubParsersAction):
-            names = list(action.choices.keys())
+            for name, sp in action.choices.items():
+                if is_client_view(role) and getattr(sp, 'host_only', False):
+                    continue
+                names.append(name)
             break
     verbs, verb_objs, singles = set(), {}, set()
     for name in names:
@@ -156,10 +167,71 @@ COMMAND_OVERRIDES = {
     'reports':       'Host machines',
 }
 
+# ---------------------------------------------------------------------------
+# Host-only command classification (CLN-3582)
+#
+# A command is either host-only or not — there's no third state. The client
+# CLI view hides host-only commands from --help, tab completion, and error
+# hints; everything else stays visible to everyone. Unclassified commands
+# default to visible (not host-only), so a module nobody's flagged yet just
+# shows up everywhere rather than needing an entry to "opt in" to visibility.
+# This is a display classification only — it never affects whether a command
+# executes.
+# ---------------------------------------------------------------------------
+
+# Modules where every command is host-only.
+HOST_ONLY_MODULES = {
+    'vastai.cli.commands.machines',
+    'vastai.cli.commands.metrics',
+}
+
+# Individual host-only commands in modules that are mostly client-facing.
+# Keyed by the registered "verb object" (or bare verb) name, same shape as
+# COMMAND_OVERRIDES above.
+HOST_ONLY_COMMANDS = {
+    'reports',                # misc.py: machine reports, not instance logs
+    'show earnings',          # billing.py: machine earning history
+    'list network-volume',    # storage.py: list disk space for rent
+    'list volume',
+    'list volumes',
+    'unlist network-volume',
+    'unlist volume',
+}
+
+
+def is_host_only_command(name, module, explicit=None):
+    """Whether a registered command should be hidden from the client CLI view.
+
+    Priority: explicit ``host_only=`` kwarg on the decorator > per-command
+    override > per-module default. Defaults to ``False`` (visible) so an
+    unclassified module or an ad-hoc parser built outside the real command
+    modules (as tests do) never has commands silently disappear.
+    """
+    if explicit is not None:
+        return bool(explicit)
+    if name in HOST_ONLY_COMMANDS:
+        return True
+    return module in HOST_ONLY_MODULES
+
+
 GROUP_ORDER = [
     'Search', 'Instances', 'Host machines', 'Teams', 'Auth & keys',
     'Billing & account', 'Serverless', 'Metrics', 'Storage volumes', 'Other',
 ]
+
+# Well-known client equivalents for commonly-confused host commands. Used to
+# build the "did you mean" 401 hint on the client CLI role — e.g. a renter
+# running 'show machines' (a host command) when they meant 'show instances'.
+# Not exhaustive; commands without an entry get a generic hint instead. See
+# main.py's _emit_error and CLN-3582.
+HOST_COMMAND_CLIENT_HINTS = {
+    'show machine':  'show instances',
+    'show machines': 'show instances',
+    'list machine':  'create instance',
+    'list machines': 'create instance',
+    'show maints':   'show instances',
+    'set min-bid':   'change bid',
+}
 
 
 class GroupedArgumentParser(argparse.ArgumentParser):
@@ -187,8 +259,12 @@ class GroupedArgumentParser(argparse.ArgumentParser):
             formatter.add_arguments(non_sub_actions)
             formatter.end_section()
 
-        self._add_grouped_commands(formatter, sub_action)
+        hidden_count = self._add_grouped_commands(formatter, sub_action)
         formatter.add_text(self.epilog)
+        if hidden_count:
+            formatter.add_text(
+                "Hosting on Vast? Run 'vastai set role host' to show host commands."
+            )
         return formatter.format_help()
 
     def _subparsers_action(self):
@@ -198,10 +274,16 @@ class GroupedArgumentParser(argparse.ArgumentParser):
         return None
 
     def _add_grouped_commands(self, formatter, sub_action):
+        """Render grouped commands; returns the count hidden by the client role view."""
+        role = get_role()
         grouped = {}
+        hidden_count = 0
         for pseudo in sub_action._choices_actions:
             sp = sub_action.choices.get(pseudo.dest)
             if sp is None:
+                continue
+            if is_client_view(role) and getattr(sp, 'host_only', False):
+                hidden_count += 1
                 continue
             label = COMMAND_OVERRIDES.get(pseudo.dest)
             if label is None:
@@ -223,6 +305,8 @@ class GroupedArgumentParser(argparse.ArgumentParser):
             formatter.start_section(label)
             formatter.add_arguments(actions)
             formatter.end_section()
+
+        return hidden_count
 
 
 # ---------------------------------------------------------------------------
@@ -284,7 +368,7 @@ class apwrap(object):
             name = verb
         return name
 
-    def command(self, *arguments, aliases=(), help=None, **kwargs):
+    def command(self, *arguments, aliases=(), help=None, host_only=None, **kwargs):
         help_ = help
         if not self.added_help_cmd:
             self.added_help_cmd = True
@@ -304,7 +388,14 @@ class apwrap(object):
             if "formatter_class" not in kwargs:
                 kwargs["formatter_class"] = MyWideHelpFormatter
 
-            sp = self.subparsers().add_parser(name, aliases=aliases_transformed, help=help_, **kwargs)
+            is_host_only = is_host_only_command(name, func.__module__, explicit=host_only)
+            display_help = help_
+            if is_host_only and display_help and not display_help.startswith('[Host]'):
+                display_help = f'[Host] {display_help}'
+
+            sp = self.subparsers().add_parser(name, aliases=aliases_transformed, help=display_help, **kwargs)
+            sp.host_only = is_host_only
+            sp.command_name = name
 
             # TODO: Sometimes the parser.command has a help parameter. Ideally
             # I'd extract this during the sdk phase but for the life of me

--- a/vastai/cli/util.py
+++ b/vastai/cli/util.py
@@ -191,6 +191,59 @@ def format_key_suffix(k):
 
 
 # ---------------------------------------------------------------------------
+# Client / host CLI role (CLN-3582)
+#
+# Purely a display preference — it only affects which commands --help, tab
+# completion, and error hints show. It is never used to gate execution: a
+# host command still runs for anyone who types it, since the server enforces
+# real permissions. Client is the default: host-only commands show only once
+# the role is explicitly resolved to 'host' (via `set role host` or, in the
+# full CLN-3582 rollout, auto-detection) — an unset or unrecognized role
+# means "assume client", not "show everything".
+# ---------------------------------------------------------------------------
+
+ROLE_FILE = os.path.join(DIRS['config'], "vast_role")
+ROLE_CLIENT = "client"
+ROLE_HOST = "host"
+VALID_ROLES = {ROLE_CLIENT, ROLE_HOST}
+
+
+def get_role():
+    """Return the stored CLI role ('client' or 'host'), or None if unset/unrecognized.
+
+    Returns ``None`` — never raises — when ``ROLE_FILE`` is missing or holds
+    anything else. Callers should treat ``None`` the same as ``'client'``
+    (see :func:`is_client_view`) rather than checking it separately.
+    """
+    try:
+        with open(ROLE_FILE) as f:
+            role = f.read().strip().lower()
+    except OSError:
+        return None
+    return role if role in VALID_ROLES else None
+
+
+def is_client_view(role):
+    """Whether ``role`` (as returned by :func:`get_role`) means "show the client view".
+
+    Client is the default: everything except an explicit ``'host'`` counts
+    as client, including ``None`` (unset) and any unrecognized value.
+    """
+    return role != ROLE_HOST
+
+
+def set_role_file(role):
+    """Persist ``role`` ('client' or 'host') to ``ROLE_FILE``.
+
+    Raises ValueError for anything else — callers pass user/API-derived input.
+    """
+    if role not in VALID_ROLES:
+        raise ValueError(f"role must be one of {sorted(VALID_ROLES)}, got {role!r}")
+    with open(ROLE_FILE, "w") as f:
+        f.write(role)
+
+
+# ---------------------------------------------------------------------------
 # Simple utility class
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Classifies every CLI command as host-only or not (`is_host_only_command()` in `vastai/cli/parser.py`), replacing the 26 hand-written `[Host]` help-text prefixes with an auto-rendered one derived from the classification.
- Adds a stored client/host role (`~/.config/vastai/vast_role`) that filters `--help`, tab completion, and error hints — display-only, never gates execution; the server remains the real permission enforcement layer.
- **Client is the default.** Host-only commands only show once the role is explicitly resolved to `host` (`vastai set role host`, or auto-detection in the follow-up PR). An unset or unrecognized role is treated as client, not "show everything" — this is what actually makes fresh installs show the filtered view without requiring the auto-detection in #463.
- `vastai set role host|client` to manually set/override the role.
- A client-role user hitting a `machine_read`-style 401 on a host command gets a "did you mean" hint (e.g. `show machines` → `show instances`).

Auto-detecting the role from an existing API key (rather than requiring `set role` to be run manually) is split into a follow-up stacked PR: #463.

## Test plan
- [x] `poetry run pytest tests/cli` — 397 passed
- [x] Manually verified: a completely fresh install (no role file, no key) shows the filtered client view by default; `set role host`/`set role client` toggle correctly; the 401 hint fires even with an unset role
- [x] Confirmed pre-existing failures in `test_tar_utils.py`/`test_search.py` are unrelated (present on `master` too)

CLN-3582