### PR TITLE
installer: throttle update nudge to once a week, not every 24h

### DIFF
--- a/docs/install-design.md
+++ b/docs/install-design.md
@@ -257,9 +257,9 @@ Not built in v1.
 > it. Opt out with `VASTAI_NO_UPDATE_CHECK=1` (also off under
 > `--raw`/`CI`/non-TTY).
 
-- Before commands: at most **one manifest GET and one stderr line per 24h**, hard
-  1s timeout, every failure silent with 24h backoff (offline machines pay ≤1s
-  once/day).
+- Before commands: at most **one manifest GET and one stderr line per week**, hard
+  1s timeout, every failure silent with weekly backoff (offline machines pay ≤1s
+  once/week).
 - Suppressed under `--raw`, `CI`, non-TTY, or `VASTAI_NO_UPDATE_CHECK=1`.
 - **No telemetry** — the check is a GET of a static file.
 - The nudge only ever *suggests*; there is no minimum-version gate and no

--- a/vastai/cli/selfupdate.py
+++ b/vastai/cli/selfupdate.py
@@ -11,7 +11,7 @@ CLI runs from <root>/current with a sibling <root>/bin/uv. That's ground
 truth — no on-disk marker to drift or hand-copy. pip installs fail the check
 and the updater never touches them.
 
-The passive nudge is throttled to one manifest GET and one notice per 24h,
+The passive nudge is throttled to one manifest GET and one notice per week,
 capped at 1s, and swallows every failure — the CLI must never get slower or
 noisier because the manifest endpoint is unreachable.
 """
@@ -40,7 +40,7 @@ PIP_UPGRADE_HINT = "pip install --upgrade vastai"
 MIN_DOWNGRADE_VERSION = "1.4.0"
 
 UPDATE_CHECK_FILE = os.path.join(DIRS['state'], "update_check.json")
-CHECK_INTERVAL_S = 24 * 60 * 60
+CHECK_INTERVAL_S = 7 * 24 * 60 * 60
 NUDGE_TIMEOUT_S = 1.0
 
 # Console scripts shipped in the wheel; each gets a swapped symlink in bin/.


### PR DESCRIPTION
## Summary
- Change the self-update passive nudge interval from 24 hours to 1 week.

## Test plan
- N/A — single constant change (`CHECK_INTERVAL_S`), governs both the manifest-check and notice-throttle windows.