### PR TITLE
Hide unreleased network-volume commands from --help

### DIFF
--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -4,6 +4,7 @@ import pytest
 from vastai.cli.parser import (
     apwrap, argument, hidden_aliases, MyWideHelpFormatter,
     build_command_maps, two_stage_command_completions,
+    is_hidden_command,
 )
 
 
@@ -183,6 +184,82 @@ class TestBuildCommandMaps:
         assert verb_objs["create"] == {"instance"}
         # bare command + the auto-registered "help" land in singles, not verbs
         assert "update" in singles and "update" not in verbs
+
+    def test_hidden_command_excluded_from_completion(self):
+        p = _completion_parser()
+
+        @p.command(help="an unreleased thing", hidden=True)
+        def show__unreleased(args):
+            pass
+
+        _, verb_objs, _ = build_command_maps(p.parser)
+        assert verb_objs["show"] == {"instances", "env-vars"}
+
+
+class TestIsHiddenCommand:
+    """Unit tests for the unreleased/feature-flagged command gate."""
+
+    def test_explicit_true_wins(self):
+        assert is_hidden_command("show instances", explicit=True) is True
+
+    def test_explicit_false_wins_over_registry(self):
+        assert is_hidden_command("search network-volumes", explicit=False) is False
+
+    def test_known_unreleased_command_is_hidden(self):
+        assert is_hidden_command("search network-volumes") is True
+        assert is_hidden_command("create network-volume") is True
+        assert is_hidden_command("list network-volume") is True
+        assert is_hidden_command("unlist network-volume") is True
+
+    def test_unregistered_command_defaults_to_visible(self):
+        assert is_hidden_command("show instances") is False
+
+
+class TestCommandDecoratorHidden:
+    def test_hidden_kwarg_is_stored_on_the_subparser(self):
+        p = apwrap()
+
+        @p.command(help="an unreleased thing", hidden=True)
+        def do__unreleased(args):
+            pass
+
+        assert do__unreleased.mysignature.hidden is True
+
+    def test_default_is_not_hidden(self):
+        p = apwrap()
+
+        @p.command(help="a normal thing")
+        def show__thing(args):
+            pass
+
+        assert show__thing.mysignature.hidden is False
+
+    def test_hidden_command_excluded_from_grouped_help(self):
+        p = apwrap(epilog="epilogue text")
+
+        @p.command(help="show instances")
+        def show__instances(args):
+            pass
+
+        @p.command(help="an unreleased thing", hidden=True)
+        def show__unreleased(args):
+            pass
+
+        help_text = p.parser.format_help()
+        assert "show instances" in help_text
+        assert "show unreleased" not in help_text
+
+
+class TestFullCliHiddenCommands:
+    """Sanity check against the real, fully-populated CLI parser."""
+
+    def test_network_volume_commands_are_hidden_from_help(self, cli_parser):
+        help_text = cli_parser.parser.format_help()
+        assert "network-volume" not in help_text
+
+    def test_network_volume_commands_still_parse_directly(self, cli_parser):
+        args = cli_parser.parse_args(["search", "network-volumes"])
+        assert callable(args.func)
 
 
 class TestTwoStageCompletions:

--- a/vastai/cli/parser.py
+++ b/vastai/cli/parser.py
@@ -47,11 +47,19 @@ def complete_sshkeys(prefix=None, action=None, parser=None, parsed_args=None):
 # ---------------------------------------------------------------------------
 
 def build_command_maps(parser):
-    """Derive (verbs, verb_objs, singles) from a parser's subparser names."""
+    """Derive (verbs, verb_objs, singles) from a parser's subparser names.
+
+    Commands flagged hidden (see ``is_hidden_command``) are left out of
+    completion — unreleased/feature-flagged functionality, still fully
+    runnable if typed directly.
+    """
     names = []
     for action in parser._actions:
         if isinstance(action, argparse._SubParsersAction):
