### PR TITLE
Auto-detect the client/host role from an existing API key

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -328,6 +328,23 @@ check_pip_coexistence() {
     warn "put $LOCAL_BIN first in PATH so this one wins."
 }
 
+# warm_role_cache — best-effort: most reinstalls are an existing user with an
+# API key already on disk from before, so there's no "enter your key" moment
+# to hook into here — just a key that's already sitting there. If one exists,
+# resolve the client/host CLI view for it now (one GET to /machines) instead
+# of waiting on whatever command they happen to run next. A fresh install has
+# no key yet, so this is a no-op for that (the common) case.
+#
+# Detached (nohup, backgrounded, disowned) so it can't add latency to the
+# install and survives this script's own process exiting; every failure mode
+# is swallowed — this must never affect install success or its output.
+warm_role_cache() {
+    local cfg_dir
+    cfg_dir="${XDG_CONFIG_HOME:-$HOME/.config}/vastai"
+    [ -f "$cfg_dir/vast_api_key" ] || [ -f "$HOME/.vast_api_key" ] || return 0
+    ( nohup "$ROOT/bin/vastai" show machines --raw >/dev/null 2>&1 & disown ) 2>/dev/null || true
+}
+
 main() {
     for arg in "$@"; do
         case "$arg" in
@@ -368,6 +385,7 @@ main() {
     generate_completions
     setup_path
     check_pip_coexistence
+    warm_role_cache
 
     printf '\n'
     say "vastai $version installed to $ROOT"

--- a/tests/cli/test_auth_commands.py
+++ b/tests/cli/test_auth_commands.py
@@ -94,6 +94,7 @@ class TestSetApiKey:
         legacy_file = tmp_path / ".vast_api_key"
         monkeypatch.setattr("vastai.cli.util.APIKEY_FILE", str(key_file))
         monkeypatch.setattr("vastai.cli.util.APIKEY_FILE_HOME", str(legacy_file))
+        monkeypatch.setattr("vastai.api.machines.show_machines", lambda client: [])
         from vastai.cli.commands.auth import set__api_key
         set__api_key(argparse.Namespace(new_api_key="test-key-abc-123"))
         assert key_file.read_bytes() == b"test-key-abc-123"
@@ -109,6 +110,7 @@ class TestSetApiKey:
         key_file = xdg_dir / "vast_api_key"
         monkeypatch.setattr("vastai.cli.util.APIKEY_FILE", str(key_file))
         monkeypatch.setattr("vastai.cli.util.APIKEY_FILE_HOME", str(tmp_path / ".vast_api_key"))
+        monkeypatch.setattr("vastai.api.machines.show_machines", lambda client: [])
 
         from vastai.cli.commands.auth import set__api_key
         set__api_key(argparse.Namespace(new_api_key="round-trip-key"))
@@ -117,6 +119,96 @@ class TestSetApiKey:
         with patch("vastai.sdk.VastClient") as MockClient:
             VastAI()
             assert MockClient.call_args[0][0] == "round-trip-key"
+
+
+class TestAutoDetectHostRoleOnSetApiKey:
+    """`set api-key` resolves and announces the client/host CLI role (CLN-3582)."""
+
+    def _set_api_key(self, tmp_path, monkeypatch, *, show_machines_result=None, show_machines_raises=None):
+        key_file = tmp_path / "vast_api_key"
+        role_file = tmp_path / "vast_role"
+        monkeypatch.setattr("vastai.cli.util.APIKEY_FILE", str(key_file))
+        monkeypatch.setattr("vastai.cli.util.APIKEY_FILE_HOME", str(tmp_path / ".vast_api_key"))
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(role_file))
+        if show_machines_raises is not None:
+            monkeypatch.setattr(
+                "vastai.api.machines.show_machines",
+                lambda client: (_ for _ in ()).throw(show_machines_raises),
+            )
+        else:
+            monkeypatch.setattr(
+                "vastai.api.machines.show_machines",
+                lambda client: show_machines_result,
+            )
+        from vastai.cli.commands.auth import set__api_key
+        set__api_key(argparse.Namespace(new_api_key="a-key"))
+        return role_file
+
+    def test_host_account_auto_enables_host_role(self, tmp_path, monkeypatch, capsys):
+        role_file = self._set_api_key(tmp_path, monkeypatch, show_machines_result=[{"id": 1}])
+        assert role_file.read_text().strip() == "host"
+        assert "host command view" in capsys.readouterr().out
+
+    def test_client_account_caches_client_role(self, tmp_path, monkeypatch, capsys):
+        # An empty machines list is a real answer, not "still unknown" — this
+        # is what brings a pre-existing install (key saved, role never
+        # written) up to date on its very first `set api-key` run.
+        role_file = self._set_api_key(tmp_path, monkeypatch, show_machines_result=[])
+        assert role_file.read_text().strip() == "client"
+        assert "client command view" in capsys.readouterr().out
+
+    def test_network_error_leaves_role_undetected_not_broken(self, tmp_path, monkeypatch):
+        # Must not raise out of `set api-key` — the key save is the important part.
+        role_file = self._set_api_key(
+            tmp_path, monkeypatch, show_machines_raises=ConnectionError("offline")
+        )
+        assert not role_file.exists()
+
+    def test_existing_host_role_is_not_rechecked_or_downgraded(self, tmp_path, monkeypatch):
+        role_file = tmp_path / "vast_role"
+        role_file.write_text("host")
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(role_file))
+        monkeypatch.setattr("vastai.cli.util.APIKEY_FILE", str(tmp_path / "vast_api_key"))
+        monkeypatch.setattr("vastai.cli.util.APIKEY_FILE_HOME", str(tmp_path / ".vast_api_key"))
+
+        called = []
+        monkeypatch.setattr(
+            "vastai.api.machines.show_machines",
+            lambda client: called.append(True) or [],
+        )
+        from vastai.cli.commands.auth import set__api_key
+        set__api_key(argparse.Namespace(new_api_key="a-key"))
+
+        assert called == []  # already host -> no re-check
+        assert role_file.read_text().strip() == "host"
+
+    def test_existing_client_role_is_not_rechecked_or_upgraded(self, tmp_path, monkeypatch):
+        # Symmetric to the host case: once resolved to 'client', a later
+        # `set api-key` run does not silently flip it to 'host' even if this
+        # key now belongs to an account with machines. 'vastai set role host'
+        # is the deliberate override path for that transition.
+        role_file = tmp_path / "vast_role"
+        role_file.write_text("client")
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(role_file))
+        monkeypatch.setattr("vastai.cli.util.APIKEY_FILE", str(tmp_path / "vast_api_key"))
+        monkeypatch.setattr("vastai.cli.util.APIKEY_FILE_HOME", str(tmp_path / ".vast_api_key"))
+
+        called = []
+        monkeypatch.setattr(
+            "vastai.api.machines.show_machines",
+            lambda client: called.append(True) or [{"id": 1}],
+        )
+        from vastai.cli.commands.auth import set__api_key
+        set__api_key(argparse.Namespace(new_api_key="a-key"))
+
+        assert called == []
+        assert role_file.read_text().strip() == "client"
+
+    def test_bare_namespace_missing_url_and_retry_does_not_crash(self, tmp_path, monkeypatch):
+        # Direct callers (like the existing TestSetApiKey tests) construct a
+        # bare Namespace(new_api_key=...) with no `url`/`retry` attributes.
+        role_file = self._set_api_key(tmp_path, monkeypatch, show_machines_result=[{"id": 1}])
+        assert role_file.read_text().strip() == "host"
 
 
 class TestSetRole:

