### PR TITLE
fix: keep API keys out of request URLs

### DIFF
--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -20,10 +20,19 @@ class TestBuildUrl:
         assert "/api/v1/invoices/" in url
         assert "/api/v0" not in url
 
-    def test_appends_api_key(self):
+    def test_does_not_append_api_key(self):
         c = VastClient(api_key="mykey123")
         url = c._build_url("/instances")
-        assert "api_key=mykey123" in url
+        assert url == "https://console.vast.ai/api/v0/instances"
+
+    def test_api_key_is_not_added_to_query_args(self):
+        c = VastClient(api_key="mykey123")
+        query_args = {"owner": "me"}
+
+        url = c._build_url("/instances", query_args=query_args)
+
+        assert url == "https://console.vast.ai/api/v0/instances?owner=me"
+        assert query_args == {"owner": "me"}
 
     def test_no_query_when_no_args_and_no_key(self):
         c = VastClient(api_key=None)

--- a/tests/test_legacy_vast.py
+++ b/tests/test_legacy_vast.py
@@ -54,6 +54,25 @@ def test_http_request_adds_bearer_header_when_headers_are_omitted(legacy_vast):
     assert "api_key" not in prepared_request.url
 
 
+def test_http_request_adds_bearer_header_when_headers_are_empty(legacy_vast):
+    # library-style callers pass the module-level `headers` global, which is
+    # empty when main() never ran; they used to rely on the api_key query param
+    args = SimpleNamespace(api_key="secret", retry=1, explain=False, curl=False)
+    legacy_vast.ARGS = args
+    response = SimpleNamespace(status_code=200)
+
+    with patch.object(legacy_vast.requests.Session, "send", return_value=response) as send:
+        legacy_vast.http_get(
+            args,
+            "https://example.test/api/v0/instances",
+            headers={},
+        )
+
+    prepared_request = send.call_args.args[0]
+    assert prepared_request.headers["Authorization"] == "Bearer secret"
+    assert "api_key" not in prepared_request.url
+
+
 def test_http_request_preserves_explicit_headers(legacy_vast):
     args = SimpleNamespace(api_key="secret", retry=1, explain=False, curl=False)
     legacy_vast.ARGS = args

--- a/tests/test_legacy_vast.py
+++ b/tests/test_legacy_vast.py
@@ -1,0 +1,71 @@
+"""Regression tests for the deprecated standalone ``vast.py`` client."""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def legacy_vast(tmp_path_factory):
+    """Load vast.py without touching the user's real configuration paths."""
+    temp_home = tmp_path_factory.mktemp("legacy-vast-home")
+    module_path = Path(__file__).parents[1] / "vast.py"
+    original_expanduser = os.path.expanduser
+    cache_dir = temp_home / ".cache" / "vastai"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "gpu_names_cache.json").write_text(
+        json.dumps({"gpu_names": ["Test GPU"]})
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(temp_home / ".config"))
+        monkeypatch.setenv("XDG_CACHE_HOME", str(temp_home / ".cache"))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: temp_home))
+        monkeypatch.setattr(
+            os.path,
+            "expanduser",
+            lambda path: str(temp_home / path[2:])
+            if path.startswith("~/")
+            else original_expanduser(path),
+        )
+        spec = importlib.util.spec_from_file_location("legacy_vast", module_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+    return module
+
+
+def test_http_request_adds_bearer_header_when_headers_are_omitted(legacy_vast):
+    args = SimpleNamespace(api_key="secret", retry=1, explain=False, curl=False)
+    legacy_vast.ARGS = args
+    response = SimpleNamespace(status_code=200)
+
+    with patch.object(legacy_vast.requests.Session, "send", return_value=response) as send:
+        result = legacy_vast.http_get(args, "https://example.test/api/v0/instances")
+
+    prepared_request = send.call_args.args[0]
+    assert result is response
+    assert prepared_request.headers["Authorization"] == "Bearer secret"
+    assert "api_key" not in prepared_request.url
+
+
+def test_http_request_preserves_explicit_headers(legacy_vast):
+    args = SimpleNamespace(api_key="secret", retry=1, explain=False, curl=False)
+    legacy_vast.ARGS = args
+    response = SimpleNamespace(status_code=200)
+    explicit_headers = {"Authorization": "Bearer override"}
+
+    with patch.object(legacy_vast.requests.Session, "send", return_value=response) as send:
+        legacy_vast.http_get(
+            args,
+            "https://example.test/api/v0/instances",
+            headers=explicit_headers,
+        )
+
+    prepared_request = send.call_args.args[0]
+    assert prepared_request.headers["Authorization"] == "Bearer override"

--- a/vast.py
+++ b/vast.py
@@ -582,15 +582,13 @@ def apiurl(args: argparse.Namespace, subpath: str, query_args: Dict = None) -> s
 
     :param argparse.Namespace args: Namespace with many fields relevant to the endpoint.
     :param str subpath: added to end of URL to further specify endpoint.
-    :param typing.Dict query_args: specifics such as API key and search parameters that complete the URL.
+    :param typing.Dict query_args: search parameters that complete the URL.
     :rtype str:
     """
     result = None
 
     if query_args is None:
         query_args = {}
-    if args.api_key is not None:
-        query_args["api_key"] = args.api_key
     if not re.match(r"^/api/v(\d)+/", subpath):
         subpath = "/api/v0" + subpath
     

--- a/vast.py
+++ b/vast.py
@@ -336,7 +336,7 @@ class hidden_aliases(object):
         self.l.append(x)
 
 def http_request(verb, args, req_url, headers: dict[str, str] | None = None, json_data = None):
-    if headers is None:
+    if not headers:
         headers = apiheaders(args)
 
     t = 0.15

--- a/vast.py
+++ b/vast.py
@@ -336,6 +336,9 @@ class hidden_aliases(object):
         self.l.append(x)
 
 def http_request(verb, args, req_url, headers: dict[str, str] | None = None, json_data = None):
+    if headers is None:
+        headers = apiheaders(args)
+
     t = 0.15
     for i in range(0, args.retry):
         req = requests.Request(method=verb, url=req_url, headers=headers, json=json_data)

--- a/vastai/api/client.py
+++ b/vastai/api/client.py
@@ -57,8 +57,6 @@ class VastClient:
         """Build full API URL from subpath and optional query args."""
         if query_args is None:
             query_args = {}
-        if self.api_key is not None:
-            query_args["api_key"] = self.api_key
         if not re.match(r"^/api/v(\d)+/", subpath):
             subpath = "/api/v0" + subpath
 


### PR DESCRIPTION
Stop VastClient and the deprecated vast.py CLI from adding API keys to URL query parameters. Authentication continues through the Authorization Bearer header.

Add regression tests ensuring URLs and caller-provided query arguments do not contain injected API keys.

Fixes #470