### PR TITLE
installer: show a progress bar with one live log line, not scrolling uv output

### DIFF
--- a/docs/install-design.md
+++ b/docs/install-design.md
@@ -75,6 +75,26 @@ curl -fsSL https://vast.ai/install.sh | bash
    immediately (no PyPI index propagation window) — into an isolated venv.
    **System Python is never used, even if present.**
 
+### Install output at a terminal
+
+The bootstrap tools are chatty — a 33 MB CPython download, then ~40 `+ pkg==ver`
+lines — and that scrolled the "Get started" block off the screen, which is the
+one thing a first-time installer needs to read. So at a TTY the install renders
+as a fixed two-line region on stderr: a step bar plus a single live log line
+that tails whatever `uv` is doing (`Downloading cpython-… (32.6MiB)`, then
+package names). The region is erased when the install finishes, leaving ~9
+lines total, ending with the next steps.
+
+- A background ticker animates the spinner; steps and tool output reach it
+  through state files under the temp workdir, so a step change repaints
+  immediately and the two writers can never split a frame.
+- Tool output is tailed through `tee`, with the full copy replayed if that step
+  fails — a wrapped command's own diagnostics are the real error, so they must
+  outlive the region.
+- No TTY (CI, pipes) → plain step lines and tool output straight through, as
+  before; `VASTAI_PROGRESS=0|1` forces either mode. Ctrl-C is trapped so the
+  region is erased and the cursor restored on the way out.
+
 ### Fail-closed guarantees
 
 - Whole script wrapped in `main()`, invoked on the **last line** — a truncated
@@ -288,6 +308,7 @@ is.
 - `VASTAI_CLI_BASE_URL` — manifest origin (dev/release verification).
 - `VASTAI_PIP_SPEC` — dev/CI: install from a local wheel path/URL.
 - `VASTAI_GLIBC_FLOOR` — override the minimum-glibc gate (default 2.31).
+- `VASTAI_PROGRESS=0|1` — force the progress bar off/on (default: on at a TTY, §2).
 - `VASTAI_NO_UPDATE_CHECK=1` — suppress the nudge.
 - `--no-modify-path` — skip PATH/completion edits.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,6 +20,7 @@
 #   VASTAI_PIP_SPEC=...        what to install instead of vastai==VERSION
 #                              (dev/CI only: e.g. a local wheel path)
 #   VASTAI_GLIBC_FLOOR=2.31    minimum glibc; below this, bail to pip
+#   VASTAI_PROGRESS=0|1        force the progress bar off/on (default: on at a TTY)
 #
 # Uninstall:  rm -rf "$XDG_DATA_HOME/vastai" ~/.local/bin/vastai
 #             (default XDG_DATA_HOME is ~/.local/share; use whatever
@@ -38,23 +39,172 @@ WORKDIR=""
 RC_UPDATED=""
 NEEDS_PATH_HINT=""
 
-say()  { printf '  %s\n' "$*"; }
-warn() { printf '  warning: %s\n' "$*" >&2; }
-die()  { printf '  error: %s\n' "$*" >&2; exit 1; }
+# Anything that prints first tears down the live progress region (no-op when it's not up).
+say()  { ui_end; printf '  %s\n' "$*"; }
+warn() { ui_end; printf '  warning: %s\n' "$*" >&2; }
+die()  { ui_end; printf '  error: %s\n' "$*" >&2; exit 1; }
 
-cleanup() { [ -n "$WORKDIR" ] && rm -rf "$WORKDIR"; }
+cleanup() { ui_end; [ -n "$WORKDIR" ] && rm -rf "$WORKDIR"; }
 trap cleanup EXIT
