### PR TITLE
Client/host command classification with role-aware CLI display + auto-detection (CLN-3582)

### DIFF
--- a/tests/cli/test_auth_commands.py
+++ b/tests/cli/test_auth_commands.py
@@ -94,6 +94,7 @@ class TestSetApiKey:
         legacy_file = tmp_path / ".vast_api_key"
         monkeypatch.setattr("vastai.cli.util.APIKEY_FILE", str(key_file))
         monkeypatch.setattr("vastai.cli.util.APIKEY_FILE_HOME", str(legacy_file))
+        monkeypatch.setattr("vastai.api.machines.show_machines", lambda client: [])
         from vastai.cli.commands.auth import set__api_key
         set__api_key(argparse.Namespace(new_api_key="test-key-abc-123"))
         assert key_file.read_bytes() == b"test-key-abc-123"
@@ -109,6 +110,7 @@ class TestSetApiKey:
         key_file = xdg_dir / "vast_api_key"
         monkeypatch.setattr("vastai.cli.util.APIKEY_FILE", str(key_file))
         monkeypatch.setattr("vastai.cli.util.APIKEY_FILE_HOME", str(tmp_path / ".vast_api_key"))
+        monkeypatch.setattr("vastai.api.machines.show_machines", lambda client: [])
 
         from vastai.cli.commands.auth import set__api_key
         set__api_key(argparse.Namespace(new_api_key="round-trip-key"))
@@ -117,6 +119,28 @@ class TestSetApiKey:
         with patch("vastai.sdk.VastClient") as MockClient:
             VastAI()
             assert MockClient.call_args[0][0] == "round-trip-key"
+
+
+class TestSetRole:
+    def test_set_role_host(self, tmp_path, monkeypatch, capsys):
+        role_file = tmp_path / "vast_role"
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(role_file))
+        from vastai.cli.commands.auth import set__role
+        set__role(argparse.Namespace(role="host"))
+        assert role_file.read_text() == "host"
+        assert "host" in capsys.readouterr().out.lower()
+
+    def test_set_role_client(self, tmp_path, monkeypatch, capsys):
+        role_file = tmp_path / "vast_role"
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(role_file))
+        from vastai.cli.commands.auth import set__role
+        set__role(argparse.Namespace(role="client"))
+        assert role_file.read_text() == "client"
+        assert "hidden" in capsys.readouterr().out.lower()
+
+    def test_only_host_and_client_are_valid_choices(self, cli_parser):
+        with pytest.raises(SystemExit):
+            cli_parser.parse_args(["set", "role", "admin"])
 
 
 class TestTfaStatus:

--- a/tests/cli/test_main_error_handling.py
+++ b/tests/cli/test_main_error_handling.py
@@ -16,7 +16,7 @@ def _http_error(status_code, msg):
     return HTTPError(response=resp)
 
 
-def _args(*, raw=False, func):
+def _args(*, raw=False, func=None):
     return argparse.Namespace(raw=raw, func=func)
 
 

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -1,10 +1,12 @@
 """Tests for vastai/cli/parser.py — apwrap, command registration, parse_args."""
 
+import argparse
+
 import pytest
 from vastai.cli.parser import (
     apwrap, argument, hidden_aliases, MyWideHelpFormatter,
     build_command_maps, two_stage_command_completions,
-    is_hidden_command,
+    is_hidden_command, is_host_only_command,
 )
 
 
@@ -176,6 +178,16 @@ def _completion_parser():
     return p
 
 
+def _completion_parser_with_host_cmd():
+    p = _completion_parser()
+
+    @p.command(help="show host machines", host_only=True)
+    def show__machines(args):
+        pass
+
+    return p
+
+
 class TestBuildCommandMaps:
     def test_splits_verbs_objects_and_singles(self):
         verbs, verb_objs, singles = build_command_maps(_completion_parser().parser)
@@ -193,6 +205,23 @@ class TestBuildCommandMaps:
             pass
 
         _, verb_objs, _ = build_command_maps(p.parser)
