### PR TITLE
docs(install): updated flow diagram + show wheel-install progress at a TTY

### DIFF
--- a/docs/install-design.md
+++ b/docs/install-design.md
@@ -8,6 +8,31 @@ curl -fsSL https://vast.ai/install.sh | bash
 testing. This splits the audience (CLI users vs. SDK users); it does not
 replace pip.
 
+## 1. Goals
+
+- Install the CLI with **no system Python, pip, or sudo** required. Fresh VMs
+  and CI runners frequently have no usable Python — for a GPU cloud this is the
+  common case.
+- Decouple the CLI from the user's Python environment (avoid PEP 668 refusals,
+  venv confusion, pinned-dependency conflicts on `cryptography`/`pillow`).
+- Provide a first-class `vastai update` so the CLI can ship — and users can
+  adopt — daily releases (pip already lets us release daily; the gap is that
+  users lag, so the fixes never land).
+
+## 2. Core architecture: one-time install script + per-release manifest
+
+The design splits the install into two layers:
+
+- **`install.sh` — a one-time install script** with **no version numbers and
+  no artifact URLs**. It only: detects platform → fetches the manifest →
+  verifies sha256 → bootstraps + symlinks. "One-time" is about *change
+  frequency*: per-release churn lives in the manifest, so the script is written
+  once and rarely touched.
+- **`manifest.{json,env}` — regenerated every release.** Carries the latest
+  version, the CPython pin, and per-platform `uv` URLs + sha256.
+  `manifest.json` is for `vastai update`; flat `manifest.env` is for
+  `install.sh` (bare machines have no JSON parser).
+
 ### Current flow (post-activation)
 
 ```
@@ -38,31 +63,6 @@ curl -fsSL https://vast.ai/install.sh | bash
    passive nudge enabled as      pip installs refused with the pip hint, never touched
    a pre-command hook, §7)
 ```
-
-## 1. Goals
-
-- Install the CLI with **no system Python, pip, or sudo** required. Fresh VMs
-  and CI runners frequently have no usable Python — for a GPU cloud this is the
-  common case.
-- Decouple the CLI from the user's Python environment (avoid PEP 668 refusals,
-  venv confusion, pinned-dependency conflicts on `cryptography`/`pillow`).
-- Provide a first-class `vastai update` so the CLI can ship — and users can
-  adopt — daily releases (pip already lets us release daily; the gap is that
-  users lag, so the fixes never land).
-
-## 2. Core architecture: one-time install script + per-release manifest
-
-The design splits the install into two layers:
-
-- **`install.sh` — a one-time install script** with **no version numbers and
-  no artifact URLs**. It only: detects platform → fetches the manifest →
-  verifies sha256 → bootstraps + symlinks. "One-time" is about *change
-  frequency*: per-release churn lives in the manifest, so the script is written
-  once and rarely touched.
-- **`manifest.{json,env}` — regenerated every release.** Carries the latest
-  version, the CPython pin, and per-platform `uv` URLs + sha256.
-  `manifest.json` is for `vastai update`; flat `manifest.env` is for
-  `install.sh` (bare machines have no JSON parser).
 
 ### Install bootstrap sequence
 

--- a/docs/install-design.md
+++ b/docs/install-design.md
@@ -8,6 +8,37 @@ curl -fsSL https://vast.ai/install.sh | bash
 testing. This splits the audience (CLI users vs. SDK users); it does not
 replace pip.
 