+# Ctrl-C must reach cleanup too, or a hidden cursor and a half-drawn region outlive us.
+trap 'exit 130' INT
+trap 'exit 143' TERM HUP
+
+# Progress UI (§"Install output at a terminal" in install-design.md): at a TTY, steps render as
+# a bar plus one live log line, so uv's chatter can't scroll the "Get started" block off the
+# screen; without one, plain step lines. VASTAI_PROGRESS=0 forces plain, =1 forces the bar.
+UI_DIR=""            # non-empty only while the live region is up
+UI_PID=""
+UI_TICK=0.2
+UI_COLS=80
+UI_LOGFILE=""
+UI_FULL='#'; UI_EMPTY='.'; UI_ARROW='>'
+UI_FRAMES=('-' "\\" '|' '/')
+
+ui_on() { [ -n "$UI_DIR" ]; }
+
+ui_wanted() {
+    case "${VASTAI_PROGRESS:-}" in 0) return 1 ;; 1) return 0 ;; esac
+    [ -t 2 ] || return 1
+    case "${TERM:-}" in ''|dumb) return 1 ;; esac
+    return 0
+}
+
+# ui_cols — window width, first plausible probe wins; /dev/tty leads because under
+# `curl | bash` our stdin is the pipe, and a sized-0 pty must fall through to terminfo.
+ui_cols() {
+    local c="" probe
+    for probe in "$({ stty size < /dev/tty 2>/dev/null || true; } | awk '{print $2}')" \
+                 "$({ tput cols 2>/dev/null || true; } | head -1)"; do
+        case "$probe" in ''|0|*[!0-9]*) continue ;; esac
+        c="$probe"; break
+    done
+    [ -n "$c" ] || c=80
+    [ "$c" -ge 40 ] || c=40
+    printf '%s' "$c"
+}
+
+# ui_repeat N CHAR — CHAR N times (built in-shell: `tr` mangles multibyte glyphs).
+ui_repeat() {
+    local n="$1" ch="$2" out="" i=0
+    while [ "$i" -lt "$n" ]; do out="$out$ch"; i=$(( i + 1 )); done
+    printf '%s' "$out"
+}
+
+ui_get() {
+    local v=""
+    [ -f "$UI_DIR/$1" ] && { IFS= read -r v < "$UI_DIR/$1" || true; }
+    printf '%s' "$v"
+}
+
+# ui_set KEY VALUE — rename into place so the ticker never reads a half-written line.
+ui_set() {
+    { printf '%s\n' "$2" > "$UI_DIR/$1.tmp" && mv -f "$UI_DIR/$1.tmp" "$UI_DIR/$1"; } 2>/dev/null || true
+}
+
+# ui_draw — repaint bar + log line; whoever changes state redraws (a sub-tick step still shows)
+# and so does the ticker, so each repaint is one printf and the two writers can't split a frame.
+ui_draw() {
+    local pct step log frame width filled smax lmax
+    pct="$(ui_get pct)"; step="$(ui_get step)"; log="$(ui_get log)"; frame="$(ui_get frame)"
+    case "$pct" in ''|*[!0-9]*) pct=0 ;; esac
+    [ -n "$frame" ] || frame="${UI_FRAMES[0]}"
+    width=$(( UI_COLS / 3 ))
+    [ "$width" -gt 32 ] && width=32
+    [ "$width" -lt 10 ] && width=10
+    filled=$(( pct * width / 100 ))
+    smax=$(( UI_COLS - width - 12 )); [ "$smax" -ge 8 ] || smax=8
+    lmax=$(( UI_COLS - 7 ));          [ "$lmax" -ge 8 ] || lmax=8
+    printf '\r\033[K  %s %s%s %3d%%  %s\n\r\033[K    %s %s\033[A\r' \
+        "$frame" "$(ui_repeat "$filled" "$UI_FULL")" "$(ui_repeat $(( width - filled )) "$UI_EMPTY")" \
+        "$pct" "${step:0:$smax}" "$UI_ARROW" "${log:0:$lmax}" >&2
+}
+
+ui_ticker() {
+    local i=0
+    while [ -f "$UI_DIR/on" ]; do
+        [ $(( i % 20 )) -eq 0 ] && UI_COLS="$(ui_cols)"
+        ui_set frame "${UI_FRAMES[$(( i % ${#UI_FRAMES[@]} ))]}"
+        ui_draw
+        i=$(( i + 1 ))
+        sleep "$UI_TICK"
+    done
+}
+
+ui_start() {
+    ui_wanted || return 0
+    mkdir -p "$WORKDIR/ui" || return 0
+    UI_DIR="$WORKDIR/ui"
+    case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+        *[Uu][Tt][Ff]*8*) UI_FULL='━'; UI_EMPTY='─'; UI_ARROW='↳'
+                          UI_FRAMES=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧') ;;
+    esac
+    # Sub-second sleep is not universal (some minimal /bin/sleep); fall back to 1s ticks.
+    sleep 0.2 2>/dev/null || UI_TICK=1
+    UI_COLS="$(ui_cols)"
+    ui_set pct 0; ui_set step "Starting"; ui_set log ""
+    : > "$UI_DIR/on"
+    printf '\033[?25l' >&2      # cursor hidden until ui_end
+    ui_ticker &
+    UI_PID=$!
+}
+
+# ui_end — stop the ticker, erase the region, restore the cursor; idempotent, and every path
+# that prints (say/warn/die, the EXIT trap) runs it first.
+ui_end() {
+    ui_on || return 0
+    rm -f "$UI_DIR/on"
+    UI_DIR=""
+    if [ -n "$UI_PID" ]; then
+        kill "$UI_PID" 2>/dev/null || true
+        wait "$UI_PID" 2>/dev/null || true
+        UI_PID=""
+    fi
+    printf '\r\033[K\n\r\033[K\033[A\r\033[?25h' >&2
+}
+
+# ui_step PCT LABEL — advance the bar, or announce the step when there's no bar.
+ui_step() {
+    if ui_on; then ui_set pct "$1"; ui_set step "$2"; ui_set log ""; ui_draw
+    else say "$2..."; fi
+}
+
+# ui_log LINE — replace the live log line (no-op without the bar).
+ui_log() { ui_on && { ui_set log "$1"; ui_draw; }; return 0; }
+
+# ui_run CMD... — tail CMD's output onto the log line, keeping a full copy in $UI_LOGFILE for
+# ui_fail; runs CMD untouched without the bar, and exits with CMD's status (pipefail).
+ui_run() {
+    ui_on || { "$@"; return; }
+    local line
+    UI_LOGFILE="$WORKDIR/last-command.log"
+    # No filters in this pipe: tr/sed block-buffer into a pipe, holding every line until CMD exits.
+    "$@" 2>&1 | tee "$UI_LOGFILE" | while IFS= read -r line || [ -n "$line" ]; do
+        line="${line##*$'\r'}"          # redrawn in place: keep only the last segment
+        line="${line//$'\033'/}"        # no escape codes inside our own region
+        case "$line" in *[![:space:]]*) ui_set log "$line"; ui_draw ;; esac
+    done
+}
+
+# ui_fail — tear the region down and replay the failed command's output tail, the real error.
+ui_fail() {
+    local f="$UI_LOGFILE"
+    ui_end
+    [ -n "$f" ] && [ -s "$f" ] && { printf '\n' >&2; tail -n 20 "$f" >&2; printf '\n' >&2; }
+    return 0
+}
 
 need_cmd() {
     command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
 }
 