+        assert verb_objs["show"] == {"instances", "env-vars"}
+
+    def test_no_role_defaults_to_client_completions(self):
+        # Client is the default: an unset role (no role= passed) hides host-only commands too.
+        _, verb_objs, _ = build_command_maps(_completion_parser_with_host_cmd().parser)
+        assert verb_objs["show"] == {"instances", "env-vars"}
+
+    def test_host_role_completes_host_commands(self):
+        _, verb_objs, _ = build_command_maps(
+            _completion_parser_with_host_cmd().parser, role="host"
+        )
+        assert verb_objs["show"] == {"instances", "env-vars", "machines"}
+
+    def test_client_role_hides_host_commands_from_completion(self):
+        _, verb_objs, _ = build_command_maps(
+            _completion_parser_with_host_cmd().parser, role="client"
+        )
         assert verb_objs["show"] == {"instances", "env-vars"}
 
 
@@ -329,3 +358,133 @@ class TestTwoStageCompletions:
         cands, merged = self._complete(["vastai", "show", "--help"], "")
         assert cands is None
         assert merged == ["vastai", "show", "--help"]  # unchanged
+
+
+class TestIsHostOnlyCommand:
+    """Unit tests for the host-only/not classification (CLN-3582)."""
+
+    def test_explicit_true_wins_over_everything(self):
+        assert is_host_only_command(
+            "search offers", "vastai.cli.commands.machines", explicit=True
+        ) is True
+
+    def test_explicit_false_wins_over_everything(self):
+        assert is_host_only_command(
+            "show earnings", "vastai.cli.commands.machines", explicit=False
+        ) is False
+
+    def test_command_override_wins_over_module_default(self):
+        # 'reports' is flagged host-only despite misc.py being client-facing.
+        assert is_host_only_command("reports", "vastai.cli.commands.misc") is True
+
+    def test_falls_back_to_module_default(self):
+        assert is_host_only_command(
+            "show instances", "vastai.cli.commands.instances"
+        ) is False
+        assert is_host_only_command(
+            "show machines", "vastai.cli.commands.machines"
+        ) is True
+
+    def test_unmapped_module_and_command_defaults_to_visible(self):
+        # No raise, no "unresolved" state: an unmapped module/command is simply not host-only.
+        assert is_host_only_command("do stuff", "some.made.up.module") is False
+
+
+class TestCommandDecoratorHostOnly:
+    def test_unmapped_module_defaults_to_not_host_only(self):
+        # This test file's module isn't in HOST_ONLY_MODULES — the command is simply visible.
+        p = apwrap()
+
+        @p.command(help="show items")
+        def show__items(args):
+            pass
+
+        assert show__items.mysignature.host_only is False
+
+    def test_explicit_host_only_kwarg_is_honored(self):
+        p = apwrap()
+
+        @p.command(help="a host-only test command", host_only=True)
+        def do__hostthing(args):
+            pass
+
+        assert do__hostthing.mysignature.host_only is True
+
+    def test_host_only_help_text_is_not_auto_prefixed(self):
+        # No auto-generated [Host] marker — commands that want one write it themselves.
+        p = apwrap()
+
+        @p.command(help="do a host thing", host_only=True)
+        def do__hostthing(args):
+            pass
+
+        choices_actions = p.subparsers()._choices_actions
+        rendered = next(c.help for c in choices_actions if c.dest == "do hostthing")
+        assert rendered == "do a host thing"
+
+    def test_non_host_only_help_text_is_unchanged(self):
+        p = apwrap()
+
+        @p.command(help="a client thing", host_only=False)
+        def show__clientthing(args):
+            pass
+
+        choices_actions = p.subparsers()._choices_actions
+        rendered = {c.dest: c.help for c in choices_actions}
+        assert rendered["show clientthing"] == "a client thing"
+
+
+class TestFullCliHostOnlyCoverage:
+    """Sanity check against the real, fully-populated CLI parser."""
+
+    def _all_choices_actions(self, cli_parser):
+        for a in cli_parser.parser._actions:
+            if isinstance(a, argparse._SubParsersAction):
+                return a
+        raise AssertionError("no subparsers action found")
+
+    def test_client_view_excludes_known_host_only_commands(self, cli_parser):
+        sub_action = self._all_choices_actions(cli_parser)
+        host_only = {
+            pseudo.dest
+            for pseudo in sub_action._choices_actions
+            if getattr(sub_action.choices.get(pseudo.dest), "host_only", False)
+        }
+        assert {"show machines", "list machine", "set min-bid"} <= host_only
+        assert "show instances" not in host_only
+
+
+class TestGroupedHelpRoleFiltering:
+    """--help output hides host-only commands for the client role (CLN-3582)."""
+
+    def _parser_with_host_and_client_cmds(self):
+        p = apwrap(epilog="epilogue text")
+
+        @p.command(help="show instances", host_only=False)
+        def show__instances(args):
+            pass
+
+        @p.command(help="show host machines", host_only=True)
+        def show__machines(args):
+            pass
+
+        return p
+
+    def test_unset_role_defaults_to_client_view(self, monkeypatch):
+        # Client is the default: an unset role hides host-only commands too, not just an explicit 'client'.
+        monkeypatch.setattr("vastai.cli.parser.get_role", lambda: None)
+        help_text = self._parser_with_host_and_client_cmds().parser.format_help()
+        assert "show instances" in help_text
+        assert "show machines" not in help_text
+
+    def test_host_role_shows_everything(self, monkeypatch):
+        monkeypatch.setattr("vastai.cli.parser.get_role", lambda: "host")
+        help_text = self._parser_with_host_and_client_cmds().parser.format_help()
+        assert "show instances" in help_text
+        assert "show machines" in help_text
+
+    def test_client_role_hides_host_commands(self, monkeypatch):
+        monkeypatch.setattr("vastai.cli.parser.get_role", lambda: "client")
+        help_text = self._parser_with_host_and_client_cmds().parser.format_help()
+        assert "show instances" in help_text
+        assert "show machines" not in help_text

