### PR TITLE
Hide unreleased network-disk commands from --help

### DIFF
--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -210,6 +210,8 @@ class TestIsHiddenCommand:
         assert is_hidden_command("create network-volume") is True
         assert is_hidden_command("list network-volume") is True
         assert is_hidden_command("unlist network-volume") is True
+        assert is_hidden_command("show network-disks") is True
+        assert is_hidden_command("add network-disk") is True
 
     def test_unregistered_command_defaults_to_visible(self):
         assert is_hidden_command("show instances") is False
@@ -259,6 +261,15 @@ class TestFullCliHiddenCommands:
 
     def test_network_volume_commands_still_parse_directly(self, cli_parser):
         args = cli_parser.parse_args(["search", "network-volumes"])
+        assert callable(args.func)
+
+    def test_network_disk_commands_are_hidden_from_help(self, cli_parser):
+        help_text = cli_parser.parser.format_help()
+        assert "network-disk" not in help_text
+
+    def test_network_disk_commands_still_parse_directly(self, cli_parser):
+        assert callable(cli_parser.parse_args(["show", "network-disks"]).func)
+        args = cli_parser.parse_args(["add", "network-disk", "1", "/mnt/data"])
         assert callable(args.func)
 
     def test_update_and_uninstall_are_hidden_from_help(self, cli_parser):

--- a/vastai/cli/parser.py
+++ b/vastai/cli/parser.py
@@ -183,6 +183,8 @@ HIDDEN_COMMANDS = {
     'create network-volume',
     'list network-volume',
     'unlist network-volume',
+    'show network-disks',      # network disks are not yet released
+    'add network-disk',
 }
 
 


### PR DESCRIPTION
## Summary

Follow-up to #466 (network volumes). Network disks aren't released either — `show network-disks` and `add network-disk` were still fully visible in `vastai --help` and tab completion.

Reuses the same `HIDDEN_COMMANDS` mechanism from #466: discoverability gate only, not an access gate — both commands still run if typed directly.

## Test plan
- [x] `poetry run pytest tests/cli` — 415 passed
- [x] Manually verified: neither command appears anywhere in `vastai --help`; both still parse and run when typed directly