-# download URL DEST [progress] — non-empty progress shows a bar (TTY only).
+# download URL DEST [progress] — non-empty progress shows curl's bar (TTY only, and never while
+# our own bar owns the screen).
 download() {
     local url="$1" dest="$2" progress="${3:-}"
     if command -v curl >/dev/null 2>&1; then
         local vflags=(-fsS)
-        [ -n "$progress" ] && [ -t 2 ] && vflags=(-f --progress-bar)
+        [ -n "$progress" ] && [ -t 2 ] && ! ui_on && vflags=(-f --progress-bar)
         case "$url" in
             https://*) curl --proto '=https' --tlsv1.2 "${vflags[@]}" -L --retry 3 -o "$dest" "$url" ;;
             *)         curl "${vflags[@]}" -L --retry 3 -o "$dest" "$url" ;;
@@ -177,11 +327,14 @@ install_uv() {
         die "no build available for your platform ($PLATFORM_KEY) — install with pip instead: pip install vastai"
     fi
 
-    say "Downloading runtime..."
+    ui_step 5 "Downloading runtime"
     tarball="$WORKDIR/uv.tar.gz"
+    ui_log "$url"
     download "$url" "$tarball" progress
+    ui_log "verifying checksum"
     verify_sha "$tarball" "$sha" "uv"
 
+    ui_log "unpacking"
     mkdir -p "$WORKDIR/uv-extract"
     tar -xzf "$tarball" -C "$WORKDIR/uv-extract" \
         || die "could not unpack the runtime — tar+gzip required; install them or use pip: pip install vastai"
@@ -203,27 +356,30 @@ install_version() {
     local version="$1" python_pin="$2" wheel_url="${3:-}" wheel_sha="${4:-}"
     local envdir="$ROOT/current" newdir="$ROOT/.current.new"
 
-    say "Installing vastai $version (Python $python_pin) → $ROOT"
     rm -rf "$newdir"
     export UV_PYTHON_INSTALL_DIR="$ROOT/python"
     export UV_PYTHON_PREFERENCE="only-managed"
-    # Provision the managed CPython first — the slow, download-heavy step, so show
-    # its progress at a TTY (quiet in CI). The venv build is then always quiet:
-    # uv venv's own "Activate with: source .../.current.new/..." line is misleading
-    # here — .current.new is renamed to current/ below, and vastai is a symlinked
-    # CLI you run, never a venv you "activate".
+    # Provision the managed CPython first — the slow, download-heavy step, so its
+    # output feeds the live log line (quiet in CI). The venv build is then always
+    # quiet: uv venv's own "Activate with: source .../.current.new/..." line is
+    # misleading here — .current.new is renamed to current/ below, and vastai is a
+    # symlinked CLI you run, never a venv you "activate".
     # ${arr[@]+...} guard: bash 3.2 (macOS default) treats an empty array as
     # unset under `set -u`, so a bare "${pyquiet[@]}" would abort the install.
     # --no-bin: the venv finds the interpreter via UV_PYTHON_INSTALL_DIR;
     # shims in ~/.local/bin would only add uv's misleading PATH warning.
+    ui_step 20 "Installing Python $python_pin"
     local pyquiet=(--quiet)
-    [ -t 2 ] && pyquiet=()
-    if ! "$ROOT/bin/uv" python install "$python_pin" --no-bin ${pyquiet[@]+"${pyquiet[@]}"}; then
+    ui_on && pyquiet=()
+    if ! ui_run "$ROOT/bin/uv" python install "$python_pin" --no-bin ${pyquiet[@]+"${pyquiet[@]}"}; then
+        ui_fail
         rm -rf "$newdir"
         die "could not provision the Python $python_pin runtime"
     fi
     # --relocatable: no hardcoded build path in shebangs (current/ is renamed into place).
-    if ! "$ROOT/bin/uv" venv "$newdir" --python "$python_pin" --relocatable --quiet; then
+    ui_step 55 "Creating environment"
+    if ! ui_run "$ROOT/bin/uv" venv "$newdir" --python "$python_pin" --relocatable --quiet; then
+        ui_fail
         rm -rf "$newdir"
         die "could not set up the Python $python_pin runtime"
     fi
@@ -234,10 +390,13 @@ install_version() {
     if [ -z "${VASTAI_PIP_SPEC:-}" ] && [ -n "$wheel_url" ] && [ -n "$wheel_sha" ]; then
         spec="vastai @ ${wheel_url}#sha256=${wheel_sha}"
     fi
-    if ! "$ROOT/bin/uv" pip install --python "$newdir/bin/python" "$spec"; then
+    ui_step 60 "Installing vastai $version"
+    if ! ui_run "$ROOT/bin/uv" pip install --python "$newdir/bin/python" "$spec"; then
+        ui_fail
         rm -rf "$newdir"
         die "could not install $spec (is the version correct?)"
     fi
+    ui_log "checking the installed CLI"
     "$newdir/bin/vastai" --version >/dev/null \
         || { rm -rf "$newdir"; die "installed CLI failed its smoke test"; }
 
@@ -362,9 +521,13 @@ main() {
         wheel_sha="$(manifest_get WHEEL_SHA256)"
     fi
 
+    say "Installing vastai $version (Python $python_pin) → $ROOT"
+    ui_start
     install_uv
     install_version "$version" "$python_pin" "$wheel_url" "$wheel_sha"
+    ui_step 95 "Finishing setup"
     generate_completions
+    ui_end       # the rest prints: PATH hints, coexistence warnings, next steps
     setup_path
     check_pip_coexistence
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -154,12 +154,12 @@ ui_start() {
 ui_end() {
     ui_on || return 0
     rm -f "$UI_DIR/on"
-    UI_DIR=""
     if [ -n "$UI_PID" ]; then
         kill "$UI_PID" 2>/dev/null || true
         wait "$UI_PID" 2>/dev/null || true
         UI_PID=""
     fi
+    UI_DIR=""       # last: while it's set, a re-entry (signal mid-wait) still restores the cursor
     printf '\r\033[K\n\r\033[K\033[A\r\033[?25h' >&2
 }
 

--- a/tests/installer/run_tests.sh
+++ b/tests/installer/run_tests.sh
@@ -42,13 +42,21 @@ build_fake_uv() {
     mkdir -p "$dir"
     cat > "$dir/uv" <<'EOF'
 #!/bin/sh
-# Fake uv: handles `uv venv DIR ...` and `uv pip install --python PY ... SPEC`
+# Fake uv: handles `uv python install ...`, `uv venv DIR ...` and `uv pip install --python PY
+# ... SPEC`; the chatter mimics real uv's line-per-event output (which the installer tails onto
+# its progress line) and a spec containing "fail-me" fails loudly.
 set -e
-if [ "$1" = "venv" ]; then
+if [ "$1" = "python" ]; then
+    echo "Downloading cpython-fake (32.6MiB)"
+    echo "Installed Python in 1ms"
+elif [ "$1" = "venv" ]; then
     mkdir -p "$2/bin"
     printf '#!/bin/sh\nexit 0\n' > "$2/bin/python"
     chmod +x "$2/bin/python"
 elif [ "$1" = "pip" ]; then
+    case " $* " in *fail-me*) echo "fake uv: no solution found" >&2; exit 1 ;; esac
+    echo "Resolved 3 packages in 1ms"
+    echo " + fake-dep==1.0"
     py="" prev="" last=""
     for a in "$@"; do
         [ "$prev" = "--python" ] && py="$a"
@@ -124,6 +132,20 @@ run_install() {
     fi
 }
 
+# run_install_tty [VAR=VAL ...] — real install.sh with stderr on a pty (so the progress UI
+# engages), under ${VASTAI_TEST_TTY_BASH:-/bin/bash} — macOS CI points that at stock bash 3.2,
+# which is the regression guarantee for the TTY-only array and $'...' paths. Needs script(1).
+run_install_tty() {
+    local cmd=(env "HOME=$SB_HOME" "VASTAI_INSTALL_DIR=$SB_ROOT" \
+        "VASTAI_CLI_BASE_URL=$SERVER/good" "SHELL=/bin/bash" "$@" \
+        "${VASTAI_TEST_TTY_BASH:-/bin/bash}" "$INSTALL_SH")
+    case "$(uname -s)" in
+        Darwin*) script -q /dev/null "${cmd[@]}" >"$SB_OUT" 2>&1 </dev/null ;;
+        # util-linux script wants one string; sandbox paths contain no spaces.
+        *)       script -qec "${cmd[*]}" /dev/null >"$SB_OUT" 2>&1 </dev/null ;;
+    esac
+}
+
 assert() { # assert DESC command...
     local desc="$1"; shift
     "$@" || { echo "    assert failed: $desc"; return 1; }
@@ -131,6 +153,9 @@ assert() { # assert DESC command...
 
 out_contains() { grep -q "$1" "$SB_OUT"; }
 out_lacks()    { ! grep -qa "$1" "$SB_OUT"; }
+# ..._raw: fixed strings, for escape sequences that BRE would misread.
+out_contains_raw() { grep -qaF "$1" "$SB_OUT"; }
+out_lacks_raw()    { ! grep -qaF "$1" "$SB_OUT"; }
 
 # ---------------------------------------------------------------------------
 # Scenarios
@@ -144,7 +169,8 @@ test_fresh_install() { # happy path: fixed current symlink, runnable CLI, manage
     assert "installed CLI runs" [ "$("$SB_ROOT/bin/vastai" --version)" = "1.2.3" ] &&
     assert "managed-install markers present (current/ + bin/uv)" \
         [ -d "$SB_ROOT/current" ] && [ -x "$SB_ROOT/bin/uv" ] &&
-    assert "local bin link exists" [ -L "$SB_HOME/.local/bin/vastai" ]
+    assert "local bin link exists" [ -L "$SB_HOME/.local/bin/vastai" ] &&
+    assert "no escape codes when detached from a tty" out_lacks_raw "$(printf '\033')"
 }
 
 test_pinned_reinstall() { # VASTAI_VERSION pin replaces current in place, no retention
@@ -265,13 +291,7 @@ test_pip_shadowing_quiet() { # rc update resolves coexistence -> no warning, jus
     chmod +x "$SB/pipbin/vastai"
     # A pty lets the installer write the rc line, settling precedence — no warning.
     # PATH is pinned to sandbox dirs + system bins so the pip fake outranks ours.
-    local cmd=(env "HOME=$SB_HOME" "VASTAI_INSTALL_DIR=$SB_ROOT" \
-        "VASTAI_CLI_BASE_URL=$SERVER/good" "SHELL=/bin/bash" \
-        "PATH=$SB/pipbin:$SB_HOME/.local/bin:/usr/bin:/bin" /bin/bash "$INSTALL_SH")
-    case "$(uname -s)" in
-        Darwin*) script -q /dev/null "${cmd[@]}" >"$SB_OUT" 2>&1 </dev/null ;;
-        *)       script -qec "${cmd[*]}" /dev/null >"$SB_OUT" 2>&1 </dev/null ;;
-    esac
+    run_install_tty "PATH=$SB/pipbin:$SB_HOME/.local/bin:/usr/bin:/bin"
     assert "rc gained the env.sh line" grep -q 'env\.sh' "$SB_HOME/.bashrc" &&
     assert "no coexistence warning once resolved" out_lacks "another vastai" &&
     assert "current-shell hint printed" out_contains "Use it now"
@@ -284,25 +304,13 @@ test_pip_shadowing_rerun() { # re-run with new shadowing: rc line idempotent, no
     # .bashrc as a symlink (dotfile-manager layout): the append must write through it.
     touch "$SB_HOME/dotfiles/bashrc"
     ln -s dotfiles/bashrc "$SB_HOME/.bashrc"
-    local cmd=(env "HOME=$SB_HOME" "VASTAI_INSTALL_DIR=$SB_ROOT" \
-        "VASTAI_CLI_BASE_URL=$SERVER/good" "SHELL=/bin/bash" \
-        "PATH=$SB_HOME/.local/bin:/usr/bin:/bin" /bin/bash "$INSTALL_SH")
-    case "$(uname -s)" in
-        Darwin*) script -q /dev/null "${cmd[@]}" >"$SB_OUT" 2>&1 </dev/null ;;
-        *)       script -qec "${cmd[*]}" /dev/null >"$SB_OUT" 2>&1 </dev/null ;;
-    esac
+    run_install_tty "PATH=$SB_HOME/.local/bin:/usr/bin:/bin"
     assert "rc gained the env.sh line" grep -q 'env\.sh' "$SB_HOME/.bashrc" || return 1
     # A pip vastai now outranks ours: the re-run is a quiet no-op (env.sh wins at shell startup).
     printf '#!/bin/sh\necho 1.0.13\n' > "$SB/pipbin/vastai"
     chmod +x "$SB/pipbin/vastai"
     cp "$SB_HOME/dotfiles/bashrc" "$SB/before"
-    local cmd2=(env "HOME=$SB_HOME" "VASTAI_INSTALL_DIR=$SB_ROOT" \
-        "VASTAI_CLI_BASE_URL=$SERVER/good" "SHELL=/bin/bash" \
-        "PATH=$SB/pipbin:$SB_HOME/.local/bin:/usr/bin:/bin" /bin/bash "$INSTALL_SH")
-    case "$(uname -s)" in
-        Darwin*) script -q /dev/null "${cmd2[@]}" >"$SB_OUT" 2>&1 </dev/null ;;
-        *)       script -qec "${cmd2[*]}" /dev/null >"$SB_OUT" 2>&1 </dev/null ;;
-    esac
+    run_install_tty "PATH=$SB/pipbin:$SB_HOME/.local/bin:/usr/bin:/bin"
     assert "re-run leaves the rc untouched" cmp -s "$SB_HOME/dotfiles/bashrc" "$SB/before" &&
     assert "rc line present exactly once" [ "$(grep -c 'env\.sh' "$SB_HOME/.bashrc")" -eq 1 ] &&
     assert "rc symlink survives" [ -L "$SB_HOME/.bashrc" ] &&
@@ -322,34 +330,57 @@ test_completion_files_generated() { # static completion scripts precomputed unde
 }
 
 test_tty_install() { # interactive install (stderr on a pty) must survive old bash
-    # install.sh empties its pyquiet array at a TTY ([ -t 2 ]), and on bash
-    # < 4.4 expanding an empty array under `set -u` is fatal ("pyquiet[@]:
-    # unbound variable") — macOS's stock /bin/bash is 3.2. The other scenarios
-    # never hit this: they run detached from any tty, so the array stays
-    # non-empty. Runs the real installer on a pty via script(1) under
-    # ${VASTAI_TEST_TTY_BASH:-/bin/bash}; the regression guarantee comes from
-    # hosts whose /bin/bash predates 4.4 (the macOS leg of installer CI).
+    # install.sh empties its pyquiet array with the bar up, and on bash < 4.4 expanding an empty
+    # array under `set -u` is fatal ("pyquiet[@]: unbound variable"); detached runs keep it full.
     new_sandbox tty
     command -v script >/dev/null 2>&1 || { echo "    (skipped: no script(1))"; return 0; }
-    local tty_bash="${VASTAI_TEST_TTY_BASH:-/bin/bash}"
-    local cmd=(env "HOME=$SB_HOME" "VASTAI_INSTALL_DIR=$SB_ROOT" \
-        "VASTAI_CLI_BASE_URL=$SERVER/good" "SHELL=/bin/bash" \
-        "VASTAI_NO_MODIFY_PATH=1" "$tty_bash" "$INSTALL_SH")
-    case "$(uname -s)" in
-        Darwin*) script -q /dev/null "${cmd[@]}" >"$SB_OUT" 2>&1 </dev/null ;;
-        # util-linux script wants one string; sandbox paths contain no spaces.
-        *)       script -qec "${cmd[*]}" /dev/null >"$SB_OUT" 2>&1 </dev/null ;;
-    esac
+    run_install_tty VASTAI_NO_MODIFY_PATH=1
     assert "no set -u explosion at a TTY" out_lacks "unbound variable" &&
     assert "install completed" out_contains "vastai 1.2.3 installed" &&
     assert "installed CLI runs" [ "$("$SB_ROOT/bin/vastai" --version)" = "1.2.3" ]
+}
+
+test_progress_bar() { # at a TTY: a bar + one live log line, and the hints survive
+    new_sandbox progress
+    command -v script >/dev/null 2>&1 || { echo "    (skipped: no script(1))"; return 0; }
+    run_install_tty VASTAI_NO_MODIFY_PATH=1 TERM=xterm || { cat "$SB_OUT"; return 1; }
+    assert "step labels rendered" out_contains "Downloading runtime" &&
+    assert "bar advances with the steps" out_contains "5%" &&
+    assert "bar reaches the last step" out_contains "95%  Finishing setup" &&
+    assert "tool output reaches the live log line" out_contains "Downloading cpython-fake" &&
+    assert "region torn down, cursor restored" out_contains_raw "$(printf '\033[?25h')" &&
+    # The whole point: a chatty install must not scroll the next steps away.
+    assert "getting-started block still printed" out_contains "Get started" &&
+    assert "installed CLI runs" [ "$("$SB_ROOT/bin/vastai" --version)" = "1.2.3" ]
+}
+
+test_progress_opt_out() { # VASTAI_PROGRESS=0 at a TTY: plain lines, no escape codes
+    new_sandbox noprogress
+    command -v script >/dev/null 2>&1 || { echo "    (skipped: no script(1))"; return 0; }
+    run_install_tty VASTAI_NO_MODIFY_PATH=1 TERM=xterm VASTAI_PROGRESS=0 \
+        || { cat "$SB_OUT"; return 1; }
+    assert "steps print as plain lines" out_contains "Downloading runtime\.\.\." &&
+    assert "no live region" out_lacks_raw "$(printf '\033[?25l')" &&
+    assert "tool output passes straight through" out_contains "Downloading cpython-fake" &&
+    assert "install completed" out_contains "vastai 1.2.3 installed"
+}
+
+test_progress_failure_shows_tool_error() { # the bar must not swallow diagnostics
+    new_sandbox progressfail
+    command -v script >/dev/null 2>&1 || { echo "    (skipped: no script(1))"; return 0; }
+    run_install_tty VASTAI_NO_MODIFY_PATH=1 TERM=xterm VASTAI_PIP_SPEC=fail-me==1.0 \
+        && { echo "    expected failure"; return 1; }
+    assert "replays the tool's own error" out_contains "fake uv: no solution found" &&
+    assert "names the failed spec" out_contains "could not install fail-me==1.0" &&
+    assert "cursor restored on the error path" out_contains_raw "$(printf '\033[?25h')" &&
+    assert "no half-built env left behind" [ ! -e "$SB_ROOT/.current.new" ]
 }
 
 # ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 