--- a/tests/cli/test_util.py
+++ b/tests/cli/test_util.py
@@ -324,3 +324,100 @@ class TestRequiredInetMbps:
         from vastai.cli.util import required_inet_mbps
         result = required_inet_mbps(183359)
         assert 460.0 < result < 470.0
+
+
+class TestRole:
+    """get_role / set_role_file — the client/host CLI display preference (CLN-3582)."""
+
+    def test_unset_returns_none(self, tmp_path, monkeypatch):
+        from vastai.cli.util import get_role
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(tmp_path / "vast_role"))
+        assert get_role() is None
+
+    def test_set_then_get_round_trips(self, tmp_path, monkeypatch):
+        from vastai.cli.util import get_role, set_role_file
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(tmp_path / "vast_role"))
+        set_role_file("host")
+        assert get_role() == "host"
+
+    def test_invalid_role_raises(self, tmp_path, monkeypatch):
+        from vastai.cli.util import set_role_file
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(tmp_path / "vast_role"))
+        with pytest.raises(ValueError):
+            set_role_file("admin")
+
+    def test_corrupt_file_contents_return_none_not_raise(self, tmp_path, monkeypatch):
+        from vastai.cli.util import get_role
+        role_file = tmp_path / "vast_role"
+        role_file.write_text("garbage\nbinary\x00data")
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(role_file))
+        assert get_role() is None
+
+
+class TestDetectRole:
+    """detect_role — lazy role resolution on the user's next real command (CLN-3582)."""
+
+    def _client(self, tmp_path, monkeypatch, *, host_agreement_accepted=None, show_user_raises=None):
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(tmp_path / "vast_role"))
+        if show_user_raises is not None:
+            monkeypatch.setattr(
+                "vastai.api.billing.show_user",
+                lambda client: (_ for _ in ()).throw(show_user_raises),
+            )
+        else:
+            monkeypatch.setattr(
+                "vastai.api.billing.show_user",
+                lambda client: {"host_agreement_accepted": host_agreement_accepted},
+            )
+        return object()  # stand-in "client"; show_user is patched to ignore it
+
+    def test_host_account_caches_host(self, tmp_path, monkeypatch, capsys):
+        # host_agreement_accepted flips the moment the hosting agreement is accepted —
+        # independent of whether any machine has been listed yet.
+        from vastai.cli.util import detect_role, get_role
+        client = self._client(tmp_path, monkeypatch, host_agreement_accepted=True)
+        detect_role(client)
+        assert get_role() == "host"
+        assert capsys.readouterr().err == "Detecting role.. host\n"
+
+    def test_client_account_caches_client(self, tmp_path, monkeypatch, capsys):
+        # An unaccepted agreement is a real answer, not "still unknown" — it gets cached just like a host does.
+        from vastai.cli.util import detect_role, get_role
+        client = self._client(tmp_path, monkeypatch, host_agreement_accepted=False)
+        detect_role(client)
+        assert get_role() == "client"
+        assert capsys.readouterr().err == "Detecting role.. client\n"
+
+    def test_network_error_leaves_role_undetected(self, tmp_path, monkeypatch, capsys):
+        from vastai.cli.util import detect_role, get_role
+        client = self._client(tmp_path, monkeypatch, show_user_raises=ConnectionError("offline"))
+        detect_role(client)
+        assert get_role() is None
+        assert capsys.readouterr().err == "Detecting role.."
+
+    def test_role_file_write_failure_does_not_raise(self, tmp_path, monkeypatch, capsys):
+        # set_role_file() must be inside the try/except: a disk that can't be written
+        # to (permissions, read-only home, disk full) shouldn't crash the real command
+        # that triggered detection.
+        from vastai.cli.util import detect_role, get_role
+        client = self._client(tmp_path, monkeypatch, host_agreement_accepted=True)
+        monkeypatch.setattr(
+            "vastai.cli.util.set_role_file",
+            lambda role: (_ for _ in ()).throw(OSError("read-only filesystem")),
+        )
+        detect_role(client)  # must not raise
+        assert get_role() is None
+        assert capsys.readouterr().err == "Detecting role.."
+
+    def test_already_resolved_role_is_not_rechecked(self, tmp_path, monkeypatch):
+        from vastai.cli.util import detect_role, set_role_file, get_role
+        monkeypatch.setattr("vastai.cli.util.ROLE_FILE", str(tmp_path / "vast_role"))
+        set_role_file("client")
+        called = []
+        monkeypatch.setattr(
+            "vastai.api.billing.show_user",
+            lambda client: called.append(True) or {"host_agreement_accepted": True},
+        )
+        detect_role(object())
+        assert called == []
+        assert get_role() == "client"  # not flipped to host

