### PR TITLE
benchmarks: paginate search benchmarks, show perf/$ for cached

### DIFF
--- a/tests/api/test_benchmarks_pagination.py
+++ b/tests/api/test_benchmarks_pagination.py
@@ -1,6 +1,9 @@
-"""search_benchmarks pages through next_token only when asked to."""
+"""Benchmarks pagination: the flat-list helper pages, the v1 helper does not."""
+
+from unittest.mock import patch
 
 from vastai.api import offers
+from vastai.sdk import VastAI
 
 
 class _FakeResp:
@@ -23,48 +26,82 @@ class _FakeClient:
         self.calls = []
 
     def get(self, subpath, query_args=None):
-        self.calls.append(query_args or {})
+        # Copy: the pager reuses one params dict across pages.
+        self.calls.append(dict(query_args or {}))
         if (query_args or {}).get("after_token"):
             return _FakeResp([{"id": 3}])
         return _FakeResp([{"id": 1}, {"id": 2}], token="TOK")
 
 
-def test_single_page_by_default():
-    client = _FakeClient()
-    rows, token = offers.search_benchmarks(client, query={"type": {"eq": "perf"}})
+def sdk_with(client):
+    with patch("vastai.sdk.VastClient"):
+        v = VastAI(api_key="test-key")
+    v.client = client
+    return v
 
-    assert [r["id"] for r in rows] == [1, 2]
-    assert token == "TOK"
+
+def test_v1_returns_one_page_with_token():
+    client = _FakeClient()
+    data = offers.search_benchmarks_v1(client, {"select_filters": {}})
+
+    assert [r["id"] for r in data["benchmarks"]] == [1, 2]
+    assert data["next_token"] == "TOK"
     assert len(client.calls) == 1
-    assert "after_token" not in client.calls[0]
 
 
-def test_all_pages_follows_next_token():
+def test_search_benchmarks_follows_next_token():
     client = _FakeClient()
-    rows, token = offers.search_benchmarks(client, all_pages=True)
-    assert token is None
+    rows = offers.search_benchmarks(client, query={"type": {"eq": "perf"}})
 
     # Every row across both pages, in order.
     assert [r["id"] for r in rows] == [1, 2, 3]
     # Two requests: the second echoes the token from the first page.
     assert len(client.calls) == 2
+    assert "after_token" not in client.calls[0]
     assert client.calls[1]["after_token"] == "TOK"
 
 
-def test_omits_limit_when_unset():
+def test_search_benchmarks_resumes_from_token():
     client = _FakeClient()
-    offers.search_benchmarks(client)
-    assert "limit" not in client.calls[0]
+    rows = offers.search_benchmarks(client, after_token="TOK")
+    assert [r["id"] for r in rows] == [3]
+
+
+def test_omits_limit_when_unset():
+    assert "limit" not in offers.benchmarks_query_args()
 
 
 def test_forwards_limit():
-    client = _FakeClient()
-    offers.search_benchmarks(client, limit=100)
-    assert client.calls[0]["limit"] == 100
+    assert offers.benchmarks_query_args(limit=100)["limit"] == 100
 
 
-def test_resumes_from_token():
+def test_sdk_returns_a_single_page_by_default():
+    """A broad query must not scan the whole table unless the caller asks."""
     client = _FakeClient()
-    rows, token = offers.search_benchmarks(client, after_token="TOK")
+    rows = sdk_with(client).search_benchmarks(query={"type": {"eq": "perf"}})
+
+    assert [r["id"] for r in rows] == [1, 2]
+    assert len(client.calls) == 1
+
+
+def test_sdk_all_pages_fetches_everything():
+    client = _FakeClient()
+    rows = sdk_with(client).search_benchmarks(all_pages=True)
+
+    assert [r["id"] for r in rows] == [1, 2, 3]
+    assert len(client.calls) == 2
+
+
+def test_sdk_resumes_from_token():
+    client = _FakeClient()
+    rows = sdk_with(client).search_benchmarks(after_token="TOK")
+
     assert [r["id"] for r in rows] == [3]
-    assert token is None
+    assert client.calls[0]["after_token"] == "TOK"
+
+
+def test_sdk_v1_exposes_next_token():
+    client = _FakeClient()
+    data = sdk_with(client).search_benchmarks_v1({"select_filters": {}})
+
+    assert data["next_token"] == "TOK"