-ALL_TESTS=(fresh_install pinned_reinstall xdg_data_home_default wheel_url_install wheel_url_pin_fallback checksum_abort truncation_guard glibc_floor rc_safety env_sh pip_shadowing pip_shadowing_quiet pip_shadowing_rerun completion_files_generated tty_install)
+ALL_TESTS=(fresh_install pinned_reinstall xdg_data_home_default wheel_url_install wheel_url_pin_fallback checksum_abort truncation_guard glibc_floor rc_safety env_sh pip_shadowing pip_shadowing_quiet pip_shadowing_rerun completion_files_generated tty_install progress_bar progress_opt_out progress_failure_shows_tool_error)
 # No "${@:-...}": expanding $@ with zero args under set -u is itself fatal on
 # old bash, and this harness must run under macOS's stock bash 3.2 (see
 # test_tty_install).


### PR DESCRIPTION
#467 dropped `--quiet` from the wheel install so a TTY install showed progress. It showed too much: the CPython download plus ~40 `+ pkg==ver` lines scroll the "Get started" block off the screen, which is the one thing a first-time installer needs to read (a coworker missed it entirely).

At a TTY the install now renders as a fixed two-line region on stderr — a step bar plus one live log line that tails whatever `uv` is doing:

```
  Installing vastai 1.5.0 (Python 3.12) → /home/you/.local/share/vastai
  ⠹ ━━━━━━━━━━━━━━━───────────  60%  Installing vastai 1.5.0
    ↳  + cryptography==49.0.0
```