--- a/vastai/cli/commands/auth.py
+++ b/vastai/cli/commands/auth.py
@@ -221,6 +221,31 @@ def set__api_key(args):
 
 
 # ---------------------------------------------------------------------------
+# set role
+# ---------------------------------------------------------------------------
+
+@parser.command(
+    argument("role", help="'host' or 'client'", choices=["host", "client"]),
+    usage="vastai set role host|client",
+    help="Set host role to view host-only commands",
+    epilog=deindent("""
+        This only changes what --help and tab completion display — every command
+        still runs regardless of role, since the server enforces real permissions.
+    """),
+)
+def set__role(args):
+    """Set the client/host CLI display role."""
+    from vastai.cli.util import set_role_file
+
+    set_role_file(args.role)
+    print(f"CLI role set to '{args.role}'.")
+    if args.role == "client":
+        print("Host-only commands are now hidden from --help and tab completion.")
+    else:
+        print("All commands (client + host) are now shown in --help and tab completion.")
+
+
+# ---------------------------------------------------------------------------
 # Note: set__user and show__user are in billing.py.
 # Note: show__ipaddrs is in billing.py.
 # ---------------------------------------------------------------------------

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -135,7 +135,8 @@ def main():
             def _command_maps(self):
                 cached = getattr(self, "_cmd_maps", None)
                 if cached is None:
-                    cached = self._cmd_maps = build_command_maps(self._parser)
+                    from vastai.cli.util import get_role
+                    cached = self._cmd_maps = build_command_maps(self._parser, role=get_role())
                 return cached
 
             def _get_completions(self, comp_words, cword_prefix, cword_prequote, last_wordbreak_pos):

