### PR TITLE
Add vastai uninstall command for managed installs

### DIFF
--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -261,6 +261,15 @@ class TestFullCliHiddenCommands:
         args = cli_parser.parse_args(["search", "network-volumes"])
         assert callable(args.func)
 
+    def test_update_and_uninstall_are_hidden_from_help(self, cli_parser):
+        help_text = cli_parser.parser.format_help()
+        assert "\nupdate " not in help_text
+        assert "\nuninstall " not in help_text
+
+    def test_update_and_uninstall_still_parse_directly(self, cli_parser):
+        assert callable(cli_parser.parse_args(["update", "--check"]).func)
+        assert callable(cli_parser.parse_args(["uninstall", "--yes"]).func)
+
 
 class TestTwoStageCompletions:
     def setup_method(self):

--- a/tests/cli/test_uninstall_command.py
+++ b/tests/cli/test_uninstall_command.py
@@ -5,14 +5,16 @@ managed install root under tmp_path, argv-level tests via parse_argv, and
 the same-method discipline (pip installs are refused, never shelled out to).
 """
 
+import shutil
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from vastai.cli import selfupdate
-from vastai.cli.selfupdate import perform_uninstall
+from vastai.cli.selfupdate import UninstallError, perform_uninstall
 
 
 @pytest.fixture
@@ -64,6 +66,38 @@ class TestPerformUninstall:
 
     def test_returns_the_removed_root(self, install_root, local_bin):
         assert perform_uninstall() == install_root
+
+    def test_matches_symlinks_when_install_dir_is_itself_a_symlink(self, tmp_path, local_bin, monkeypatch):
+        # VASTAI_INSTALL_DIR pointing through a symlink must not defeat the
+        # "does this bin/ symlink belong to us" check (compare resolved to resolved).
+        real_root = tmp_path / "real-root"
+        (real_root / "bin").mkdir(parents=True)
+        (real_root / "current" / "bin").mkdir(parents=True)
+        link_root = tmp_path / "linked-root"
+        link_root.symlink_to(real_root)
+        monkeypatch.setenv("VASTAI_INSTALL_DIR", str(link_root))
+        _link(local_bin, "vastai", link_root / "bin" / "vastai")
+
+        perform_uninstall()
+
+        assert not (local_bin / "vastai").exists()
+        assert not real_root.exists()
+
+    def test_symlink_removal_failure_raises_uninstall_error(self, install_root, local_bin, monkeypatch):
+        _link(local_bin, "vastai", install_root / "bin" / "vastai")
+        monkeypatch.setattr(Path, "unlink", lambda self: (_ for _ in ()).throw(OSError("permission denied")))
+        with pytest.raises(UninstallError, match="permission denied"):
+            perform_uninstall()
+
+    def test_root_removal_failure_raises_uninstall_error(self, install_root, local_bin, monkeypatch):
+        monkeypatch.setattr(shutil, "rmtree", lambda *a, **kw: (_ for _ in ()).throw(PermissionError("nope")))
+        with pytest.raises(UninstallError, match="nope"):
+            perform_uninstall()
+
+    def test_missing_root_is_not_an_error(self, install_root, local_bin):
+        # already removed (e.g. a retry after a prior partial failure) — not fatal
+        shutil.rmtree(install_root)
+        perform_uninstall()
 
 
 class TestUninstallCommand:
@@ -130,3 +164,16 @@ class TestUninstallCommand:
              patch("vastai.cli.commands.uninstall.perform_uninstall") as mock_uninstall:
             assert args.func(args) == 1
         mock_uninstall.assert_not_called()
+
+    def test_removal_failure_reports_error_and_exits_nonzero(self, parse_argv, capsys, tmp_path):
+        # perform_uninstall is fallible (see TestPerformUninstall) — the command
+        # must surface that failure, not claim success regardless.
+        args = parse_argv(["uninstall", "--yes"])
+        with patch("vastai.cli.commands.uninstall.is_managed_install", return_value=True), \
+             patch("vastai.cli.commands.uninstall.install_root", return_value=tmp_path), \
+             patch("vastai.cli.commands.uninstall.perform_uninstall",
+                   side_effect=UninstallError("could not remove /fake/root: permission denied")):
+            assert args.func(args) == 1
+        out, err = capsys.readouterr()
+        assert "permission denied" in err
+        assert "uninstalled" not in out

--- a/tests/cli/test_uninstall_command.py
+++ b/tests/cli/test_uninstall_command.py
@@ -1,0 +1,132 @@
+"""Tests for the `vastai uninstall` command and its removal machinery.
+
+Mirrors tests/cli/test_update_command.py's fixtures/patterns: a fake
+managed install root under tmp_path, argv-level tests via parse_argv, and
+the same-method discipline (pip installs are refused, never shelled out to).
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from vastai.cli import selfupdate
+from vastai.cli.selfupdate import perform_uninstall
+
+
+@pytest.fixture
+def install_root(tmp_path, monkeypatch):
+    root = tmp_path / "vastai-root"
+    (root / "bin").mkdir(parents=True)
+    (root / "current" / "bin").mkdir(parents=True)
+    monkeypatch.setenv("VASTAI_INSTALL_DIR", str(root))
+    return root
+
+
+@pytest.fixture
+def local_bin(tmp_path, monkeypatch):
+    bindir = tmp_path / "local-bin"
+    bindir.mkdir()
+    monkeypatch.setattr(selfupdate, "LOCAL_BIN", bindir)
+    return bindir
+
+
+def _link(local_bin, name, target):
+    (local_bin / name).symlink_to(target)
+
+
+class TestPerformUninstall:
+    def test_removes_the_install_root(self, install_root, local_bin):
+        (install_root / "current" / "bin" / "vastai").write_text("#!/bin/sh\n")
+        perform_uninstall()
+        assert not install_root.exists()
+
+    def test_removes_managed_binary_symlinks(self, install_root, local_bin):
+        _link(local_bin, "vastai", install_root / "bin" / "vastai")
+        _link(local_bin, "serve-vast-deployment", install_root / "bin" / "serve-vast-deployment")
+        perform_uninstall()
+        assert not (local_bin / "vastai").exists()
+        assert not (local_bin / "serve-vast-deployment").exists()
+
+    def test_leaves_unmanaged_binaries_with_the_same_name_alone(self, install_root, local_bin, tmp_path):
+        # a symlink named "vastai" pointing somewhere outside our root isn't ours to remove
+        foreign = tmp_path / "foreign-vastai"
+        foreign.write_text("#!/bin/sh\necho foreign\n")
+        _link(local_bin, "vastai", foreign)
+        perform_uninstall()
+        assert (local_bin / "vastai").is_symlink()
+
+    def test_missing_binaries_are_a_no_op(self, install_root, local_bin):
+        # no symlinks ever created in local_bin — must not raise
+        perform_uninstall()
+        assert not install_root.exists()
+
+    def test_returns_the_removed_root(self, install_root, local_bin):
+        assert perform_uninstall() == install_root
+
+
+class TestUninstallCommand:
+    def test_pip_install_refused_with_hint(self, parse_argv, capsys):
+        args = parse_argv(["uninstall", "--yes"])
+        with patch("vastai.cli.commands.uninstall.is_managed_install", return_value=False):
+            assert args.func(args) == 1
+        assert "pip uninstall vastai" in capsys.readouterr().err
+
+    def test_pip_install_never_calls_perform_uninstall(self, parse_argv):
+        args = parse_argv(["uninstall", "--yes"])
+        with patch("vastai.cli.commands.uninstall.is_managed_install", return_value=False), \
+             patch("vastai.cli.commands.uninstall.perform_uninstall") as mock_uninstall:
+            args.func(args)
+        mock_uninstall.assert_not_called()
+
+    def test_yes_flag_skips_confirmation(self, parse_argv, capsys, tmp_path):
+        args = parse_argv(["uninstall", "--yes"])
+        with patch("vastai.cli.commands.uninstall.is_managed_install", return_value=True), \
+             patch("vastai.cli.commands.uninstall.install_root", return_value=tmp_path), \
+             patch("vastai.cli.commands.uninstall.perform_uninstall") as mock_uninstall:
+            assert args.func(args) == 0
+        mock_uninstall.assert_called_once_with()
+        assert "uninstalled" in capsys.readouterr().out
+
+    def test_non_interactive_without_yes_refuses(self, parse_argv, capsys, tmp_path, monkeypatch):
+        args = parse_argv(["uninstall"])
+        monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: False))
+        with patch("vastai.cli.commands.uninstall.is_managed_install", return_value=True), \
+             patch("vastai.cli.commands.uninstall.install_root", return_value=tmp_path), \
+             patch("vastai.cli.commands.uninstall.perform_uninstall") as mock_uninstall:
+            assert args.func(args) == 1
+        mock_uninstall.assert_not_called()
+        assert "--yes" in capsys.readouterr().err
+
+    def test_declining_the_prompt_aborts(self, parse_argv, capsys, tmp_path, monkeypatch):
+        args = parse_argv(["uninstall"])
+        monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: True))
+        with patch("vastai.cli.commands.uninstall.is_managed_install", return_value=True), \
+             patch("vastai.cli.commands.uninstall.install_root", return_value=tmp_path), \
+             patch("builtins.input", return_value="n"), \
+             patch("vastai.cli.commands.uninstall.perform_uninstall") as mock_uninstall:
+            assert args.func(args) == 1
+        mock_uninstall.assert_not_called()
+        assert "Aborted" in capsys.readouterr().out
+
+    def test_confirming_the_prompt_proceeds(self, parse_argv, capsys, tmp_path, monkeypatch):
+        args = parse_argv(["uninstall"])
+        monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: True))
+        with patch("vastai.cli.commands.uninstall.is_managed_install", return_value=True), \
+             patch("vastai.cli.commands.uninstall.install_root", return_value=tmp_path), \
+             patch("builtins.input", return_value="y"), \
+             patch("vastai.cli.commands.uninstall.perform_uninstall") as mock_uninstall:
+            assert args.func(args) == 0
+        mock_uninstall.assert_called_once_with()
+        assert "uninstalled" in capsys.readouterr().out
+
+    def test_eof_on_prompt_aborts_rather_than_raising(self, parse_argv, tmp_path, monkeypatch):
+        args = parse_argv(["uninstall"])
+        monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: True))
+        with patch("vastai.cli.commands.uninstall.is_managed_install", return_value=True), \
+             patch("vastai.cli.commands.uninstall.install_root", return_value=tmp_path), \
+             patch("builtins.input", side_effect=EOFError), \
+             patch("vastai.cli.commands.uninstall.perform_uninstall") as mock_uninstall:
+            assert args.func(args) == 1
+        mock_uninstall.assert_not_called()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1789,6 +1789,7 @@ def cli_parser():
         benchmarks,
         price_increase,
         update,