The region is erased when the install finishes, so the last thing on screen is the next-steps block. A full install leaves ~14 lines instead of ~60.

## How it works

- A background ticker animates the spinner; steps and tool output reach it through state files under the temp workdir. Both writers repaint with a single `printf`, so frames can't interleave, and a state change repaints immediately — a step that finishes inside a tick still shows.
- `ui_run` tails a command's output through `tee`; on failure `ui_fail` tears the region down and replays the tail, so `uv`'s own diagnostic ("No solution found when resolving dependencies…") is still what the user sees. No `tr`/`sed` in that pipe: they block-buffer into a pipe and hold every line back until the command exits.
- Widths come from `/dev/tty` first (`curl | bash` leaves stdin as the pipe), falling through to terminfo, with a sized-0 pty rejected. Nothing exceeds the terminal width. ASCII glyphs (`#`/`.`/`-\|/`) replace the Unicode ones outside UTF-8 locales.
- `INT`/`TERM`/`HUP` are trapped so Ctrl-C erases the region and restores the cursor instead of leaving it hidden.

## Unchanged without a TTY

CI and pipes get plain step lines and tool output straight through, no escape codes — `uv python install` keeps `--quiet` there as before. `VASTAI_PROGRESS=0|1` forces either mode.

## Testing

- 18/18 hermetic installer tests pass, 3 new: bar rendering with the hints surviving, the `VASTAI_PROGRESS=0` opt-out, and failure diagnostics surviving the region. The fake `uv` now emits real-shaped chatter and can fail on demand. A `run_install_tty` helper replaces the pty invocation duplicated across the three existing pty tests. `fresh_install` also asserts no escape codes when detached from a tty.
- `shellcheck -S style` clean.
- Real end-to-end installs against the production manifest, including through `curl … | bash`, at 45/50/80/100 columns, in a UTF-8 and an `LC_ALL=C` locale, plus a forced pip failure and a Ctrl-C mid-install.

[Screencast from 2026-07-27 10-45-26.webm](https://github.com/user-attachments/assets/57625d2d-93c9-4957-a780-a1139db44071)

