### PR TITLE
Stop advertising unreleased network volume type in 'show volumes --type'

### DIFF
--- a/vastai/cli/commands/storage.py
+++ b/vastai/cli/commands/storage.py
@@ -627,7 +627,7 @@ def clone__volume(args):
 # ---------------------------------------------------------------------------
 
 @parser.command(
-    argument("-t", "--type", help="volume type to display. Default to all. Possible values are \"local\", \"all\", \"network\"", type=str, default="all"),
+    argument("-t", "--type", help="volume type to display. Default to all. Possible values are \"local\", \"all\"", type=str, default="all"),
     usage="vastai show volumes [OPTIONS]",
     help="Show stats on owned volumes.",
     epilog=deindent("""


### PR DESCRIPTION
## Summary

Follow-up to #466. That PR hid the four dedicated network-volume commands (`search network-volumes`, `create network-volume`, `list network-volume`, `unlist network-volume`) from `--help`/completion, but missed a second discovery path: the already-released, always-visible `vastai show volumes` command takes `--type local|all|network`, and its help text advertised `"network"` as a valid value.

Confirmed against `~/workspace/vast/web`: there's no dedicated "show network volume" endpoint — network volume data rides along inside the existing `/volumes` endpoint via that `type` filter, which is why this didn't show up as a separate hideable command.

Fix mirrors #466's approach: stop advertising the value in the help text; don't restrict/block it (no `choices=` on the argument), so `--type network` still works for anyone who already knows about it (internal/QA testing unaffected) — discoverability gate, not an access gate.

## Test plan
- [x] `poetry run pytest tests/cli` — 413 passed
- [x] Manually verified `vastai show volumes --help` no longer mentions "network"