--- a/tests/api/test_benchmarks_pagination.py
+++ b/tests/api/test_benchmarks_pagination.py
@@ -1,0 +1,70 @@
+"""search_benchmarks pages through next_token only when asked to."""
+
+from vastai.api import offers
+
+
+class _FakeResp:
+    def __init__(self, rows, token=None):
+        self._rows = rows
+        self._token = token
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"success": True, "benchmarks_found": len(self._rows),
+                "benchmarks": self._rows, "next_token": self._token}
+
+
+class _FakeClient:
+    """Two pages: the first carries a token, the second does not."""
+
+    def __init__(self):
+        self.calls = []
+
+    def get(self, subpath, query_args=None):
+        self.calls.append(query_args or {})
+        if (query_args or {}).get("after_token"):
+            return _FakeResp([{"id": 3}])
+        return _FakeResp([{"id": 1}, {"id": 2}], token="TOK")
+
+
+def test_single_page_by_default():
+    client = _FakeClient()
+    rows, token = offers.search_benchmarks(client, query={"type": {"eq": "perf"}})
+
+    assert [r["id"] for r in rows] == [1, 2]
+    assert token == "TOK"
+    assert len(client.calls) == 1
+    assert "after_token" not in client.calls[0]
+
+
+def test_all_pages_follows_next_token():
+    client = _FakeClient()
+    rows, token = offers.search_benchmarks(client, all_pages=True)
+    assert token is None
+
+    # Every row across both pages, in order.
+    assert [r["id"] for r in rows] == [1, 2, 3]
+    # Two requests: the second echoes the token from the first page.
+    assert len(client.calls) == 2
+    assert client.calls[1]["after_token"] == "TOK"
+
+
+def test_omits_limit_when_unset():
+    client = _FakeClient()
+    offers.search_benchmarks(client)
+    assert "limit" not in client.calls[0]
+
+
+def test_forwards_limit():
+    client = _FakeClient()
+    offers.search_benchmarks(client, limit=100)
+    assert client.calls[0]["limit"] == 100
+
+
+def test_resumes_from_token():
+    client = _FakeClient()
+    rows, token = offers.search_benchmarks(client, after_token="TOK")
+    assert [r["id"] for r in rows] == [3]
+    assert token is None

--- a/tests/cli/test_benchmarks_commands.py
+++ b/tests/cli/test_benchmarks_commands.py
@@ -67,7 +67,7 @@ def _mk_vast(*, create_endpoint=None, create_workergroup=None,
                                       else {"success": True})
     v.show_instance.return_value = (show_instance
                                     if show_instance is not None
-                                    else {"dph_total": 0.5})
+                                    else {"dph_base": 0.5})
     return v
 
 
