### PR TITLE
docs: split README install (installer for Linux/macOS/WSL, pip for SDK/Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@ The official Vast.ai Python package — provides both the CLI and SDK for managi
 
 ## Install
 
+**Linux, macOS, or WSL** — install the CLI with no Python required:
+
+```bash
+curl -fsSL https://vast.ai/install.sh | bash
+```
+
+This installs `vastai` into an isolated managed runtime under
+`~/.local/share/vastai`, decoupled from any system or project Python. Update
+anytime with `vastai update`, or pin/roll back with `vastai update --version X`.
+
+**Windows, or using the Python SDK** — install from PyPI instead:
+
 ```bash
 pip install vastai
 ```


### PR DESCRIPTION
## Summary
- README: Linux/macOS/WSL now lead with `curl -fsSL https://vast.ai/install.sh | bash`; `pip install vastai` stays documented for the Python SDK and for Windows users (no native Windows installer yet).

Redirects are confirmed live (`https://vast.ai/install.sh` → GitHub Release asset via 307), so this is the intended next step per the dark-launch rollout in `docs/install-design.md`.

## Test plan
- [x] `git diff` confirms only README.md changed
- [ ] Reviewer sanity-check: README renders correctly on GitHub