### PR TITLE
fix(cli): restore 404 expired-2FA-session fallback (CLN-3555)

### DIFF
--- a/tests/cli/test_main_error_handling.py
+++ b/tests/cli/test_main_error_handling.py
@@ -1,0 +1,113 @@
+"""Tests for the 2FA session-expiry retry logic in vastai/cli/main.py (CLN-3555)."""
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import pytest
+from requests.exceptions import HTTPError
+
+from vastai.cli.main import _is_tfa_session_expired, run_command
+
+
+def _http_error(status_code, msg):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = {"msg": msg}
+    return HTTPError(response=resp)
+
+
+def _args(*, raw=False, func):
+    return argparse.Namespace(raw=raw, func=func)
+
+
+class TestIsTfaSessionExpired:
+    def test_401_invalid_user_key_is_expired(self):
+        assert _is_tfa_session_expired(401, "Invalid user key") is True
+
+    def test_404_session_expired_message_is_expired(self):
+        assert _is_tfa_session_expired(404, "Session expired. Please log in again.") is True
+
+    def test_401_with_other_message_is_not_expired(self):
+        assert _is_tfa_session_expired(401, "Please log in or sign up") is False
+
+    def test_404_with_other_message_is_not_expired(self):
+        assert _is_tfa_session_expired(404, "Not found") is False
+
+    def test_other_status_codes_are_not_expired(self):
+        assert _is_tfa_session_expired(500, "Session expired. Please log in again.") is False
+
+
+class TestRunCommandSessionExpiredRetry:
+    def test_404_session_expired_falls_back_to_api_key_and_retries(self, tmp_path, capsys):
+        tfa_file = tmp_path / "vast_tfa_key"
+        api_file = tmp_path / "vast_api_key"
+        tfa_file.write_text("stale-tfa-key")
+        api_file.write_text("normal-api-key")
+
+        func = MagicMock(side_effect=[_http_error(404, "Session expired. Please log in again."), 0])
+        args = _args(func=func)
+
+        with patch("vastai.cli.main.TFAKEY_FILE", str(tfa_file)), \
+             patch("vastai.cli.main.APIKEY_FILE", str(api_file)):
+            with pytest.raises(SystemExit) as exc_info:
+                run_command(args)
+
+        assert exc_info.value.code == 0
+        assert func.call_count == 2
+        assert args.api_key == "normal-api-key"
+        assert not tfa_file.exists()
+
+        err = capsys.readouterr().out
+        assert "Your 2FA session has expired." in err
+        assert "Trying again with your normal API Key" in err
+        assert "vastai tfa login" in err
+
+    def test_401_invalid_user_key_falls_back_same_as_404(self, tmp_path):
+        tfa_file = tmp_path / "vast_tfa_key"
+        api_file = tmp_path / "vast_api_key"
+        tfa_file.write_text("stale-tfa-key")
+        api_file.write_text("normal-api-key")
+
+        func = MagicMock(side_effect=[_http_error(401, "Invalid user key"), 0])
+        args = _args(func=func)
+
+        with patch("vastai.cli.main.TFAKEY_FILE", str(tfa_file)), \
+             patch("vastai.cli.main.APIKEY_FILE", str(api_file)):
+            with pytest.raises(SystemExit):
+                run_command(args)
+
+        assert func.call_count == 2
+        assert args.api_key == "normal-api-key"
+
+    def test_no_fallback_api_key_tells_user_to_run_tfa_login(self, tmp_path, capsys):
+        tfa_file = tmp_path / "vast_tfa_key"
+        api_file = tmp_path / "vast_api_key"  # does not exist
+        tfa_file.write_text("stale-tfa-key")
+
+        func = MagicMock(side_effect=[_http_error(404, "Session expired. Please log in again.")])
+        args = _args(func=func)
+
+        with patch("vastai.cli.main.TFAKEY_FILE", str(tfa_file)), \
+             patch("vastai.cli.main.APIKEY_FILE", str(api_file)):
+            run_command(args)  # breaks out of the loop without sys.exit
+
+        assert func.call_count == 1
+        assert not tfa_file.exists()
+
+        out = capsys.readouterr().out
+        assert "vastai tfa login" in out
+
+    def test_plain_404_without_tfa_key_file_is_not_treated_as_session_expiry(self, tmp_path, capsys):
+        tfa_file = tmp_path / "vast_tfa_key"  # does not exist
+        api_file = tmp_path / "vast_api_key"
+
+        func = MagicMock(side_effect=[_http_error(404, "Session expired. Please log in again.")])
+        args = _args(raw=False, func=func)
+
+        with patch("vastai.cli.main.TFAKEY_FILE", str(tfa_file)), \
+             patch("vastai.cli.main.APIKEY_FILE", str(api_file)):
+            run_command(args)
+
+        assert func.call_count == 1
+        err = capsys.readouterr().err
+        assert "Failed with error 404: Session expired. Please log in again." in err

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -16,6 +16,19 @@ except AttributeError:
     JSONDecodeError = ValueError
 
 