--- a/vastai/cli/parser.py
+++ b/vastai/cli/parser.py
@@ -11,6 +11,8 @@ import sys
 import argparse
 from pathlib import Path
 
+from vastai.cli.util import get_role, is_client_view
+
 
 # ---------------------------------------------------------------------------
 # Tab-completion helpers
@@ -46,18 +48,15 @@ def complete_sshkeys(prefix=None, action=None, parser=None, parsed_args=None):
 # into staged completion. The argcomplete adapter in cli/main.py calls them.
 # ---------------------------------------------------------------------------
 
-def build_command_maps(parser):
-    """Derive (verbs, verb_objs, singles) from a parser's subparser names.
-
-    Commands flagged hidden (see ``is_hidden_command``) are left out of
-    completion — unreleased/feature-flagged functionality, still fully
-    runnable if typed directly.
-    """
+def build_command_maps(parser, role=None):
+    """Derive (verbs, verb_objs, singles) from a parser's subparser names, excluding hidden and (unless role='host') host-only commands."""
     names = []
     for action in parser._actions:
         if isinstance(action, argparse._SubParsersAction):
             for name, sp in action.choices.items():
                 if getattr(sp, 'hidden', False):
+                    continue
+                if is_client_view(role) and getattr(sp, 'host_only', False):
                     continue
                 names.append(name)
             break
@@ -164,6 +163,35 @@ COMMAND_OVERRIDES = {
     'reports':       'Host machines',
 }
 