+        uninstall,
     )
     from vastai.cli.util import server_url_default, api_key_guard
     parser.add_argument("--url", help="Server REST API URL", default=server_url_default)

--- a/vastai/cli/commands/uninstall.py
+++ b/vastai/cli/commands/uninstall.py
@@ -9,9 +9,9 @@ import sys
 
 from vastai.cli.parser import argument
 from vastai.cli.display import deindent
-from vastai.cli.util import VERSION
+from vastai.cli.util import DIRS, VERSION
 from vastai.cli.selfupdate import (
-    INSTALL_SH_HINT, is_managed_install, install_root, perform_uninstall,
+    INSTALL_SH_HINT, UninstallError, is_managed_install, install_root, perform_uninstall,
 )
 from vastai.cli.utils import get_parser as _get_parser
 
@@ -28,7 +28,7 @@ PIP_UNINSTALL_HINT = "pip uninstall vastai"
     epilog=deindent(f"""
         Removes a CLI installed with the managed installer
         ({INSTALL_SH_HINT}): the install root and its symlinks in
-        ~/.local/bin. Config in ~/.config/vastai (your API key) is left
+        ~/.local/bin. Config in {DIRS['config']} (your API key) is left
         untouched, so re-running the installer keeps you logged in.
         For pip installs, uninstall with: {PIP_UNINSTALL_HINT}
     """),