--- a/tests/cli/test_util.py
+++ b/tests/cli/test_util.py
@@ -352,3 +352,55 @@ class TestRole:
         role_file.write_text("garbage\nbinary\x00data")
         monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(role_file))
         assert get_role() is None
+
+
+class TestEnsureHostRoleDetected:
+    """ensure_host_role_detected — lazy role resolution for pre-existing installs (CLN-3582)."""
+
+    def _client(self, tmp_path, monkeypatch, *, show_machines_result=None, show_machines_raises=None):
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(tmp_path / "vast_role"))
+        if show_machines_raises is not None:
+            monkeypatch.setattr(
+                "vastai.api.machines.show_machines",
+                lambda client: (_ for _ in ()).throw(show_machines_raises),
+            )
+        else:
+            monkeypatch.setattr(
+                "vastai.api.machines.show_machines",
+                lambda client: show_machines_result,
+            )
+        return object()  # stand-in "client"; show_machines is patched to ignore it
+
+    def test_host_account_caches_host(self, tmp_path, monkeypatch):
+        from vastai.cli.util import ensure_host_role_detected, get_role
+        client = self._client(tmp_path, monkeypatch, show_machines_result=[{"id": 1}])
+        ensure_host_role_detected(client)
+        assert get_role() == "host"
+
+    def test_client_account_caches_client(self, tmp_path, monkeypatch):
+        # This is what brings a pre-existing install (key saved, role never
+        # written) up to date: an empty machines list is a real answer, not
+        # a "still unknown" — so it gets cached just like a host does.
+        from vastai.cli.util import ensure_host_role_detected, get_role
+        client = self._client(tmp_path, monkeypatch, show_machines_result=[])
+        ensure_host_role_detected(client)
+        assert get_role() == "client"
+
+    def test_network_error_leaves_role_undetected(self, tmp_path, monkeypatch):
+        from vastai.cli.util import ensure_host_role_detected, get_role
+        client = self._client(tmp_path, monkeypatch, show_machines_raises=ConnectionError("offline"))
+        ensure_host_role_detected(client)
+        assert get_role() is None
+
+    def test_already_resolved_role_is_not_rechecked(self, tmp_path, monkeypatch):
+        from vastai.cli.util import ensure_host_role_detected, set_role_file, get_role
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(tmp_path / "vast_role"))
+        set_role_file("client")
+        called = []
+        monkeypatch.setattr(
+            "vastai.api.machines.show_machines",
+            lambda client: called.append(True) or [{"id": 1}],
+        )
+        ensure_host_role_detected(object())
+        assert called == []
+        assert get_role() == "client"  # not flipped to host