+def _is_tfa_session_expired(status_code, errmsg):
+    """True if this error signals an expired 2FA session key.
+
+    401 "Invalid user key" is sent when a deleted API key is used; an expired
+    TFA session instead returns 404 "Session expired. Please log in again."
+    (matches legacy vast.py's handling of both signals).
+    """
+    return (
+        (status_code == 401 and errmsg == "Invalid user key")
+        or (status_code == 404 and errmsg == "Session expired. Please log in again.")
+    )
+
+
 def _emit_error(args, status_code, message):
     """Emit a command error in the appropriate format.
 
@@ -159,7 +172,11 @@ def main():
         else:
             args.api_key = None
 
-    # Execute command with error handling
+    run_command(args)
+
+
+def run_command(args):
+    """Execute ``args.func(args)``, retrying once on an expired 2FA session key."""
     while True:
         try:
             res = args.func(args)
@@ -181,18 +198,18 @@ def main():
                 else:
                     errmsg = "(no detail message supplied)"
 
-            # 2FA session key expired -> retry with long-lived API key
-            if (e.response.status_code == 401 and errmsg == "Invalid user key"
-                    and os.path.exists(TFAKEY_FILE)):
+            # 2FA session key expired -> retry with long-lived API key.
+            if _is_tfa_session_expired(e.response.status_code, errmsg) and os.path.exists(TFAKEY_FILE):
                 print(f"Failed with error {e.response.status_code}: Your 2FA session has expired.")
                 os.remove(TFAKEY_FILE)
                 if os.path.exists(APIKEY_FILE):
                     with open(APIKEY_FILE, "r") as reader:
                         args.api_key = reader.read().strip()
                         print(f"Trying again with your normal API Key from {APIKEY_FILE}...")
+                        print("To start a new 2FA session, run: vastai tfa login")
                         continue
                 else:
-                    print("Please log in using the `tfa login` command and try again.")
+                    print("Run `vastai tfa login` to start a new 2FA session and try again.")
                     break
 
             _emit_error(args, e.response.status_code, errmsg)


### PR DESCRIPTION
## Summary
- Restore the 404 "Session expired. Please log in again." branch (dropped when error handling was ported from legacy `vast.py`) alongside the existing 401 "Invalid user key" check, so an expired 2FA session key is detected, removed, and the CLI retries with the long-lived API key.
- When session expiry is hit, tell the user to run `vastai tfa login` to start a new 2FA session — both after a successful fallback and when no fallback API key exists — instead of printing the raw server error or a generic message.

## Test plan
- [x] Added `tests/cli/test_main_error_handling.py` covering the 401/404 expiry detection matrix and the retry loop's fallback / no-fallback / non-expiry paths.
- [x] `poetry run pytest tests/cli/` — 374 passed.

Jira: CLN-3555