+# Host-only command classification (CLN-3582): display-only, hides host-only commands from --help/completion/hints for the client role; unclassified defaults to visible.
+
+# Modules where every command is host-only.
+HOST_ONLY_MODULES = {
+    'vastai.cli.commands.machines',
+    'vastai.cli.commands.metrics',
+}
+
+# Individual host-only commands in modules that are mostly client-facing (same shape as COMMAND_OVERRIDES above).
+HOST_ONLY_COMMANDS = {
+    'reports',                # misc.py: machine reports, not instance logs
+    'show earnings',          # billing.py: machine earning history
+    'list network-volume',    # storage.py: list disk space for rent
+    'list volume',
+    'list volumes',
+    'unlist network-volume',
+    'unlist volume',
+}
+
+
+def is_host_only_command(name, module, explicit=None):
+    """Whether a command is hidden from the client CLI view: explicit host_only= kwarg > per-command override > per-module default > False (visible)."""
+    if explicit is not None:
+        return bool(explicit)
+    if name in HOST_ONLY_COMMANDS:
+        return True
+    return module in HOST_ONLY_MODULES
+
+
 GROUP_ORDER = [
     'Search', 'Instances', 'Host machines', 'Teams', 'Auth & keys',
     'Billing & account', 'Serverless', 'Metrics', 'Storage volumes', 'Other',
@@ -235,12 +263,16 @@ class GroupedArgumentParser(argparse.ArgumentParser):
         return None
 
     def _add_grouped_commands(self, formatter, sub_action):
+        """Render grouped commands."""
+        role = get_role()
         grouped = {}
         for pseudo in sub_action._choices_actions:
             sp = sub_action.choices.get(pseudo.dest)
             if sp is None:
                 continue
             if getattr(sp, 'hidden', False):
+                continue
+            if is_client_view(role) and getattr(sp, 'host_only', False):
                 continue
             label = COMMAND_OVERRIDES.get(pseudo.dest)
             if label is None:
@@ -323,7 +355,7 @@ class apwrap(object):
             name = verb
         return name
 
-    def command(self, *arguments, aliases=(), help=None, hidden=None, **kwargs):
+    def command(self, *arguments, aliases=(), help=None, hidden=None, host_only=None, **kwargs):
         help_ = help
         if not self.added_help_cmd:
             self.added_help_cmd = True
@@ -345,6 +377,8 @@ class apwrap(object):
 
             sp = self.subparsers().add_parser(name, aliases=aliases_transformed, help=help_, **kwargs)
             sp.hidden = is_hidden_command(name, explicit=hidden)
+            sp.host_only = is_host_only_command(name, func.__module__, explicit=host_only)
+            sp.command_name = name
 
             # TODO: Sometimes the parser.command has a help parameter. Ideally
             # I'd extract this during the sdk phase but for the life of me

--- a/vastai/cli/util.py
+++ b/vastai/cli/util.py
@@ -190,6 +190,52 @@ def format_key_suffix(k):
     return "(empty)"
 
 
+# Client/host CLI role (CLN-3582): display-only (--help/completion/hints), never gates execution; client is the default until the role explicitly resolves to 'host'.
+
+ROLE_FILE = os.path.join(DIRS['config'], "vast_role")
+ROLE_CLIENT = "client"
+ROLE_HOST = "host"
+VALID_ROLES = {ROLE_CLIENT, ROLE_HOST}
+
+
+def get_role():
+    """Return the stored CLI role ('client' or 'host'), or None if ROLE_FILE is missing/unrecognized — never raises."""
+    try:
+        with open(ROLE_FILE) as f:
+            role = f.read().strip().lower()
+    except OSError:
+        return None
+    return role if role in VALID_ROLES else None
+
+
+def is_client_view(role):
+    """Whether role (as returned by get_role) means "show the client view" — everything except explicit 'host', including None."""
+    return role != ROLE_HOST
+
+
+def set_role_file(role):
+    """Persist role ('client' or 'host') to ROLE_FILE; raises ValueError for anything else."""
+    if role not in VALID_ROLES:
+        raise ValueError(f"role must be one of {sorted(VALID_ROLES)}, got {role!r}")
+    with open(ROLE_FILE, "w") as f:
+        f.write(role)
+
+
+def detect_role(client):
+    """Best-effort: resolve and permanently cache the role via client if it isn't known yet; never raises (a failed check just leaves it undetected for retry)."""
+    if get_role() is not None:
+        return
+    try:
+        print("Detecting role..", end="", file=sys.stderr, flush=True)
+        from vastai.api import billing as billing_api
+        is_host = bool(billing_api.show_user(client).get("host_agreement_accepted"))
+        role = ROLE_HOST if is_host else ROLE_CLIENT
+        set_role_file(role)
+        print(f" {role}", file=sys.stderr)
+    except Exception:
+        return
+
+
 # ---------------------------------------------------------------------------
 # Simple utility class
 # ---------------------------------------------------------------------------

--- a/vastai/cli/utils.py
+++ b/vastai/cli/utils.py
@@ -9,7 +9,8 @@ def get_parser():
 def get_client(args):
     """Create a VastClient from parsed CLI args."""
     from vastai.api.client import VastClient
-    return VastClient(
+    from vastai.cli.util import detect_role
+    client = VastClient(
         api_key=args.api_key,
         server_url=args.url,
         retry=args.retry,
@@ -17,3 +18,5 @@ def get_client(args):
         curl=getattr(args, 'curl', False),
         client_type="cli",
     )
+    detect_role(client)
+    return client


### PR DESCRIPTION
Renters (clients) no longer see host-only commands in `--help`/tab completion (machine management, listings, min-bid, maintenance, etc.); hosts see everything. Display-only — the server still enforces real permissions, so any command still runs if typed directly.

## How
- Every command is classified host-only or not (`is_host_only_command()` in `vastai/cli/parser.py`) via an explicit `host_only=` kwarg, a per-command override set, or a per-module default (`machines.py`, `metrics.py`). Unclassified defaults to visible.
- Role (`client`/`host`) is stored in `~/.config/vastai/vast_role`. Unset = client, the default.
- Auto-detected lazily on the user's next real command (`get_client()` → `ensure_host_role_detected()`), via `GET /users/current`'s `host_agreement_accepted` flag — resolves correctly even before a new host's first machine listing. Cached permanently once resolved; `vastai set role host|client` overrides manually.
- The existing hand-written `[Host]` help-text prefixes are preserved as-is — no auto-generated prefix.

## Validation
- `poetry run pytest tests/cli` — 458 passed
- `bash tests/installer/run_tests.sh` — 19 passed
- CI green end to end

[CLN-3582](https://vastai.atlassian.net/browse/CLN-3582)
