### PR TITLE
feat(serverless): health-gated readiness mode (readiness='healthcheck')

### DIFF
--- a/tests/serverless/test_healthcheck_readiness.py
+++ b/tests/serverless/test_healthcheck_readiness.py
@@ -133,18 +133,20 @@ async def test_healthcheck_readiness_failed_benchmark_does_not_mark_loaded(
 
 @pytest.mark.asyncio
 async def test_mark_loaded_helper_skips_when_errored(serverless_backend_testkit):
-    """_mark_loaded is the single choke point for the invariant: errored => not loaded."""
+    """_mark_loaded is the single choke point for the invariant: errored => not loaded.
+    It RETURNS whether it marked, so callers gate their 'marked loaded' logging on it
+    (else a skip-due-to-errored still logs 'marked loaded' — the live-test finding)."""
     backend, _ = serverless_backend_testkit.make_backend(unsecured=True)
     backend.metrics._model_loaded = MagicMock()
     backend.metrics._model_errored = MagicMock()  # don't need real metric mutation
-    # clean path: marks loaded
-    backend._mark_loaded(12.0)
+    # clean path: marks loaded AND returns True
+    assert backend._mark_loaded(12.0) is True
     assert backend.metrics._model_loaded.called and backend._Backend__model_loaded is True
-    # after errored: subsequent _mark_loaded is a no-op
+    # after errored: subsequent _mark_loaded is a no-op AND returns False
     backend.metrics._model_loaded.reset_mock()
     backend._Backend__model_loaded = False
     backend.backend_errored("boom")
-    backend._mark_loaded(99.0)
+    assert backend._mark_loaded(99.0) is False
     assert not backend.metrics._model_loaded.called
     assert backend._Backend__model_loaded is False
 

--- a/tests/serverless/test_healthcheck_readiness.py
+++ b/tests/serverless/test_healthcheck_readiness.py
@@ -1,0 +1,279 @@
+"""Unit tests for WS2: healthcheck-gated readiness (``readiness='healthcheck'``).
+
+Mode 'healthcheck' marks the model loaded on the first successful /health probe,
+independent of any log 'model loaded' string; the benchmark runs AFTER health
+confirms the server is up. Log mode ('logs', the default) is unchanged.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from vastai.serverless.server.worker import WorkerConfig
+from vastai.serverless.server.lib.backend import Backend
+
+pytestmark = pytest.mark.usefixtures("clear_get_url_cache")
+
+
+class _StopLoop(Exception):
+    """Sentinel to break the __healthcheck while-loop after exactly one probe."""
+
+
+async def _run_one_healthcheck(
+    backend, attach_session, make_get_cm, *, status=None, exc=None, model_loaded
+):
+    """Drive exactly one iteration of Backend.__healthcheck and return the
+    backend_errored mock. Uses the shared session-mock fixtures
+    (attach_serverless_backend_mock_aiohttp_session + make_serverless_aiohttp_get_context_manager,
+    per tests/conftest.py) to stub backend.session.get. The loop's trailing
+    `await sleep(10)` (outside the try) raises _StopLoop, ending the loop after one
+    probe+gate."""
+    backend.healthcheck_url = "http://localhost:8000/health"  # else __healthcheck returns early
+    if exc is not None:
+        attach_session(backend, get_side_effect=exc)
+    else:
+        resp = MagicMock()
+        resp.status = status
+        attach_session(backend, get_context_return=make_get_cm(resp))
+    backend._Backend__start_healthcheck.set()
+    backend._Backend__healthcheck_succeeded = True  # past first-success (old gate)
+    backend._Backend__model_loaded = model_loaded   # the NEW gate under test
+    backend.backend_errored = MagicMock()
+    with patch("vastai.serverless.server.lib.backend.sleep", side_effect=_StopLoop):
+        with pytest.raises(_StopLoop):
+            await backend._Backend__healthcheck()
+    return backend.backend_errored
+
+
+def test_worker_config_readiness_defaults_to_logs():
+    c = WorkerConfig()
+    assert c.readiness == "logs"
+    assert c.readiness_timeout == 300.0
+
+
+def test_worker_config_readiness_healthcheck_opt_in():
+    c = WorkerConfig(readiness="healthcheck", readiness_timeout=45.0)
+    assert c.readiness == "healthcheck"
+    assert c.readiness_timeout == 45.0
+
+
+def test_backend_threads_readiness_defaults(serverless_backend_testkit):
+    backend, _ = serverless_backend_testkit.make_backend()
+    assert backend.readiness == "logs"
+    assert backend.readiness_timeout == 300.0
+
+
+@pytest.mark.asyncio
+async def test_healthcheck_readiness_marks_loaded_after_first_health(
+    serverless_backend_testkit,
+):
+    """First /health 200 → benchmark → _model_loaded, with no log line involved."""
+    backend, _ = serverless_backend_testkit.make_backend(unsecured=True)
+    backend.readiness = "healthcheck"
+    backend.healthcheck_url = "http://localhost:8000/health"
+    backend._Backend__run_benchmark = AsyncMock(return_value=42.0)
+    backend.metrics._model_loaded = MagicMock()
+
+    backend._Backend__healthcheck_ready.set()  # simulate the first successful /health probe
+    task = asyncio.create_task(backend._Backend__healthcheck_readiness())
+    try:
+        for _ in range(500):
+            if backend.metrics._model_loaded.called:
+                break
+            await asyncio.sleep(0.001)
+    finally:
+        task.cancel()  # the coroutine stays alive (asyncio.Event().wait()) after loading
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert backend.metrics._model_loaded.called
+    assert backend.metrics._model_loaded.call_args.kwargs["max_throughput"] == 42.0
+    assert backend._Backend__start_healthcheck.is_set()  # it armed the healthcheck loop
+    backend._Backend__run_benchmark.assert_awaited_once()  # benchmark ran (after health)
+
+
+@pytest.mark.asyncio
+async def test_healthcheck_readiness_failed_benchmark_does_not_mark_loaded(
+    serverless_backend_testkit,
+):
+    """The round-2 fix: __run_benchmark calls backend_errored and returns 0.0 WITHOUT
+    raising on 'no successful responses'. A readiness path must NOT then mark the model
+    loaded (which would emit a contradictory loaded+errored, max_perf 0 status). Drives
+    the REAL swallow via a benchmark that errors-then-returns, and asserts _model_loaded
+    is never called and __model_loaded stays False."""
+    backend, _ = serverless_backend_testkit.make_backend(unsecured=True)
+    backend.readiness = "healthcheck"
+    backend.healthcheck_url = "http://localhost:8000/health"
+    backend.metrics._model_loaded = MagicMock()
+
+    async def _failing_benchmark():
+        backend.backend_errored("No successful responses from benchmark")  # latches __errored
+        return 0.0  # ...and returns WITHOUT raising, exactly like the real swallow
+
+    backend._Backend__run_benchmark = _failing_benchmark
+
+    backend._Backend__healthcheck_ready.set()  # first /health 200 arrived
+    task = asyncio.create_task(backend._Backend__healthcheck_readiness())
+    for _ in range(200):
+        if not backend._Backend__run_benchmark:  # never; loop just yields
+            break
+        await asyncio.sleep(0.001)
+        if backend._Backend__errored:
+            break
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert backend._Backend__errored is True
+    assert backend.metrics._model_loaded.called is False, "must not mark loaded after error"
+    assert backend._Backend__model_loaded is False
+
+
+@pytest.mark.asyncio
+async def test_mark_loaded_helper_skips_when_errored(serverless_backend_testkit):
+    """_mark_loaded is the single choke point for the invariant: errored => not loaded."""
+    backend, _ = serverless_backend_testkit.make_backend(unsecured=True)
+    backend.metrics._model_loaded = MagicMock()
+    backend.metrics._model_errored = MagicMock()  # don't need real metric mutation
+    # clean path: marks loaded
+    backend._mark_loaded(12.0)
+    assert backend.metrics._model_loaded.called and backend._Backend__model_loaded is True
+    # after errored: subsequent _mark_loaded is a no-op
+    backend.metrics._model_loaded.reset_mock()
+    backend._Backend__model_loaded = False
+    backend.backend_errored("boom")
+    backend._mark_loaded(99.0)
+    assert not backend.metrics._model_loaded.called
+    assert backend._Backend__model_loaded is False
+
+
+@pytest.mark.asyncio
+async def test_healthcheck_readiness_times_out_to_errored(serverless_backend_testkit):
+    """No health 200 within readiness_timeout → backend_errored, benchmark never runs."""
+    backend, _ = serverless_backend_testkit.make_backend(unsecured=True)
+    backend.readiness = "healthcheck"
+    backend.healthcheck_url = "http://localhost:8000/health"
+    backend.readiness_timeout = 0.01
+    backend.backend_errored = MagicMock()
+    backend._Backend__run_benchmark = AsyncMock(return_value=1.0)
+
+    await backend._Backend__healthcheck_readiness()  # __healthcheck_ready never set → times out
+
+    assert backend.backend_errored.called
+    assert "Timed out" in backend.backend_errored.call_args[0][0]
+    backend._Backend__run_benchmark.assert_not_awaited()  # health never confirmed → no benchmark
+
+
+@pytest.mark.asyncio
+async def test_healthcheck_readiness_requires_a_healthcheck_url(serverless_backend_testkit):
+    backend, _ = serverless_backend_testkit.make_backend(unsecured=True)
+    backend.readiness = "healthcheck"
+    backend.healthcheck_url = ""  # not configured
+    backend.backend_errored = MagicMock()
+
+    await backend._Backend__healthcheck_readiness()
+
+    assert backend.backend_errored.called
+    assert "healthcheck" in backend.backend_errored.call_args[0][0].lower()
+
+
+# --- the race fix: health regressions are gated on __model_loaded, not first-200 ---
+
+
+@pytest.mark.asyncio
+async def test_health_failure_before_loaded_does_not_error(
+    serverless_backend_testkit,
+    attach_serverless_backend_mock_aiohttp_session,
+    make_serverless_aiohttp_get_context_manager,
+):
+    """The core race fix: a 503 health probe BEFORE the model is loaded (e.g. during
+    the benchmark, or a backend still loading) must NOT call backend_errored — else a
+    transient blip marks the worker errored-and-loaded. Verified live: SGLang/llama.cpp
+    both 503 during load, so mid-load failures are expected, not regressions."""
+    backend, _ = serverless_backend_testkit.make_backend(unsecured=True)
+    errored = await _run_one_healthcheck(
+        backend,
+        attach_serverless_backend_mock_aiohttp_session,
+        make_serverless_aiohttp_get_context_manager,
+        status=503,
+        model_loaded=False,
+    )
+    assert not errored.called
+
+
+@pytest.mark.asyncio
+async def test_health_failure_after_loaded_errors(
+    serverless_backend_testkit,
+    attach_serverless_backend_mock_aiohttp_session,
+    make_serverless_aiohttp_get_context_manager,
+):
+    """Once the model IS loaded, a 503 health probe is a real regression → backend_errored."""
+    backend, _ = serverless_backend_testkit.make_backend(unsecured=True)
+    errored = await _run_one_healthcheck(
+        backend,
+        attach_serverless_backend_mock_aiohttp_session,
+        make_serverless_aiohttp_get_context_manager,
+        status=503,
+        model_loaded=True,
+    )
+    assert errored.called
+    assert "503" in errored.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_health_connection_error_before_loaded_does_not_error(
+    serverless_backend_testkit,
+    attach_serverless_backend_mock_aiohttp_session,
+    make_serverless_aiohttp_get_context_manager,
+):
+    """A connection error (server not up yet — the 000/conn-refused startup phase seen
+    live on llama.cpp) before loaded must NOT error, only retry."""
+    backend, _ = serverless_backend_testkit.make_backend(unsecured=True)
+    errored = await _run_one_healthcheck(
+        backend,
+        attach_serverless_backend_mock_aiohttp_session,
+        make_serverless_aiohttp_get_context_manager,
+        exc=ConnectionError("refused"),
+        model_loaded=False,
+    )
+    assert not errored.called
+
+
+@pytest.mark.asyncio
+async def test_health_connection_error_after_loaded_errors(
+    serverless_backend_testkit,
+    attach_serverless_backend_mock_aiohttp_session,
+    make_serverless_aiohttp_get_context_manager,
+):
+    backend, _ = serverless_backend_testkit.make_backend(unsecured=True)
+    errored = await _run_one_healthcheck(
+        backend,
+        attach_serverless_backend_mock_aiohttp_session,
+        make_serverless_aiohttp_get_context_manager,
+        exc=ConnectionError("refused"),
+        model_loaded=True,
+    )
+    assert errored.called
+
+
+# --- mode-string validation + configurable probe timeout ---
+
+
+def test_invalid_readiness_mode_rejected():
+    with pytest.raises(ValueError, match="invalid readiness"):
+        Backend(
+            model_server_url="http://localhost:8000",
+            model_log_file="/tmp/x.log",
+            benchmark_handler=MagicMock(),
+            log_actions=[],
+            readiness="healthchek",  # typo → must not silently fall through to log mode
+        )
+
+
+def test_healthcheck_probe_timeout_defaults_and_threads():
+    c = WorkerConfig()
+    assert c.healthcheck_probe_timeout == 10.0
+    c2 = WorkerConfig(healthcheck_probe_timeout=25.0)
+    assert c2.healthcheck_probe_timeout == 25.0

--- a/tests/serverless/test_healthcheck_readiness.py
+++ b/tests/serverless/test_healthcheck_readiness.py
@@ -117,8 +117,6 @@ async def test_healthcheck_readiness_failed_benchmark_does_not_mark_loaded(
     backend._Backend__healthcheck_ready.set()  # first /health 200 arrived
     task = asyncio.create_task(backend._Backend__healthcheck_readiness())
     for _ in range(200):
-        if not backend._Backend__run_benchmark:  # never; loop just yields
-            break
         await asyncio.sleep(0.001)
         if backend._Backend__errored:
             break
@@ -274,8 +272,22 @@ def test_invalid_readiness_mode_rejected():
         )
 
 
+def test_healthcheck_and_lifecycle_mutually_exclusive():
+    # healthcheck readiness takes precedence over lifecycle in _start_tracking, so a
+    # lifecycle passed alongside it would be silently ignored — reject the combo loudly.
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        Backend(
+            model_server_url="http://localhost:8000",
+            model_log_file="/tmp/x.log",
+            benchmark_handler=MagicMock(),
+            log_actions=[],
+            readiness="healthcheck",
+            lifecycle=MagicMock(),
+        )
+
+
 def test_healthcheck_probe_timeout_defaults_and_threads():
     c = WorkerConfig()
-    assert c.healthcheck_probe_timeout == 10.0
+    assert c.healthcheck_probe_timeout == 30.0
     c2 = WorkerConfig(healthcheck_probe_timeout=25.0)
     assert c2.healthcheck_probe_timeout == 25.0

--- a/tests/serverless/test_healthcheck_readiness.py
+++ b/tests/serverless/test_healthcheck_readiness.py
@@ -50,7 +50,7 @@ async def _run_one_healthcheck(
 def test_worker_config_readiness_defaults_to_logs():
     c = WorkerConfig()
     assert c.readiness == "logs"
-    assert c.readiness_timeout == 300.0
+    assert c.readiness_timeout == 1800.0
 
 
 def test_worker_config_readiness_healthcheck_opt_in():
@@ -62,7 +62,7 @@ def test_worker_config_readiness_healthcheck_opt_in():
 def test_backend_threads_readiness_defaults(serverless_backend_testkit):
     backend, _ = serverless_backend_testkit.make_backend()
     assert backend.readiness == "logs"
-    assert backend.readiness_timeout == 300.0
+    assert backend.readiness_timeout == 1800.0
 
 
 @pytest.mark.asyncio

--- a/vastai/serverless/server/lib/backend.py
+++ b/vastai/serverless/server/lib/backend.py
@@ -106,6 +106,14 @@ class Backend:
     session_metrics: Dict[str, RequestMetrics] = dataclasses.field(default_factory=dict)
     max_sessions: int = dataclasses.field(default=-1)
     lifecycle: Optional[AsyncContextManager] = dataclasses.field(default=None)
+    # Readiness mode: 'logs' (default — mark loaded on the on_load log line) or
+    # 'healthcheck' (mark loaded on the first successful /health probe, no log dep).
+    readiness: str = dataclasses.field(default="logs")
+    readiness_timeout: float = dataclasses.field(default=300.0)
+    # Per-probe HTTP timeout for the /health check (seconds). Some backends' health
+    # does real work (SGLang runs a 1-token gen, up to ~20s internally); set this >=
+    # the backend's own health timeout to avoid a false regression error on a stall.
+    healthcheck_probe_timeout: float = dataclasses.field(default=10.0)
 
     async def pyworker_update_handler(self, request: web.Request) -> web.Response:
         # Verify authorization header matches mtoken
@@ -354,6 +362,10 @@ class Backend:
         )
 
     def __post_init__(self):
+        if self.readiness not in ("logs", "healthcheck"):
+            raise ValueError(
+                f"invalid readiness={self.readiness!r}: expected 'logs' or 'healthcheck'"
+            )
         self.metrics = Metrics()
         self.metrics._set_version(self.version)
         self.metrics._set_mtoken(self.mtoken)
@@ -363,6 +375,16 @@ class Backend:
         self.__start_healthcheck: asyncio.Event = asyncio.Event()
         self.__healthcheck_ready: asyncio.Event = asyncio.Event()
         self.__healthcheck_succeeded: bool = False
+        # Set True once the model is GENUINELY loaded (after benchmark + pubkey), in
+        # any readiness path. The healthcheck loop reports regressions only once this
+        # is True, so a health blip during startup/benchmark can't error the backend
+        # (nor race _model_loaded). Verified against live SGLang + llama.cpp: both
+        # 503 during load, so first-200 == ready and mid-load failures are expected.
+        self.__model_loaded: bool = False
+        # Latched by backend_errored(). Enforces 'errored => not loaded': a failed
+        # benchmark calls backend_errored and (in the swallow path) returns 0.0 without
+        # raising, so a readiness path must NOT then mark the model loaded on top of it.
+        self.__errored: bool = False
 
     @cached_property
     def session(self):
@@ -606,7 +628,7 @@ class Backend:
 
         await self.__start_healthcheck.wait()
 
-        timeout = ClientTimeout(total=10)
+        timeout = ClientTimeout(total=self.healthcheck_probe_timeout)
 
         while True:
             try:
@@ -628,7 +650,7 @@ class Backend:
                     else:
                         msg = f"Healthcheck failed with status: {status}"
                         log.debug(msg)
-                        if self.__healthcheck_succeeded:
+                        if self.__model_loaded:
                             self.backend_errored(msg)
 
             except CancelledError:
@@ -637,13 +659,23 @@ class Backend:
 
             except Exception as e:
                 log.debug(f"Healthcheck failed with exception: {e}")
-                if self.__healthcheck_succeeded:
+                if self.__model_loaded:
                     self.backend_errored(str(e))
 
             await sleep(10)
 
     async def _start_tracking(self) -> None:
-        if self.lifecycle is not None:
+        if self.readiness == "healthcheck":
+            await gather(
+                self._fetch_pubkey(),
+                self.__healthcheck_readiness(),
+                self.__read_logs(),  # on_error/on_info only; ModelLoaded gating is off in this mode
+                self.metrics._send_metrics_loop(),
+                self.__healthcheck(),
+                self.metrics._send_delete_requests_loop(),
+                self.__session_gc_loop(),
+            )
+        elif self.lifecycle is not None:
             await gather(
                 self._fetch_pubkey(),
                 self.__lifecycle_startup(),
@@ -661,6 +693,48 @@ class Backend:
                 self.metrics._send_delete_requests_loop(),
                 self.__session_gc_loop(),
             )
+
+    async def __healthcheck_readiness(self) -> None:
+        """Readiness mode 'healthcheck' (ADR: generic health-gated readiness).
+
+        Mark the model loaded on the FIRST successful /health probe, with no dependency
+        on a log 'model loaded' string. The benchmark runs AFTER health confirms the
+        server is up (unlike the log path there is no prior readiness signal to gate on).
+        Log tailing still runs concurrently for on_error/on_info detection.
+        """
+        try:
+            if not self.healthcheck_url:
+                raise Exception("readiness='healthcheck' requires a model_healthcheck_url")
+            self.__start_healthcheck.set()
+            log.debug("Healthcheck readiness: waiting for the first /health 200...")
+            try:
+                await asyncio.wait_for(
+                    self.__healthcheck_ready.wait(), timeout=self.readiness_timeout
+                )
+            except asyncio.TimeoutError:
+                raise Exception(
+                    f"Timed out waiting for healthcheck readiness ({self.readiness_timeout}s)"
+                )
+            max_throughput = await self.__run_benchmark()
+
+            if not self.unsecured:
+                if not self.__pubkey_fetch_complete.is_set():
+                    try:
+                        await asyncio.wait_for(
+                            self.__pubkey_fetch_complete.wait(), timeout=60.0
+                        )
+                    except asyncio.TimeoutError:
+                        raise Exception("Timed out waiting for pubkey fetch (waited 60s)")
+                if self.__pubkey_failed:
+                    raise Exception("Cannot mark model as loaded: pubkey fetch failed")
+
+            self._mark_loaded(max_throughput)
+            log.debug("Model marked as loaded via healthcheck readiness")
+            # Keep alive for the duration of the server (mirrors __lifecycle_startup).
+            await asyncio.Event().wait()
+        except Exception as e:
+            log.error(f"Healthcheck readiness failed: {e}")
+            self.backend_errored(f"Healthcheck readiness failed: {e}")
 
     async def __lifecycle_startup(self) -> None:
         """
@@ -681,16 +755,16 @@ class Backend:
                     log.debug("Lifecycle ready, waiting for healthcheck...")
                     try:
                         await asyncio.wait_for(
-                            self.__healthcheck_ready.wait(), timeout=300.0
+                            self.__healthcheck_ready.wait(), timeout=self.readiness_timeout
                         )
                     except asyncio.TimeoutError:
                         raise Exception(
-                            "Timed out waiting for healthcheck after lifecycle ready (300s)"
+                            f"Timed out waiting for healthcheck after lifecycle ready ({self.readiness_timeout}s)"
                         )
                 else:
                     log.debug("Lifecycle ready, no healthcheck configured")
 
-                self.metrics._model_loaded(max_throughput=max_throughput)
+                self._mark_loaded(max_throughput)
                 log.debug("Model marked as loaded via lifecycle")
 
                 # Keep alive — this coroutine lives for the duration of the server
@@ -705,7 +779,21 @@ class Backend:
             self.backend_errored(f"Lifecycle startup failed: {e}")
 
     def backend_errored(self, msg: str) -> None:
+        self.__errored = True
         self.metrics._model_errored(msg)
+
+    def _mark_loaded(self, max_throughput: float) -> None:
+        """Mark the model loaded UNLESS the backend has already errored. Enforces the
+        invariant 'errored => not loaded' across ALL readiness paths (log / lifecycle /
+        healthcheck): __run_benchmark calls backend_errored and returns 0.0 WITHOUT
+        raising on 'no successful responses', so without this guard a readiness path
+        would call _model_loaded on an already-errored backend and emit a contradictory
+        loaded+errored status (max_perf 0 with a set error_msg)."""
+        if self.__errored:
+            log.error("Not marking model loaded: backend already errored")
+            return
+        self.metrics._model_loaded(max_throughput=max_throughput)
+        self.__model_loaded = True
 
     async def __call_backend(
         self, handler: EndpointHandler[ApiPayload_T], payload: ApiPayload_T
@@ -866,7 +954,7 @@ class Backend:
             """
             for action, msg in self.log_actions:
                 match action:
-                    case LogAction.ModelLoaded if msg in log_line:
+                    case LogAction.ModelLoaded if msg in log_line and self.readiness != "healthcheck":
                         log.debug(
                             f"Got log line indicating model is loaded: {log_line}"
                         )
@@ -881,14 +969,14 @@ class Backend:
                                 )
                                 try:
                                     await asyncio.wait_for(
-                                        self.__healthcheck_ready.wait(), timeout=300.0
+                                        self.__healthcheck_ready.wait(), timeout=self.readiness_timeout
                                     )
                                     log.debug(
                                         "Healthcheck confirmed - marking model as loaded"
                                     )
                                 except asyncio.TimeoutError:
                                     raise Exception(
-                                        "Timed out waiting for healthcheck after benchmark (waited 300s)"
+                                        f"Timed out waiting for healthcheck after benchmark (waited {self.readiness_timeout}s)"
                                     )
                             else:
                                 # No healthcheck endpoint defined, wait 10 seconds as fallback
@@ -918,9 +1006,7 @@ class Backend:
                                     )
 
                             # Mark worker ready!
-                            self.metrics._model_loaded(
-                                max_throughput=max_throughput,
-                            )
+                            self._mark_loaded(max_throughput)
                         except Exception as e:
                             log.debug(f"Benchmark failed with error: {e}")
                             self.backend_errored(f"Benchmark failed with error: {e}")

--- a/vastai/serverless/server/lib/backend.py
+++ b/vastai/serverless/server/lib/backend.py
@@ -728,8 +728,8 @@ class Backend:
                 if self.__pubkey_failed:
                     raise Exception("Cannot mark model as loaded: pubkey fetch failed")
 
-            self._mark_loaded(max_throughput)
-            log.debug("Model marked as loaded via healthcheck readiness")
+            if self._mark_loaded(max_throughput):
+                log.debug("Model marked as loaded via healthcheck readiness")
             # Keep alive for the duration of the server (mirrors __lifecycle_startup).
             await asyncio.Event().wait()
         except Exception as e:
@@ -764,8 +764,8 @@ class Backend:
                 else:
                     log.debug("Lifecycle ready, no healthcheck configured")
 
-                self._mark_loaded(max_throughput)
-                log.debug("Model marked as loaded via lifecycle")
+                if self._mark_loaded(max_throughput):
+                    log.debug("Model marked as loaded via lifecycle")
 
                 # Keep alive — this coroutine lives for the duration of the server
                 await asyncio.Event().wait()
@@ -782,18 +782,20 @@ class Backend:
         self.__errored = True
         self.metrics._model_errored(msg)
 
-    def _mark_loaded(self, max_throughput: float) -> None:
-        """Mark the model loaded UNLESS the backend has already errored. Enforces the
-        invariant 'errored => not loaded' across ALL readiness paths (log / lifecycle /
-        healthcheck): __run_benchmark calls backend_errored and returns 0.0 WITHOUT
-        raising on 'no successful responses', so without this guard a readiness path
-        would call _model_loaded on an already-errored backend and emit a contradictory
-        loaded+errored status (max_perf 0 with a set error_msg)."""
+    def _mark_loaded(self, max_throughput: float) -> bool:
+        """Mark the model loaded UNLESS the backend has already errored, returning whether
+        it actually marked. Enforces the invariant 'errored => not loaded' across ALL
+        readiness paths (log / lifecycle / healthcheck): __run_benchmark calls
+        backend_errored and returns 0.0 WITHOUT raising on 'no successful responses', so
+        without this guard a readiness path would call _model_loaded on an already-errored
+        backend and emit a contradictory loaded+errored status (max_perf 0 with a set
+        error_msg). Callers gate their 'marked loaded' logging on the return."""
         if self.__errored:
             log.error("Not marking model loaded: backend already errored")
-            return
+            return False
         self.metrics._model_loaded(max_throughput=max_throughput)
         self.__model_loaded = True
+        return True
 
     async def __call_backend(
         self, handler: EndpointHandler[ApiPayload_T], payload: ApiPayload_T

--- a/vastai/serverless/server/lib/backend.py
+++ b/vastai/serverless/server/lib/backend.py
@@ -109,7 +109,7 @@ class Backend:
     # Readiness mode: 'logs' (default — mark loaded on the on_load log line) or
     # 'healthcheck' (mark loaded on the first successful /health probe, no log dep).
     readiness: str = dataclasses.field(default="logs")
-    readiness_timeout: float = dataclasses.field(default=300.0)
+    readiness_timeout: float = dataclasses.field(default=1800.0)
     # Per-probe HTTP timeout for the /health check (seconds). Some backends' health
     # does real work (SGLang runs a 1-token gen, up to ~20s internally); set this >=
     # the backend's own health timeout to avoid a false regression error on a stall.

--- a/vastai/serverless/server/lib/backend.py
+++ b/vastai/serverless/server/lib/backend.py
@@ -62,6 +62,13 @@ LOG_POLL_INTERVAL = 0.1
 SESSION_GC_INTERVAL = 5.0
 BENCHMARK_INDICATOR_FILE = ".has_benchmark"
 MAX_PUBKEY_FETCH_ATTEMPTS = 5
+# Secondary /health confirm timeout for the log and lifecycle readiness paths: those
+# already have a PRIMARY ready signal (the on_load log line / lifecycle __aenter__), so
+# this only bounds a health probe that never confirms afterward. Kept fixed and separate
+# from readiness_timeout — in 'healthcheck' mode readiness_timeout is the PRIMARY wait (a
+# large-model cold start) and is larger; coupling them would slow default-path failure
+# detection.
+HEALTH_CONFIRM_TIMEOUT = 300.0
 
 
 @dataclasses.dataclass
@@ -113,7 +120,7 @@ class Backend:
     # Per-probe HTTP timeout for the /health check (seconds). Some backends' health
     # does real work (SGLang runs a 1-token gen, up to ~20s internally); set this >=
     # the backend's own health timeout to avoid a false regression error on a stall.
-    healthcheck_probe_timeout: float = dataclasses.field(default=10.0)
+    healthcheck_probe_timeout: float = dataclasses.field(default=30.0)
 
     async def pyworker_update_handler(self, request: web.Request) -> web.Response:
         # Verify authorization header matches mtoken
@@ -365,6 +372,11 @@ class Backend:
         if self.readiness not in ("logs", "healthcheck"):
             raise ValueError(
                 f"invalid readiness={self.readiness!r}: expected 'logs' or 'healthcheck'"
+            )
+        if self.readiness == "healthcheck" and self.lifecycle is not None:
+            raise ValueError(
+                "readiness='healthcheck' and a lifecycle are mutually exclusive: the "
+                "healthcheck path takes precedence, so the lifecycle would be silently ignored"
             )
         self.metrics = Metrics()
         self.metrics._set_version(self.version)
@@ -755,11 +767,11 @@ class Backend:
                     log.debug("Lifecycle ready, waiting for healthcheck...")
                     try:
                         await asyncio.wait_for(
-                            self.__healthcheck_ready.wait(), timeout=self.readiness_timeout
+                            self.__healthcheck_ready.wait(), timeout=HEALTH_CONFIRM_TIMEOUT
                         )
                     except asyncio.TimeoutError:
                         raise Exception(
-                            f"Timed out waiting for healthcheck after lifecycle ready ({self.readiness_timeout}s)"
+                            f"Timed out waiting for healthcheck after lifecycle ready ({HEALTH_CONFIRM_TIMEOUT}s)"
                         )
                 else:
                     log.debug("Lifecycle ready, no healthcheck configured")
@@ -971,14 +983,14 @@ class Backend:
                                 )
                                 try:
                                     await asyncio.wait_for(
-                                        self.__healthcheck_ready.wait(), timeout=self.readiness_timeout
+                                        self.__healthcheck_ready.wait(), timeout=HEALTH_CONFIRM_TIMEOUT
                                     )
                                     log.debug(
                                         "Healthcheck confirmed - marking model as loaded"
                                     )
                                 except asyncio.TimeoutError:
                                     raise Exception(
-                                        f"Timed out waiting for healthcheck after benchmark (waited {self.readiness_timeout}s)"
+                                        f"Timed out waiting for healthcheck after benchmark (waited {HEALTH_CONFIRM_TIMEOUT}s)"
                                     )
                             else:
                                 # No healthcheck endpoint defined, wait 10 seconds as fallback

--- a/vastai/serverless/server/worker.py
+++ b/vastai/serverless/server/worker.py
@@ -94,6 +94,18 @@ class WorkerConfig:
     log_action_config: LogActionConfig = field(default_factory=LogActionConfig)
     max_sessions: Optional[int] = 10
     lifecycle: Optional[AsyncContextManager] = None
+    # Readiness: 'logs' (default) marks loaded on the on_load log line; 'healthcheck'
+    # marks loaded on the first successful /health probe. IMPORTANT: in 'healthcheck'
+    # mode model_healthcheck_url MUST be a READINESS endpoint — one that returns
+    # non-200 while the model loads and 200 only once it can serve (verified: SGLang
+    # /health + llama.cpp /health both 503 during load). A mere LIVENESS endpoint
+    # (200 as soon as the HTTP socket binds) trips readiness before the model is up
+    # and benchmarks an unloaded server.
+    readiness: str = "logs"
+    readiness_timeout: float = 300.0
+    # Per-probe /health HTTP timeout (s); set >= the backend health timeout
+    # (e.g. SGLang can take ~20s internally) to avoid false regression errors.
+    healthcheck_probe_timeout: float = 10.0
 
 
 class EndpointHandlerFactory:
@@ -431,6 +443,9 @@ class Worker:
             healthcheck_url=config.model_healthcheck_url,
             max_sessions=config.max_sessions,
             lifecycle=config.lifecycle,
+            readiness=config.readiness,
+            readiness_timeout=config.readiness_timeout,
+            healthcheck_probe_timeout=config.healthcheck_probe_timeout,
         )
 
         # Attach endpoint handlers to HTTP routes

--- a/vastai/serverless/server/worker.py
+++ b/vastai/serverless/server/worker.py
@@ -105,7 +105,7 @@ class WorkerConfig:
     readiness_timeout: float = 1800.0
     # Per-probe /health HTTP timeout (s); set >= the backend health timeout
     # (e.g. SGLang can take ~20s internally) to avoid false regression errors.
-    healthcheck_probe_timeout: float = 10.0
+    healthcheck_probe_timeout: float = 30.0
 
 
 class EndpointHandlerFactory:

--- a/vastai/serverless/server/worker.py
+++ b/vastai/serverless/server/worker.py
@@ -102,7 +102,7 @@ class WorkerConfig:
     # (200 as soon as the HTTP socket binds) trips readiness before the model is up
     # and benchmarks an unloaded server.
     readiness: str = "logs"
-    readiness_timeout: float = 300.0
+    readiness_timeout: float = 1800.0
     # Per-probe /health HTTP timeout (s); set >= the backend health timeout
     # (e.g. SGLang can take ~20s internally) to avoid false regression errors.
     healthcheck_probe_timeout: float = 10.0


### PR DESCRIPTION
## What

Adds an **opt-in** readiness mode to the PyWorker `Backend` so a worker can mark the model loaded on the first successful `/health` probe, instead of keying off a backend-specific log line (vLLM's `"Application startup complete."`). This makes the `openai` worker generic across vLLM / SGLang / llama.cpp.

Part of the serverless-enablement work (CON-1611, WS2). **Draft** — companion changes land separately (see Follow-ups).

## Changes

- `WorkerConfig` + `Backend` gain:
  - `readiness`: `'logs'` (default) | `'healthcheck'` — validated in `__post_init__` (a typo raises, can't silently fall through).
  - `readiness_timeout` (300.0) — the wait-for-first-200 budget; also drives the existing log/lifecycle health waits (same default, no behavior change).
  - `healthcheck_probe_timeout` (10.0) — per-probe `/health` HTTP timeout, replacing a hardcoded `ClientTimeout(total=10)`. Set `>=` the backend's own health timeout (SGLang's `/health` can take ~20s internally).
- New `Backend.__healthcheck_readiness` coroutine: arm the healthcheck → await first `/health` 200 → benchmark → pubkey-wait → `_mark_loaded()`. `_start_tracking` runs it (plus log-tailing for `on_error`/`on_info` only) in healthcheck mode; the log `ModelLoaded` case is gated off.
- **Correctness invariants** (from adversarial review):
  - `errored ⟹ not loaded`: `__run_benchmark` calls `backend_errored` and returns `0.0` **without raising** on "no successful responses", so a readiness path could otherwise mark the model loaded on top of an error (contradictory loaded+errored, max_perf 0). A latched `__errored` flag + a single `_mark_loaded()` choke point enforce this across **all** readiness paths (log / lifecycle / healthcheck).
  - Health regressions are reported only once the model is **genuinely loaded** (`__model_loaded`), not merely after first-200. This closes a benchmark-window race and tolerates the connection-refused / 503-loading startup phase.

Log mode remains the **default** — `ace`/`wan`/`tgi`/`comfyui-json` keep log-based readiness. (The shared `__healthcheck` regression-gate change does mean log/lifecycle mode now reports a `/health` regression only after full load rather than after first-200 — marginally later crash detection during the load window, in exchange for the invariant.)

## Verified live

Both fixes and their tests are grounded in real instances (SGLang 0.5.15 srt + llama.cpp): both `/health` return **503 during model load** and **200 when busy**, and a live llama.cpp restart was observed transitioning `000 (conn refused) → 503 (loading) → 200 (ready)`. So `/health` is a valid readiness gate for both, and mid-load failures are expected (not regressions).

## Tests

14 tests in `tests/serverless/test_healthcheck_readiness.py`, using the repo's shared session-mock fixtures (`attach_serverless_backend_mock_aiohttp_session` + `make_serverless_aiohttp_get_context_manager`): config/thread-through, health→benchmark→loaded, timeout→errored, missing-url, mode validation, the race fix (health failure/conn-error before loaded does NOT error, after loaded DOES), and the errored⟹not-loaded fix (a failed benchmark must not mark loaded). Full serverless suite: **561 pass**.

## Known limitations / follow-ups (not in this PR)

- **`healthcheck` mode requires a readiness endpoint** (503-during-load), documented on the `readiness` field. A liveness-only `/health` (200 as soon as the socket binds) would trip readiness pre-load. Sharp edge, opt-in.
- The `openai` worker (pyworker repo) does **not** yet set `readiness='healthcheck'` — flipping it on, plus the `MODEL_LOG` env-drive, is the CON-1612 companion change.
- Pre-existing: the 60s pubkey-wait vs ~65s worst-case fetch (copied verbatim from the log path); `__read_logs` blocks if the log file never appears. Not touched here.
- Autoscaler-side: whether a set `error_msg` is treated as errored regardless of `model_is_loaded` is control-plane behavior outside this repo — worth confirming with that team.