-            names = list(action.choices.keys())
+            for name, sp in action.choices.items():
+                if getattr(sp, 'hidden', False):
+                    continue
+                names.append(name)
             break
     verbs, verb_objs, singles = set(), {}, set()
     for name in names:
@@ -161,6 +169,33 @@ GROUP_ORDER = [
     'Billing & account', 'Serverless', 'Metrics', 'Storage volumes', 'Other',
 ]
 
+# ---------------------------------------------------------------------------
+# Unreleased/feature-flagged commands
+#
+# Hidden from --help and tab completion regardless of anything else — a
+# discoverability gate, not an access gate: the command still runs if typed
+# directly, so internal testing keeps working. Remove an entry once the
+# feature is ready to announce.
+# ---------------------------------------------------------------------------
+
+HIDDEN_COMMANDS = {
+    'search network-volumes',  # network volumes are not yet released
+    'create network-volume',
+    'list network-volume',
+    'unlist network-volume',
+}
+
+
+def is_hidden_command(name, explicit=None):
+    """Whether a registered command should be hidden from --help/completion.
+
+    Priority: explicit ``hidden=`` kwarg on the decorator > ``HIDDEN_COMMANDS``.
+    Defaults to ``False`` (visible).
+    """
+    if explicit is not None:
+        return bool(explicit)
+    return name in HIDDEN_COMMANDS
+
 
 class GroupedArgumentParser(argparse.ArgumentParser):
     """ArgumentParser that renders subcommands grouped by registering module."""
@@ -202,6 +237,8 @@ class GroupedArgumentParser(argparse.ArgumentParser):
         for pseudo in sub_action._choices_actions:
             sp = sub_action.choices.get(pseudo.dest)
             if sp is None:
+                continue
+            if getattr(sp, 'hidden', False):
                 continue
             label = COMMAND_OVERRIDES.get(pseudo.dest)
             if label is None:
@@ -284,7 +321,7 @@ class apwrap(object):
             name = verb
         return name
 
-    def command(self, *arguments, aliases=(), help=None, **kwargs):
+    def command(self, *arguments, aliases=(), help=None, hidden=None, **kwargs):
         help_ = help
         if not self.added_help_cmd:
             self.added_help_cmd = True
@@ -305,6 +342,7 @@ class apwrap(object):
                 kwargs["formatter_class"] = MyWideHelpFormatter
 
             sp = self.subparsers().add_parser(name, aliases=aliases_transformed, help=help_, **kwargs)
+            sp.hidden = is_hidden_command(name, explicit=hidden)
 
             # TODO: Sometimes the parser.command has a help parameter. Ideally
             # I'd extract this during the sdk phase but for the life of me


### PR DESCRIPTION
## Summary

Network volumes aren't released yet, but their CLI commands were fully visible in `vastai --help` and tab completion — `search network-volumes`, `create network-volume`, `list network-volume`, `unlist network-volume`.

Adds a general-purpose "hidden command" gate, independent of and unrelated to the client/host work in #462/#463:
- `HIDDEN_COMMANDS` (name-based registry) + an explicit `hidden=` kwarg on `@parser.command`, mirroring the existing `COMMAND_OVERRIDES`-style pattern in `vastai/cli/parser.py`.
- Discoverability gate only, not an access gate — a hidden command still runs if typed directly (e.g. `vastai search network-volumes ...`), so internal testing is unaffected.
- Applied to all four network-volume commands.

Found while manually testing #462 — noticed `search network-volumes` in `--help` but its own `usage:` string has an unrelated pre-existing typo (says `search network volumes`, missing the hyphen, present on `master` too). Not fixed here since it's a separate, small, unrelated issue — happy to do it as a follow-up if wanted.

## Test plan
- [x] `poetry run pytest tests/cli` — 375 passed
- [x] Manually verified: none of the four commands appear in `vastai --help` or tab completion; all four still parse and run when typed directly