@@ -59,7 +59,12 @@ def uninstall(args):
             print("Aborted.")
             return 1
 
-    perform_uninstall()
-    print(f"vastai {VERSION} uninstalled from {root}.")
-    print("Config in ~/.config/vastai was left untouched.")
+    try:
+        removed = perform_uninstall()
+    except UninstallError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+
+    print(f"vastai {VERSION} uninstalled from {removed}.")
+    print(f"Config in {DIRS['config']} was left untouched.")
     return 0

--- a/vastai/cli/commands/uninstall.py
+++ b/vastai/cli/commands/uninstall.py
@@ -1,0 +1,65 @@
+"""`vastai uninstall` — remove a managed (curl | bash installer) install.
+
+pip installs aren't managed by the installer; for those this command only
+prints the correct pip uninstall instructions and exits non-zero — it never
+shells out to pip, matching `update`'s same-method discipline.
+"""
+
+import sys
+
+from vastai.cli.parser import argument
+from vastai.cli.display import deindent
+from vastai.cli.util import VERSION
+from vastai.cli.selfupdate import (
+    INSTALL_SH_HINT, is_managed_install, install_root, perform_uninstall,
+)
+from vastai.cli.utils import get_parser as _get_parser
+
+parser = _get_parser()
+
+PIP_UNINSTALL_HINT = "pip uninstall vastai"
+
+
+@parser.command(
+    argument("-y", "--yes", action="store_true", help="skip the confirmation prompt"),
+    usage="vastai uninstall [-y]",
+    help="Remove the managed CLI install",
+    hidden=True,  # still under testing — remove once ready to announce
+    epilog=deindent(f"""
+        Removes a CLI installed with the managed installer
+        ({INSTALL_SH_HINT}): the install root and its symlinks in
+        ~/.local/bin. Config in ~/.config/vastai (your API key) is left
+        untouched, so re-running the installer keeps you logged in.
+        For pip installs, uninstall with: {PIP_UNINSTALL_HINT}
+    """),
+)
+def uninstall(args):
+    if not is_managed_install():
+        print(
+            "This CLI was not installed with the managed installer, so this "
+            f"command can't remove it.\n  Installed via pip? Run: {PIP_UNINSTALL_HINT}",
+            file=sys.stderr,
+        )
+        return 1
+
+    root = install_root()
+    if not args.yes:
+        if not sys.stdin.isatty():
+            print(
+                "Refusing to uninstall without confirmation in a non-interactive "
+                "shell. Re-run with --yes to skip the prompt.",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            answer = input(f"Remove vastai {VERSION} from {root}? [y/N] ").strip().lower()
+        except EOFError:
+            answer = ""
+        if answer not in ("y", "yes"):
+            print("Aborted.")
+            return 1
+
+    perform_uninstall()
+    print(f"vastai {VERSION} uninstalled from {root}.")
+    print("Config in ~/.config/vastai was left untouched.")
+    return 0

--- a/vastai/cli/commands/update.py
+++ b/vastai/cli/commands/update.py
@@ -27,6 +27,7 @@ EXIT_STALE = 10  # `update --check` exit code when a newer version exists
     argument("--version", dest="target_version", metavar="VERSION", help="install a specific version instead of the latest (also how you pin or roll back)"),
     usage="vastai update [--check | --version VERSION]",
     help="Update the CLI to the latest version",
+    hidden=True,  # still under testing — remove once ready to announce
     epilog=deindent("""
         Updates a CLI installed with the managed installer
         (curl -fsSL https://vast.ai/install.sh | bash). The new version is

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -80,6 +80,7 @@ def main():
         benchmarks,
         price_increase,
         update,
+        uninstall,
         # clusters,  # cluster/overlay commands disabled for now
     )
 

--- a/vastai/cli/selfupdate.py
+++ b/vastai/cli/selfupdate.py
@@ -46,6 +46,9 @@ NUDGE_TIMEOUT_S = 1.0
 # Console scripts shipped in the wheel; each gets a swapped symlink in bin/.
 MANAGED_BINARIES = ("vastai", "serve-vast-deployment", "register-python-argcomplete")
 
+# Fixed, not XDG-overridable — every other XDG-aware CLI lands its symlink here too.
+LOCAL_BIN = Path.home() / ".local" / "bin"
+
 
 class UpdateError(Exception):
     """A self-update step failed; the current install is untouched."""
@@ -321,3 +324,28 @@ def perform_update(target: str, manifest: dict) -> None:
     _link_binaries(root)
     shutil.rmtree(old_dir, ignore_errors=True)
     _prune_uv_cache(uv, uv_env)
+
+
+# ---------------------------------------------------------------------------
+# Uninstall (managed installs only)
+# ---------------------------------------------------------------------------
+
+def perform_uninstall() -> Path:
+    """Remove the managed install: the install root and its bin/ symlinks.
+
+    Config (~/.config/vastai), cache (~/.cache/vastai), and state
+    (~/.local/state/vastai) are left alone — the same guarantee documented
+    for a manual ``rm -rf`` (docs/install-design.md §3). Safe to call while
+    running from inside ``root``: like the update swap above, removing the
+    directory doesn't disturb an already-running interpreter on POSIX.
+    """
+    root = install_root()
+    for name in MANAGED_BINARIES:
+        link = LOCAL_BIN / name
+        try:
+            if link.is_symlink() and root in link.resolve().parents:
+                link.unlink()
+        except OSError:
+            pass
+    shutil.rmtree(root, ignore_errors=True)
+    return root

--- a/vastai/cli/selfupdate.py
+++ b/vastai/cli/selfupdate.py
@@ -54,6 +54,10 @@ class UpdateError(Exception):
     """A self-update step failed; the current install is untouched."""
 
 
+class UninstallError(Exception):
+    """A step of vastai uninstall failed; nothing further was attempted."""
+
+
 # ---------------------------------------------------------------------------
 # Install detection / manifest / versions
 # ---------------------------------------------------------------------------
@@ -333,19 +337,28 @@ def perform_update(target: str, manifest: dict) -> None:
 def perform_uninstall() -> Path:
     """Remove the managed install: the install root and its bin/ symlinks.
 
-    Config (~/.config/vastai), cache (~/.cache/vastai), and state
-    (~/.local/state/vastai) are left alone — the same guarantee documented
-    for a manual ``rm -rf`` (docs/install-design.md §3). Safe to call while
-    running from inside ``root``: like the update swap above, removing the
-    directory doesn't disturb an already-running interpreter on POSIX.
+    Config, cache, and state (``vastai.cli.util.DIRS`` — each independently
+    XDG-overridable) are left alone — the same guarantee documented for a
+    manual ``rm -rf`` (docs/install-design.md §3). Safe to call while running
+    from inside ``root``: like the update swap above, removing the directory
+    doesn't disturb an already-running interpreter on POSIX.
+
+    Raises ``UninstallError`` on any real failure (permissions, a symlink
+    loop, …) instead of silently reporting success — callers should treat
+    this as fallible, not a fire-and-forget best-effort cleanup.
     """
-    root = install_root()
+    root = install_root().resolve()
     for name in MANAGED_BINARIES:
         link = LOCAL_BIN / name
         try:
             if link.is_symlink() and root in link.resolve().parents:
                 link.unlink()
-        except OSError:
-            pass
-    shutil.rmtree(root, ignore_errors=True)
+        except OSError as e:
+            raise UninstallError(f"Could not remove {link}: {e}")
+    try:
+        shutil.rmtree(root)
+    except FileNotFoundError:
+        pass  # already gone — nothing left to remove
+    except OSError as e:
+        raise UninstallError(f"Could not remove {root}: {e}")
     return root


### PR DESCRIPTION
## Summary
- Adds `vastai uninstall`, mirroring `vastai update`'s structure and same-method discipline: on a managed (curl | bash installer) install it removes the install root and its `~/.local/bin` symlinks while leaving `~/.config/vastai` (API key), cache, and state untouched; on a pip install it refuses and points at `pip uninstall vastai` instead of shelling out.
- Prompts for confirmation unless `-y`/`--yes`; refuses in a non-interactive shell without `--yes`.
- `perform_uninstall()` added to `selfupdate.py` next to the existing `perform_update()`.
- Both `update` and `uninstall` are hidden from `--help`/tab-completion for now (same `hidden=True` discoverability gate used for the network-volume commands in #466) — still fully runnable if typed directly, until they've had more real-world testing.

## Test plan
- [x] `poetry run pytest tests/cli/` — 389 passed
- [x] New `tests/cli/test_uninstall_command.py` covers: pip-install refusal, `--yes` skipping the prompt, non-interactive refusal without `--yes`, confirm/decline/EOF on the prompt, and `perform_uninstall()`'s filesystem behavior (removes root, removes only symlinks that resolve into the root, leaves foreign same-named binaries and config alone)
- [x] New hidden-command tests in `test_parser.py` confirm `update`/`uninstall` are excluded from `--help` but still parse
- [x] Manually verified end-to-end: built a dev wheel from this branch (`scripts/dev-install.sh --from-source`), confirmed `uninstall` is hidden from `--help` but runs directly, ran `vastai uninstall --yes` against a real managed install and confirmed the install root was removed and config was left in place, then reinstalled via `scripts/install.sh` and confirmed the wheel-install progress UX still works