+### Current flow (post-activation)
+
+```
+curl -fsSL https://vast.ai/install.sh | bash
+        │
+        ▼
+  install.sh ──fetch──► manifest.{json,env}      (stable script + per-release manifest:
+  (no versions,         latest ver · py 3.12 pin ·  script holds no version/URLs, so it's
+   no URLs)             per-platform uv + sha256)   written once and rarely touched)
+        │
+        ▼  glibc ≥2.31 / musl check → pinned uv → managed CPython 3.12 → vastai wheel
+           (unsupported platform / bad hash bails to pip before anything lands)
+        │
+        ▼
+  $XDG_DATA_HOME/vastai/            (~/.local/share/vastai, or $VASTAI_INSTALL_DIR)
+   ├── bin/vastai → ../current/bin/vastai   (fixed symlink, never retargeted)
+   ├── bin/uv                                ~/.local/bin/vastai → bin/vastai  (on PATH)
+   ├── current/                              (single active venv; update = build temp → verify → swap)
+   └── python/                               (uv-managed CPython 3.12, shared)
+
+  ~/.config/vastai/        vast_api_key, etc. — untouched by install/uninstall
+  ~/.cache/vastai/         disposable (uv-pruned after each update)
+  ~/.local/state/vastai/   update_check.json (nudge throttle)
+        │
+        ▼
+  vastai update                  ──manifest──►  build temp venv → verify runs → atomic rename
+  (registered in main.py;        `--version X` pins or rolls back (same code path);
+   passive nudge enabled as      pip installs refused with the pip hint, never touched
+   a pre-command hook, §7)
+```
+
 ## 1. Goals
 
 - Install the CLI with **no system Python, pip, or sudo** required. Fresh VMs

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -227,11 +227,6 @@ install_version() {
         rm -rf "$newdir"
         die "could not set up the Python $python_pin runtime"
     fi
-    # pip install: quiet in CI/non-interactive (the per-package "+ pkg==ver"
-    # list is noise in logs); at a real TTY, show uv's own resolve/download/
-    # install progress — this step fetches vastai + all its deps and was
-    # otherwise the one silent stretch of the install (unlike the runtime
-    # download and the Python provisioning above, both already show progress).
     # Latest installs the release wheel by URL, hash-verified against the
     # manifest — no PyPI index propagation window. A pin to any other
     # version falls back to PyPI (always long-published, so race-free).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -234,9 +234,7 @@ install_version() {
     if [ -z "${VASTAI_PIP_SPEC:-}" ] && [ -n "$wheel_url" ] && [ -n "$wheel_sha" ]; then
         spec="vastai @ ${wheel_url}#sha256=${wheel_sha}"
     fi
-    local pipquiet=(--quiet)
-    [ -t 2 ] && pipquiet=()
-    if ! "$ROOT/bin/uv" pip install --python "$newdir/bin/python" ${pipquiet[@]+"${pipquiet[@]}"} "$spec"; then
+    if ! "$ROOT/bin/uv" pip install --python "$newdir/bin/python" "$spec"; then
         rm -rf "$newdir"
         die "could not install $spec (is the version correct?)"
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -227,7 +227,11 @@ install_version() {
         rm -rf "$newdir"
         die "could not set up the Python $python_pin runtime"
     fi
-    # pip install stays quiet always — the per-package "+ pkg==ver" list is noise.
+    # pip install: quiet in CI/non-interactive (the per-package "+ pkg==ver"
+    # list is noise in logs); at a real TTY, show uv's own resolve/download/
+    # install progress — this step fetches vastai + all its deps and was
+    # otherwise the one silent stretch of the install (unlike the runtime
+    # download and the Python provisioning above, both already show progress).
     # Latest installs the release wheel by URL, hash-verified against the
     # manifest — no PyPI index propagation window. A pin to any other
     # version falls back to PyPI (always long-published, so race-free).
@@ -235,7 +239,9 @@ install_version() {
     if [ -z "${VASTAI_PIP_SPEC:-}" ] && [ -n "$wheel_url" ] && [ -n "$wheel_sha" ]; then
         spec="vastai @ ${wheel_url}#sha256=${wheel_sha}"
     fi
-    if ! "$ROOT/bin/uv" pip install --python "$newdir/bin/python" --quiet "$spec"; then
+    local pipquiet=(--quiet)
+    [ -t 2 ] && pipquiet=()
+    if ! "$ROOT/bin/uv" pip install --python "$newdir/bin/python" ${pipquiet[@]+"${pipquiet[@]}"} "$spec"; then
         rm -rf "$newdir"
         die "could not install $spec (is the version correct?)"
     fi


### PR DESCRIPTION
## Summary
- Adds an ASCII flow diagram to `docs/install-design.md`, in the "Core architecture" section, reflecting the current post-activation state (XDG layout, glibc/musl gating, `vastai update` registered with the nudge enabled) rather than the dark-launch state described in #419.
- `scripts/install.sh`: drops the `--quiet` flag from the `uv pip install` step that installs the vastai wheel + deps. That step was the one silent stretch of the install — the runtime download and CPython provisioning already show progress, but the wheel install (the slowest step, since it pulls in every dependency) gave zero feedback. Now it always shows uv's normal resolve/download/install progress, including in CI/non-interactive installs.

## Test plan
- [x] `bash tests/installer/run_tests.sh` — 15/15 pass
- [x] `bash -n scripts/install.sh`