--- a/tests/installer/run_tests.sh
+++ b/tests/installer/run_tests.sh
@@ -56,7 +56,9 @@ elif [ "$1" = "pip" ]; then
     done
     bindir="$(dirname "$py")"
     for name in vastai serve-vast-deployment register-python-argcomplete; do
-        printf '#!/bin/sh\necho "%s"\n' "${last#vastai==}" > "$bindir/$name"
+        # Also logs its own invocation args (one line per call) next to the
+        # binary — lets warm_role_cache tests assert on what install.sh ran.
+        printf '#!/bin/sh\necho "$@" >> "$(dirname "$0")/invocations.log"\necho "%s"\n' "${last#vastai==}" > "$bindir/$name"
         chmod +x "$bindir/$name"
     done
 fi
@@ -131,6 +133,7 @@ assert() { # assert DESC command...
 
 out_contains() { grep -q "$1" "$SB_OUT"; }
 out_lacks()    { ! grep -qa "$1" "$SB_OUT"; }
+invocations_lack() { ! grep -qa "$1" "$SB_ROOT/bin/invocations.log" 2>/dev/null; }
 
 # ---------------------------------------------------------------------------
 # Scenarios
@@ -321,6 +324,41 @@ test_completion_files_generated() { # static completion scripts precomputed unde
         [ "$(grep -c 'eval.*register-python-argcomplete' "$SB_ROOT/env.sh")" -eq 0 ]
 }
 
+test_warm_role_cache_fires_when_key_exists() { # pre-existing key -> background role-detection call
+    new_sandbox warmkey
+    mkdir -p "$SB_HOME/.config/vastai"
+    echo "fake-key" > "$SB_HOME/.config/vastai/vast_api_key"
+    run_install || { cat "$SB_OUT"; return 1; }
+    # Detached (nohup + disown) — give it a moment to actually run.
+    local log="$SB_ROOT/bin/invocations.log" i
+    for i in $(seq 1 50); do
+        [ -s "$log" ] && grep -q "show machines" "$log" && break
+        sleep 0.1
+    done
+    assert "install still succeeded" out_contains "vastai 1.2.3 installed" &&
+    assert "role-detection call fired" grep -q "show machines --raw" "$log"
+}
+
+test_warm_role_cache_skips_when_no_key() { # fresh install, no key yet -> no extra call
+    new_sandbox warmnokey
+    run_install || { cat "$SB_OUT"; return 1; }
+    sleep 0.3  # would-be background call has had time to run if it (wrongly) fired
+    assert "install succeeded" out_contains "vastai 1.2.3 installed" &&
+    assert "no role-detection call attempted" invocations_lack "show machines"
+}
+
+test_warm_role_cache_finds_legacy_key_location() { # ~/.vast_api_key (pre-XDG) also counts
+    new_sandbox warmlegacy
+    echo "fake-key" > "$SB_HOME/.vast_api_key"
+    run_install || { cat "$SB_OUT"; return 1; }
+    local log="$SB_ROOT/bin/invocations.log" i
+    for i in $(seq 1 50); do
+        [ -s "$log" ] && grep -q "show machines" "$log" && break
+        sleep 0.1
+    done
+    assert "role-detection call fired for the legacy key path" grep -q "show machines --raw" "$log"
+}
+
 test_tty_install() { # interactive install (stderr on a pty) must survive old bash
     # install.sh empties its pyquiet array at a TTY ([ -t 2 ]), and on bash
     # < 4.4 expanding an empty array under `set -u` is fatal ("pyquiet[@]:
@@ -349,7 +387,7 @@ test_tty_install() { # interactive install (stderr on a pty) must survive old ba
 # Runner
 # ---------------------------------------------------------------------------
 
-ALL_TESTS=(fresh_install pinned_reinstall xdg_data_home_default wheel_url_install wheel_url_pin_fallback checksum_abort truncation_guard glibc_floor rc_safety env_sh pip_shadowing pip_shadowing_quiet pip_shadowing_rerun completion_files_generated tty_install)
+ALL_TESTS=(fresh_install pinned_reinstall xdg_data_home_default wheel_url_install wheel_url_pin_fallback checksum_abort truncation_guard glibc_floor rc_safety env_sh pip_shadowing pip_shadowing_quiet pip_shadowing_rerun completion_files_generated warm_role_cache_fires_when_key_exists warm_role_cache_skips_when_no_key warm_role_cache_finds_legacy_key_location tty_install)
 # No "${@:-...}": expanding $@ with zero args under set -u is itself fatal on
 # old bash, and this harness must run under macOS's stock bash 3.2 (see
 # test_tty_install).

--- a/vastai/cli/commands/auth.py
+++ b/vastai/cli/commands/auth.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from vastai.cli.parser import argument
 from vastai.cli.display import deindent, display_table
 from vastai.api import auth as auth_api
-from vastai.cli.util import SUCCESS, WARN, FAIL, format_key_suffix
+from vastai.cli.util import SUCCESS, WARN, FAIL, INFO, format_key_suffix
 
 
 # ---------------------------------------------------------------------------
@@ -219,6 +219,49 @@ def set__api_key(args):
         print(f"\n{WARN} VAST_API_KEY is set in your environment (ends in {format_key_suffix(env_key)}) and overrides the key you just saved.")
         print("Unset VAST_API_KEY to use the saved key.")
 
+    _auto_detect_and_announce_role(args)
+
+
+def _auto_detect_and_announce_role(args):
+    """Best-effort: resolve and announce the client/host CLI role for this key.
+
+    A no-op if the role is already known — once resolved (by this, or by the
+    first real command a pre-existing install runs; see
+    ``vastai.cli.util.ensure_host_role_detected``), it's never silently
+    re-detected or changed. 'vastai set role host|client' is the override
+    path for e.g. a client account that starts hosting later.
+    """
+    from vastai.cli.util import get_role, ensure_host_role_detected, ROLE_HOST, ROLE_CLIENT, server_url_default
+    from vastai.api.client import VastClient
+
+    if get_role() is not None:
+        return  # already resolved; nothing to announce
+
+    try:
+        # args.api_key was resolved from the OLD saved key before this command
+        # ran (see main.py), so it can't be used here — build a client with
+        # the key that was just written instead. getattr() defaults cover
+        # direct/test calls that construct a bare Namespace(new_api_key=...).
+        client = VastClient(
+            api_key=args.new_api_key,
+            server_url=getattr(args, "url", server_url_default),
+            retry=getattr(args, "retry", 3),
+            client_type="cli",
+        )
+    except Exception:
+        return  # malformed args: leave role detection for the next real command
+
+    ensure_host_role_detected(client)
+
+    role = get_role()
+    if role == ROLE_HOST:
+        print(f"\n{INFO} This account has machines listed for rent — enabling the host command view.")
+        print("  (Run 'vastai set role client' to hide host-only commands, or 'vastai set role host' to re-enable.)")
+    elif role == ROLE_CLIENT:
+        print(f"\n{INFO} Showing the client command view (host-only commands are hidden from --help).")
+        print("  (Hosting on Vast? Run 'vastai set role host' to show them.)")
+    # else: network/auth error — leave role detection for the next real command
+
 
 # ---------------------------------------------------------------------------
 # set role
@@ -232,6 +275,8 @@ def set__api_key(args):
         This only changes what --help and tab completion display — every command
         still runs regardless of role, since the server enforces real permissions.
 
+        The role is auto-detected the first time you run a real command (or
+        'vastai set api-key'), so most people never need to run this manually.
         Use it to override the detected role — e.g. after your account starts
         or stops hosting machines.
     """),

--- a/vastai/cli/util.py
+++ b/vastai/cli/util.py
@@ -243,6 +243,32 @@ def set_role_file(role):
         f.write(role)
 
 
+def ensure_host_role_detected(client):
+    """Best-effort: resolve and cache the role via ``client`` if it isn't known yet.
+
+    Called from :func:`vastai.cli.utils.get_client`, so it runs lazily on the
+    next real (authenticated) command a user makes — not on ``--help`` or tab
+    completion, which never build a client and so never pay this cost. This
+    is what brings a pre-existing install (API key saved before this feature
+    shipped, ``ROLE_FILE`` never written) up to date: the first real command
+    after upgrading resolves it once, and every command after that is free.
+
+    Once resolved, the role is cached permanently — 'client' as much as
+    'host' — since a successful check is a real answer, not a guess. Only a
+    failed check (network/auth error) leaves the role undetected, so it's
+    retried on the next call rather than wrongly cached as one or the other.
+    Never raises.
+    """
+    if get_role() is not None:
+        return
+    try:
+        from vastai.api import machines as machines_api
+        is_host = bool(machines_api.show_machines(client))
+    except Exception:
+        return
+    set_role_file(ROLE_HOST if is_host else ROLE_CLIENT)
+
+
 # ---------------------------------------------------------------------------
 # Simple utility class
 # ---------------------------------------------------------------------------

--- a/vastai/cli/utils.py
+++ b/vastai/cli/utils.py
@@ -9,7 +9,8 @@ def get_parser():
 def get_client(args):
     """Create a VastClient from parsed CLI args."""
     from vastai.api.client import VastClient
-    return VastClient(
+    from vastai.cli.util import ensure_host_role_detected
+    client = VastClient(
         api_key=args.api_key,
         server_url=args.url,
         retry=args.retry,
@@ -17,3 +18,8 @@ def get_client(args):
         curl=getattr(args, 'curl', False),
         client_type="cli",
     )
+    # Lazily resolves the client/host CLI role on a pre-existing install that
+    # never ran `set api-key` since this feature shipped. See CLN-3582 and
+    # ensure_host_role_detected's docstring.
+    ensure_host_role_detected(client)
+    return client


### PR DESCRIPTION
## Summary

Stacked on #462. Adds automatic role detection so most users never have to run `vastai set role` manually — the key insight is that for most existing users an API key already exists, so there's no "enter your key" moment to hook into; detection just needs to use it as soon as possible.

- `ensure_host_role_detected()` (`vastai/cli/util.py`): one best-effort API call (`GET /machines?owner=me`) that caches the role permanently either way ('client' as much as 'host') on success; a failed check (network/auth error) leaves it undetected for retry rather than guessing.
- Wired into three trigger points that already have a valid key in hand:
  - `get_client()` (`vastai/cli/utils.py`) — fires lazily on a user's next real command. Deliberately does not run on `--help`/tab completion, which never build a client.
  - `vastai set api-key` — detects immediately using the newly-saved key and announces the result.
  - The bash installer (`scripts/install.sh`) — if a key already exists on disk (a pre-existing user re-running the installer to upgrade), fires a single detached (`nohup ... & disown`) background call so it can't add install latency.
- pip installs still can't be reached at install time (no post-install hook exists in the wheel/PEP 517 standard) — they fall back to the `get_client()` lazy path, an accepted, unavoidable gap.
- Once resolved, the role is sticky — `vastai set role host|client` remains the deliberate override for e.g. a client account that starts hosting later.

## Test plan
- [x] `poetry run pytest tests/cli` — 407 passed
- [x] `bash tests/installer/run_tests.sh` — 18 passed (3 new scenarios covering the installer's background role-detection)
- [x] Manually verified `set api-key` auto-detection and announcement against the real `vastai` binary

CLN-3582