@@ -212,7 +212,7 @@ class TestBenchmarkOne:
         vast = _mk_vast(create_workergroup={"success": True, "result": 1},
                         get_endpoint_workers=[poll],
                         delete_workergroup_raises=RuntimeError("delete failed"),
-                        show_instance={"dph_total": 1.0})
+                        show_instance={"dph_base": 1.0})
         with patch.object(bench.time, "sleep"), \
              patch.object(bench.time, "monotonic", side_effect=[0, 0, 1]):
             gpu, num_gpus, status, perf, err, price = bench.benchmark_gpu(
@@ -238,7 +238,7 @@ def _run_cli(parse_argv, argv, *, create_resp=None, workers_seq=None,
     """Parse argv and invoke the command with a mocked VastAI."""
     template = template if template is not None else _FAKE_TEMPLATE
     fake_offer_list = [{"id": i} for i in range(preflight_offers)]
-    instance_resp = {"dph_total": rental_dph} if rental_dph is not None else {}
+    instance_resp = {"dph_base": rental_dph} if rental_dph is not None else {}
 
     vast = MagicMock()
     vast.client = MagicMock(api_key="k")
@@ -375,11 +375,11 @@ class TestBenchmarkRunCLI:
 # ---------------------------------------------------------------------------
 
 
-def _bench_row(value, *, template_hash="x", template_id=None, age_days=1):
+def _bench_row(value, *, template_hash="x", template_id=None, age_days=1, dph_base=None):
     import time
     return {"type": "perf", "gpu_name": "RTX 3060", "num_gpus": 1,
             "template_hash": template_hash, "template_id": template_id,
-            "value": value, "last_update": time.time() - age_days * 86400}
+            "value": value, "dph_base": dph_base, "last_update": time.time() - age_days * 86400}
 
 
 class TestBenchmarkCache:
@@ -396,9 +396,8 @@ class TestBenchmarkCache:
         vast.create_endpoint.assert_not_called()
         vast.create_workergroup.assert_not_called()
 
-    def test_cached_rows_have_no_price(self, parse_argv):
-        # Cached rows report perf only; $/hr would come from a different
-        # machine than the one benchmarked, so it is omitted.
+    def test_cached_rows_without_dph_base_have_no_price(self, parse_argv):
+        # Rows reported before the reporter sent dph_base carry no $/hr, so perf/$ is omitted.
         rows, _ = _run_cli(
             parse_argv,
             ["run", "benchmarks", "--template_id", "99999",
@@ -407,6 +406,35 @@ class TestBenchmarkCache:
         )
         assert rows[0]["rental_dph"] is None
         assert rows[0]["perf_per_dollar"] is None
+
+    def test_cached_rows_with_dph_base_show_perf_per_dollar(self, parse_argv):
+        # Once rows carry dph_base (gpu $/hr at benchmark time), cached results
+        # report perf/$ = median(value) / median(dph_base).
+        rows, _ = _run_cli(
+            parse_argv,
+            ["run", "benchmarks", "--template_id", "99999",
+             "--gpus", "RTX_3060", "-y", "--raw"],
+            benchmark_rows=[_bench_row(20.0, dph_base=0.5), _bench_row(40.0, dph_base=1.0)],
+        )
+        # median perf 30.0, median dph_base 0.75 -> 40.0 perf/$
+        assert rows[0]["rental_dph"] == 0.75
+        assert rows[0]["perf_per_dollar"] == 40.0
+
+    def test_cached_range_trims_outlier_to_p5_p95(self, parse_argv):
+        # The displayed range is p5-p95, so one flukey benchmark doesn't blow it
+        # up; the median stays robust.
+        from unittest.mock import MagicMock
+        vast = MagicMock()
+        vast.search_benchmarks.return_value = [
+            _bench_row(v) for v in
+            [9.5, 9.8, 10.0, 10.1, 10.2, 10.5, 11.0, 12.0, 74.0]
+        ]
+        hit = bench.lookup_cached_benchmark(
+            vast, gpu_name="RTX 3060", num_gpus=1,
+            template_hash="x", template_id=None, max_age_days=30)
+        assert hit["median"] == 10.2
+        assert hit["high"] < 74.0  # outlier excluded from the displayed range
+        assert hit["low"] >= 9.5
 
     def test_cached_unrentable_is_flagged(self, parse_argv, capsys):
         rows, vast = _run_cli(

--- a/tests/cli/test_offers_commands.py
+++ b/tests/cli/test_offers_commands.py
@@ -60,6 +60,29 @@ class TestSearchBenchmarks:
         call_args = patch_get_client.get.call_args
         assert "/benchmarks" in call_args[0][0]
 
+    def test_raw_returns_flat_list_when_fetching_every_page(
+            self, parse_argv, patch_get_client, mock_response):
+        """The shape scripts have always gotten from `search benchmarks --raw`."""
+        patch_get_client.get.return_value = mock_response(200, {
+            "success": True, "benchmarks_found": 1, "next_token": None,
+            "benchmarks": [{"id": 1, "gpu_name": "RTX_3090"}],
+        })
+        args = parse_argv(["search", "benchmarks", "--raw"])
+        result = args.func(args)
+        assert result == [{"id": 1, "gpu_name": "RTX_3090"}]
+
+    def test_raw_returns_envelope_in_single_page_mode(
+            self, parse_argv, patch_get_client, mock_response):
+        """--limit pages manually, so the caller needs next_token back."""
+        patch_get_client.get.return_value = mock_response(200, {
+            "success": True, "benchmarks_found": 1, "next_token": "TOK",
+            "benchmarks": [{"id": 1, "gpu_name": "RTX_3090"}],
+        })
+        args = parse_argv(["search", "benchmarks", "--raw", "--limit", "1"])
+        result = args.func(args)
+        assert result["next_token"] == "TOK"
+        assert result["benchmarks"] == [{"id": 1, "gpu_name": "RTX_3090"}]
+
 
 class TestSearchInvoices:
     def test_search_invoices(self, parse_argv, patch_get_client, mock_response):

--- a/tests/cli/test_offers_commands.py
+++ b/tests/cli/test_offers_commands.py
@@ -50,9 +50,10 @@ class TestSearchTemplates:
 
 class TestSearchBenchmarks:
     def test_search_benchmarks(self, parse_argv, patch_get_client, mock_response):
-        patch_get_client.get.return_value = mock_response(200, [
-            {"id": 1, "score": 95.5, "gpu_name": "RTX_3090"}
-        ])
+        patch_get_client.get.return_value = mock_response(200, {
+            "success": True, "benchmarks_found": 1, "next_token": None,
+            "benchmarks": [{"id": 1, "score": 95.5, "gpu_name": "RTX_3090"}],
+        })
         args = parse_argv(["search", "benchmarks"])
         result = args.func(args)
         patch_get_client.get.assert_called_once()

--- a/vastai/api/offers.py
+++ b/vastai/api/offers.py
@@ -113,10 +113,27 @@ def search_templates(client: VastClient, query: dict = None) -> list:
     return r.json().get("templates", [])
 
 
+def benchmarks_query_args(query: dict = None, order: list = None,
+                          limit: int = None, after_token: str = None) -> dict:
+    """Build the query args for a ``/benchmarks`` request."""
+    query_args = {"select_cols": ["*"], "select_filters": query or {}}
+    if order is not None:
+        query_args["order_by"] = order
+    if limit is not None:
+        query_args["limit"] = int(limit)
+    if after_token:
+        query_args["after_token"] = after_token
+    return query_args
+
+
 def search_benchmarks(client: VastClient, query: dict = None, order: list = None,
-                      limit: int = None, after_token: str = None,
-                      all_pages: bool = False) -> tuple:
-    """Search for benchmarks using a query dict.
+                      limit: int = None, after_token: str = None) -> list:
+    """Search for benchmarks using a query dict, as a flat list.
+
+    Pages through ``/benchmarks``, following ``next_token`` until it is
+    exhausted, and concatenates every page. The backend caps a page at 200 rows
+    by default, so callers that want one page at a time should use
+    :func:`search_benchmarks_v1` instead.
 
     Args:
         client: VastClient instance.
@@ -124,28 +141,35 @@ def search_benchmarks(client: VastClient, query: dict = None, order: list = None
         order: List of {"col": ..., "dir": ...} dicts, e.g. [{"col": "last_update", "dir": "desc"}].
         limit: Max number of results per page.
         after_token: Pagination token to resume from.
-        all_pages: Follow pagination and return every matching row.
 
     Returns:
-        Tuple of (list of benchmark dicts, next page token or None).
+        List of benchmark dicts.
     """
     rows = []
-    token = after_token
+    params = benchmarks_query_args(query=query, order=order, limit=limit,
+                                   after_token=after_token)
     while True:
-        query_args = {"select_cols": ["*"], "select_filters": query or {}}
-        if order is not None:
-            query_args["order_by"] = order
-        if limit is not None:
-            query_args["limit"] = int(limit)
-        if token:
-            query_args["after_token"] = token
-        r = client.get("/benchmarks", query_args=query_args)
-        r.raise_for_status()
-        data = r.json()
+        data = search_benchmarks_v1(client, params)
         rows.extend(data.get("benchmarks") or [])
-        token = data.get("next_token")
-        if not all_pages or not token:
-            return rows, token
+        next_token = data.get("next_token")
+        if not next_token:
+            return rows
+        params["after_token"] = next_token
+
+
+def search_benchmarks_v1(client: VastClient, params: dict) -> dict:
+    """Fetch one page of benchmarks using the paginated API.
+
+    Args:
+        client: VastClient instance.
+        params: Dict with select_cols, select_filters, order_by, limit, after_token.
+
+    Returns:
+        Full response dict (benchmarks, benchmarks_found, next_token).
+    """
+    r = client.get("/benchmarks", query_args=params)
+    r.raise_for_status()
+    return r.json()
 
 
 def search_volumes(client: VastClient, query: dict = None, order: list = None,

--- a/vastai/api/offers.py
+++ b/vastai/api/offers.py
@@ -114,26 +114,38 @@ def search_templates(client: VastClient, query: dict = None) -> list:
 
 
 def search_benchmarks(client: VastClient, query: dict = None, order: list = None,
-                      limit: int = None) -> list:
+                      limit: int = None, after_token: str = None,
+                      all_pages: bool = False) -> tuple:
     """Search for benchmarks using a query dict.
 
     Args:
         client: VastClient instance.
         query: Pre-parsed query dict of select_filters.
         order: List of {"col": ..., "dir": ...} dicts, e.g. [{"col": "last_update", "dir": "desc"}].
-        limit: Max number of results. Omit for an unbounded result set.
+        limit: Max number of results per page.
+        after_token: Pagination token to resume from.
+        all_pages: Follow pagination and return every matching row.
 
     Returns:
-        List of benchmark dicts.
+        Tuple of (list of benchmark dicts, next page token or None).
     """
-    query_args = {"select_cols": ["*"], "select_filters": query or {}}
-    if order is not None:
-        query_args["order_by"] = order
-    if limit is not None:
-        query_args["limit"] = int(limit)
-    r = client.get("/benchmarks", query_args=query_args)
-    r.raise_for_status()
-    return r.json()
+    rows = []
+    token = after_token
+    while True:
+        query_args = {"select_cols": ["*"], "select_filters": query or {}}
+        if order is not None:
+            query_args["order_by"] = order
+        if limit is not None:
+            query_args["limit"] = int(limit)
+        if token:
+            query_args["after_token"] = token
+        r = client.get("/benchmarks", query_args=query_args)
+        r.raise_for_status()
+        data = r.json()
+        rows.extend(data.get("benchmarks") or [])
+        token = data.get("next_token")
+        if not all_pages or not token:
+            return rows, token
 
 
 def search_volumes(client: VastClient, query: dict = None, order: list = None,

--- a/vastai/api/query.py
+++ b/vastai/api/query.py
@@ -184,6 +184,7 @@ offers_mult = {
 
 benchmarks_fields = {
     "contract_id",#             int        ID of instance/contract reporting benchmark
+    "dph_base",#                float      gpu $/hr at benchmark time
     "gpu_name",#                string     GPU model benchmarked (e.g. RTX_4090)
     "id",#                      int        benchmark unique ID
     "image",#                   string     image used for benchmark

--- a/vastai/cli/commands/benchmarks.py
+++ b/vastai/cli/commands/benchmarks.py
@@ -351,12 +351,25 @@ def lookup_cached_benchmark(vast, *, gpu_name, num_gpus, template_hash,
         return None
     values = [r["value"] for r in matched]
     newest = max((r.get("last_update") or 0) for r in matched)
+    # skip null rows (from before we tracked dph_base in benchmarks)
+    dphs = [
+        r["dph_base"]
+        for r in matched
+        if isinstance(r.get("dph_base"), (int, float)) and r["dph_base"] > 0
+    ]
+    # use p5/p95 for the range
+    if len(values) >= 2:
+        qs = statistics.quantiles(values, n=20, method="inclusive")
+        low, high = qs[0], qs[-1]
+    else:
+        low = high = values[0]
     return {
         "median": statistics.median(values),
-        "low": min(values),
-        "high": max(values),
+        "low": low,
+        "high": high,
         "n": len(matched),
         "age_days": max(0.0, (time.time() - newest) / 86400),
+        "median_dph_base": statistics.median(dphs) if dphs else None,
     }
 
 
@@ -477,7 +490,7 @@ def benchmark_gpu(vast, *, gpu_name, num_gpus, timeout,
                    class_states=None, stop_event=None):
     """Rent one instance for ``gpu_name``, poll until idle + measured_perf,
     tear down. Each call owns its own endpoint + workergroup so it can run
-    in parallel safely. Returns ``(gpu_name, num_gpus, status, perf, err, dph_total)``.
+    in parallel safely. Returns ``(gpu_name, num_gpus, status, perf, err, dph_base)``.
     """
     endpoint_id = None
     workergroup_id = None
@@ -560,7 +573,7 @@ def benchmark_gpu(vast, *, gpu_name, num_gpus, timeout,
                 if primary_id and primary_id not in dph_by_worker:
                     try:
                         inst = vast.show_instance(id=primary_id)
-                        dph_by_worker[primary_id] = inst.get("dph_total")
+                        dph_by_worker[primary_id] = inst.get("dph_base")
                     except Exception as e:
                         # Cache None so we don't re-attempt every poll, but log so a real bug isn't silently swallowed.
                         dph_by_worker[primary_id] = None
@@ -672,6 +685,10 @@ def benchmark_gpu(vast, *, gpu_name, num_gpus, timeout,
         you're asked whether to reuse that or run a fresh benchmark. Pass
         --no-cache to always re-measure, or -y to always reuse the cache.
 
+        Perf/$ uses the GPU $/hr, so cached and freshly measured rows are
+        comparable. Cached rows recorded before that price was tracked show
+        a perf with no price.
+
         Examples:
             # auto-sweep the default GPUs against TGI
             vastai run benchmarks --template_hash 79ebdd2ebfb9d42cedf7a221c42d37a5
@@ -770,14 +787,15 @@ def run__benchmarks(args):
                 max_age_days=DEFAULT_CACHE_MAX_AGE_DAYS,
             )
             if hit:
-                # Perf only: a cached row's $/hr would come from a different machine than the one benchmarked.
                 rentable = has_matching_offer(
                     vast, gpu_name=g, num_gpus=n, extra_filters=extra_filters)
                 age = (f"{hit['age_days']:.0f}d" if hit["age_days"] >= 1
                        else "<1d")
                 note = None if rentable else "no offers available to rent right now"
+                median_dph_base = hit.get("median_dph_base")
+                pps = f", {hit['median'] / median_dph_base:.1f} perf/$" if median_dph_base else ""
                 msg = (f"[green][{n}x {g}] cached:[/green] median perf "
-                       f"{hit['median']:.1f} "
+                       f"{hit['median']:.1f}{pps} "
                        f"(n={hit['n']}, range {hit['low']:.1f}-{hit['high']:.1f}, "
                        f"newest {age} ago)")
                 if note:
@@ -795,7 +813,7 @@ def run__benchmarks(args):
                 if run_fresh:
                     compatible_specs.append((g, n))  # offers already confirmed
                 else:
-                    cached_results.append((g, n, "cached", hit["median"], note, None))
+                    cached_results.append((g, n, "cached", hit["median"], None, hit.get("median_dph_base")))
                 continue
         if not has_matching_offer(
             vast, gpu_name=g, num_gpus=n,

--- a/vastai/cli/commands/offers.py
+++ b/vastai/cli/commands/offers.py
@@ -276,18 +276,28 @@ def search__benchmarks(args):
     client = get_client(args)
     # Fetch every page by default; --limit/--next-token opt into manual pagination.
     fetch_all = args.all or (args.limit is None and args.next_token is None)
-    token = args.next_token
+    if fetch_all:
+        rows = offers_api.search_benchmarks(
+            client, query=query, limit=args.limit, after_token=args.next_token)
+        if args.raw:
+            return {"success": True, "benchmarks_found": len(rows),
+                    "benchmarks": rows, "next_token": None}
+        display_table(rows, benchmarks_displayable_fields)
+        return
+
+    params = offers_api.benchmarks_query_args(
+        query=query, limit=args.limit, after_token=args.next_token)
     page = 0
     while True:
         page += 1
-        rows, next_token = offers_api.search_benchmarks(
-            client, query=query, limit=args.limit, after_token=token,
-            all_pages=fetch_all)
+        data = offers_api.search_benchmarks_v1(client, params)
+        rows = data.get("benchmarks") or []
+        next_token = data.get("next_token")
         if args.raw:
             return {"success": True, "benchmarks_found": len(rows),
                     "benchmarks": rows, "next_token": next_token}
         display_table(rows, benchmarks_displayable_fields)
-        if fetch_all or not next_token:
+        if not next_token:
             return
         print(f"Next page token: {next_token}")
         # Never block on a prompt when piped or scripted.
@@ -298,7 +308,7 @@ def search__benchmarks(args):
                 return
         except (EOFError, KeyboardInterrupt):
             return
-        token = next_token
+        params["after_token"] = next_token
 
 
 # ---------------------------------------------------------------------------

--- a/vastai/cli/commands/offers.py
+++ b/vastai/cli/commands/offers.py
@@ -218,6 +218,9 @@ def search__offers(args):
         in that mode). The prompt is skipped when output is piped or --raw is used;
         those print the next page token so you can resume with --next-token.
 
+        --raw prints a flat list when fetching every page, and the full response
+        (benchmarks plus next_token) in single-page mode.
+
         Query syntax:
 
             query = comparison comparison...
@@ -280,8 +283,10 @@ def search__benchmarks(args):
         rows = offers_api.search_benchmarks(
             client, query=query, limit=args.limit, after_token=args.next_token)
         if args.raw:
-            return {"success": True, "benchmarks_found": len(rows),
-                    "benchmarks": rows, "next_token": None}
+            # Flat list of every matching row -- the contract scripts have
+            # always depended on for --raw. Single-page mode returns the
+            # envelope instead, since only it has a token worth handing back.
+            return rows
         display_table(rows, benchmarks_displayable_fields)
         return
 

--- a/vastai/cli/commands/offers.py
+++ b/vastai/cli/commands/offers.py
@@ -1,6 +1,7 @@
 """CLI commands for searching offers, templates, and benchmarks."""
 
 import json
+import sys
 import time
 
 from vastai.cli.parser import argument, hidden_aliases
@@ -205,9 +206,18 @@ def search__offers(args):
 
 @parser.command(
     argument("query", help="Search query in simple query syntax (see below)", nargs="*", default=None),
-    usage="vastai search benchmarks [--help] [--api-key API_KEY] [--raw] <query>",
+    argument("-a", "--all",        action="store_true", help="force fetching every page, even with --limit/--next-token (fetching everything is already the default otherwise)"),
+    argument("-l", "--limit",      type=int, default=None, help="max results per page; passing this switches to single-page mode instead of fetching everything"),
+    argument("-t", "--next-token", dest="next_token",   help="resume from a pagination token (implies single-page mode)"),
+    usage="vastai search benchmarks [--help] [--api-key API_KEY] [--raw] [--limit N] [--next-token TOKEN] <query>",
     help="Search for benchmark results using custom query",
     epilog=deindent("""
+        By default this fetches every page and prints one combined result. Passing
+        --limit or --next-token switches to single-page mode, which prints a page
+        and asks whether to fetch the next one (add --all to still fetch every page
+        in that mode). The prompt is skipped when output is piped or --raw is used;
+        those print the next page token so you can resume with --next-token.
+
         Query syntax:
 
             query = comparison comparison...
@@ -225,11 +235,15 @@ def search__offers(args):
             # search for benchmarks with value > 100 on RTX 4090s for 2 specific machines
             vastai search benchmarks 'value > 100.0  gpu_name=RTX_4090  machine_id in [302,402]'
 
+            # a page at a time, prompting between pages
+            vastai search benchmarks 'gpu_name=RTX_5090' --limit 50
+
         Available fields:
 
               Name                  Type       Description
 
             contract_id             int        ID of instance/contract reporting benchmark
+            dph_base                float      gpu $/hr at the time of the benchmark
             gpu_name                string     GPU model benchmarked (e.g. RTX_4090)
             id                      int        benchmark unique ID
             image                   string     image used for benchmark
@@ -260,10 +274,31 @@ def search__benchmarks(args):
         return 1
 
     client = get_client(args)
-    rows = offers_api.search_benchmarks(client, query=query)
-    if args.raw:
-        return rows
-    display_table(rows, benchmarks_displayable_fields)
+    # Fetch every page by default; --limit/--next-token opt into manual pagination.
+    fetch_all = args.all or (args.limit is None and args.next_token is None)
+    token = args.next_token
+    page = 0
+    while True:
+        page += 1
+        rows, next_token = offers_api.search_benchmarks(
+            client, query=query, limit=args.limit, after_token=token,
+            all_pages=fetch_all)
+        if args.raw:
+            return {"success": True, "benchmarks_found": len(rows),
+                    "benchmarks": rows, "next_token": next_token}
+        display_table(rows, benchmarks_displayable_fields)
+        if fetch_all or not next_token:
+            return
+        print(f"Next page token: {next_token}")
+        # Never block on a prompt when piped or scripted.
+        if not (sys.stdin.isatty() and sys.stdout.isatty()):
+            return
+        try:
+            if input(f"Fetch next page? (page {page + 1}) (y/N): ").strip().lower() != "y":
+                return
+        except (EOFError, KeyboardInterrupt):
+            return
+        token = next_token
 
 
 # ---------------------------------------------------------------------------

--- a/vastai/cli/display.py
+++ b/vastai/cli/display.py
@@ -156,6 +156,7 @@ benchmarks_displayable_fields = (
     ("gpu_name", "Model", "{}", None, True),
     ("num_gpus", "N", "{}x", None, False),
     ("value", "Value", "{:0.2f}", None, True),
+    ("dph_base", "$/hr", "{:0.4f}", None, True),
     ("type", "Type", "{}", None, True),
     ("template_hash", "Template", "{}", None, True),
     ("template_id", "Templ_ID", "{}", None, True),

--- a/vastai/sdk.py
+++ b/vastai/sdk.py
@@ -275,11 +275,26 @@ class VastAI:
     def search_benchmarks(self, query: Optional[Union[str, dict]] = None,
                           order: Optional[list] = None,
                           limit: Optional[int] = None,
+                          after_token: Optional[str] = None,
                           all_pages: bool = False) -> list[dict]:
-        """Search for benchmarks."""
-        rows, _ = offers.search_benchmarks(self.client, query=query, order=order,
-                                           limit=limit, all_pages=all_pages)
-        return rows
+        """Search for benchmarks.
+
+        Returns a single page (the backend caps it at 200 rows) so a broad query
+        doesn't scan the whole table. Pass all_pages=True to follow pagination
+        and get every matching row, or use search_benchmarks_v1() to page
+        manually via next_token.
+        """
+        if all_pages:
+            return offers.search_benchmarks(self.client, query=query, order=order,
+                                            limit=limit, after_token=after_token)
+        params = offers.benchmarks_query_args(query=query, order=order,
+                                              limit=limit, after_token=after_token)
+        data = offers.search_benchmarks_v1(self.client, params)
+        return data.get("benchmarks") or []
+
+    def search_benchmarks_v1(self, params: dict) -> dict:
+        """Return benchmarks using the paginated API; for manual pagination."""
+        return offers.search_benchmarks_v1(self.client, params)
 
     def search_volumes(self, query: Optional[str] = None, **kwargs) -> list[dict]:
         """Search for volume offers."""

--- a/vastai/sdk.py
+++ b/vastai/sdk.py
@@ -274,10 +274,12 @@ class VastAI:
 
     def search_benchmarks(self, query: Optional[Union[str, dict]] = None,
                           order: Optional[list] = None,
-                          limit: Optional[int] = None) -> list[dict]:
+                          limit: Optional[int] = None,
+                          all_pages: bool = False) -> list[dict]:
         """Search for benchmarks."""
-        return offers.search_benchmarks(self.client, query=query, order=order,
-                                        limit=limit)
+        rows, _ = offers.search_benchmarks(self.client, query=query, order=order,
+                                           limit=limit, all_pages=all_pages)
+        return rows
 
     def search_volumes(self, query: Optional[str] = None, **kwargs) -> list[dict]:
         """Search for volume offers."""


### PR DESCRIPTION
**Important** - merge after 08/17's webserver release

pairs with the backend benchmarks PR. two things:

pagination - search benchmarks pulls every page by default so nothing changes for
normal use. --limit or --next-token gives you one page at a time with a "fetch
next page? (y/N)" prompt instead of making you paste tokens around. --raw returns
the envelope (benchmarks + next_token) so scripts can walk pages. also made
dph_base queryable and added a $/hr column.

perf/$ on cached results. run benchmarks cache hits show perf/$ from the new
dph_base (gpu $/hr). rows without it just don't show a price. switched the live
path to dph_base too so cached and fresh rows aren't on different denominators,
and moved the cached range from min/max to p5-p95 so one flukey run doesn't make
the spread look scary.

cut order: webserver has to be out before this hits pypi, the cli reads
data["benchmarks"] now and an old backend returns a bare list. perf/$ stays blank
until the autoscaler lands, which is harmless.

relevant BE branch - feat/benchmarks-pagination-dph