### PR TITLE
fix(cli): don't retry bulk destroy after success (CLN-3669)

### DIFF
--- a/tests/cli/test_instances_commands.py
+++ b/tests/cli/test_instances_commands.py
@@ -276,6 +276,39 @@ class TestDestroyInstance:
         assert "Aborted" in captured.out
 
 
+class TestDestroyInstances:
+    def test_bulk_destroy_sends_one_request_per_chunk(self, parse_argv, patch_get_client, mock_response, capsys):
+        """A successful bulk destroy must not be retried by exec_with_threads.
+
+        Without a truthy return from destroy_instance_impl the retry loop
+        re-sent the DELETE, and each repeat 404s because the instances are
+        already gone.
+        """
+        patch_get_client.delete.return_value = mock_response(200, {"success": True})
+        args = parse_argv(["destroy", "instances", "123", "456", "789", "--yes"])
+
+        args.func(args)
+
+        patch_get_client.delete.assert_called_once()
+        call_args = patch_get_client.delete.call_args
+        assert "/instances/" in call_args[0][0]
+        assert call_args[1]["json_data"] == {"instance_ids": [123, 456, 789]}
+
+    def test_bulk_destroy_chunks_at_64(self, parse_argv, patch_get_client, mock_response):
+        patch_get_client.delete.return_value = mock_response(200, {"success": True})
+        ids = [str(i) for i in range(1, 66)]
+        args = parse_argv(["destroy", "instances", *ids, "--yes"])
+
+        args.func(args)
+
+        assert patch_get_client.delete.call_count == 2
+        sent = sorted(
+            len(c[1]["json_data"]["instance_ids"])
+            for c in patch_get_client.delete.call_args_list
+        )
+        assert sent == [1, 64]
+
+
 class TestStartInstance:
     def test_start_instance(self, parse_argv, patch_get_client, mock_response, capsys):
         patch_get_client.put.return_value = mock_response(200, {"success": True})

--- a/vastai/cli/commands/instances.py
+++ b/vastai/cli/commands/instances.py
@@ -296,8 +296,10 @@ def destroy_instance_impl(id, args):
         return rj
     elif rj.get("success"):
         print("destroying instance {id}.".format(**(locals())))
+        return True
     else:
         print(rj.get("msg", rj))
+    return False
 
 
 @parser.command(


### PR DESCRIPTION
## Problem

`vastai destroy instances <id> <id> <id>` prints the success line, then repeats this five times:

```
404 Client Error: Not Found for url: https://console.vast.ai/api/v0/instances/?api_key=...
retrying in 0.325s
```

The instances *are* destroyed. The bulk `DELETE /api/v0/instances/` succeeds on the first attempt — every 404 arrives after the work is already done.

## Cause

`destroy_instance_impl` returns `None` on the normal success path; only `--raw` returns something truthy. `exec_with_threads` treats a falsy return as failure:

```python
if result:  # Assuming a truthy return value means success
    break
```

So each successful chunk is scored as a failure and re-sent, up to `max_retries=5`. The instances are already gone by then, so the server returns 404, `raise_for_status()` raises, and the worker's `except` prints `str(e)`. Six attempts total, five spurious 404s.

`destroy_instance_impl` was the only one of the four `exec_with_threads` callers missing this — `create_instance_impl`, `start_instance_impl` and `stop_instance_impl` all `return True`.

Worth noting for anyone who hits this again: the endpoint, the route and the proxy are all fine. Reaching for `--raw` to debug makes the symptom vanish (it returns a truthy value), which makes the bug look endpoint-shaped when it isn't.

## Fix

`return True` / `return False` from `destroy_instance_impl`, mirroring `start_instance_impl` exactly.

## Tests

Added `TestDestroyInstances` — the bulk path had no coverage at all; `TestDestroyInstance` only exercised the singular command. The two new tests assert one DELETE per chunk and correct chunking at the 64 boundary. Both fail before this change (6 DELETEs instead of 1) and pass after. Full `tests/cli` + `tests/api`: 505 passed.

## Follow-up (not in this PR)

`exec_with_threads`' "truthy return means success" contract silently turns any forgotten `return True` into a 6x retry of a non-idempotent operation, and it retries non-retryable statuses (404/400) even though `VastClient._request` already limits retries to 429/502/503/504. Tracked as a separate cleanup.

Fixes CLN-3669.
