### PR TITLE
installer: simplify post-install messages, api-key check; unhide vastai update

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,7 +37,6 @@ LOCAL_BIN="$HOME/.local/bin"
 NO_MODIFY_PATH="${VASTAI_NO_MODIFY_PATH:-}"
 WORKDIR=""
 RC_UPDATED=""
-NEEDS_PATH_HINT=""
 
 # Anything that prints first tears down the live progress region (no-op when it's not up).
 say()  { ui_end; printf '  %s\n' "$*"; }
@@ -446,14 +445,6 @@ setup_path() {
     link_swap "$ROOT/bin/vastai" "$LOCAL_BIN/vastai"
     write_env_sh
 
-    # Hint "Use it now" whenever this shell wouldn't run our vastai (off PATH or outranked, e.g. by a pip install).
-    local existing
-    existing="$(command -v vastai 2>/dev/null || true)"
-    case "$existing" in
-        "$LOCAL_BIN/vastai"|"$ROOT/bin/vastai") ;;
-        *) NEEDS_PATH_HINT=1 ;;
-    esac
-
     local rc_file line
     rc_file="$(rc_file_for_shell)"
     line="[ -f \"$ROOT/env.sh\" ] && . \"$ROOT/env.sh\"  # vastai shell setup"
@@ -470,6 +461,13 @@ setup_path() {
         say "To finish setup, add this line to your shell rc file:"
         printf '\n%s\n\n' "$line"
     fi
+}
+
+# Mirrors the CLI's key lookup (env var, XDG config file, legacy dotfile).
+has_api_key() {
+    [ -n "${VAST_API_KEY:-}" ] && return 0
+    [ -s "${XDG_CONFIG_HOME:-$HOME/.config}/vastai/vast_api_key" ] && return 0
+    [ -s "$HOME/.vast_api_key" ]
 }
 
 check_pip_coexistence() {
@@ -532,16 +530,16 @@ main() {
     check_pip_coexistence
 
     printf '\n'
-    say "vastai $version installed to $ROOT"
-    if [ -n "$RC_UPDATED" ] && [ -n "$NEEDS_PATH_HINT" ]; then
-        say "  Use it now:   start a new shell, or run: export PATH=\"\$HOME/.local/bin:\$PATH\""
+    say "vastai $version installed"
+    # A returning user (key already configured) gets a check instead of the setup hint.
+    if has_api_key; then
+        local check='✓'
+        [ -t 1 ] && [ "${TERM:-dumb}" != dumb ] && check="$(printf '\033[32m✓\033[0m')"
+        say "  API key:       $check found"
+    else
+        say "  Get started:   vastai set api-key YOUR_API_KEY   (https://cloud.vast.ai/manage-keys/?tab=api-keys)"
     fi
-    say "  Get started:  vastai set api-key YOUR_API_KEY   (https://cloud.vast.ai/manage-keys/?tab=api-keys)"
-    say "  All commands: vastai --help"
-    say "  Update later: vastai update"
-    if [ -n "$RC_UPDATED" ]; then
-        say "  Tab completion: start a new shell, then type 'vastai <TAB>'"
-    fi
+    say "  All commands:  vastai --help"
 }
 
 main "$@"

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -272,10 +272,13 @@ class TestFullCliHiddenCommands:
         args = cli_parser.parse_args(["add", "network-disk", "1", "/mnt/data"])
         assert callable(args.func)
 
-    def test_update_and_uninstall_are_hidden_from_help(self, cli_parser):
+    def test_update_is_visible_in_help(self, cli_parser):
         help_text = cli_parser.parser.format_help()
-        assert "\nupdate " not in help_text
-        assert "\nuninstall " not in help_text
+        assert "Update the CLI to the latest version" in help_text
+
+    def test_uninstall_is_hidden_from_help(self, cli_parser):
+        help_text = cli_parser.parser.format_help()
+        assert "uninstall" not in help_text
 
     def test_update_and_uninstall_still_parse_directly(self, cli_parser):
         assert callable(cli_parser.parse_args(["update", "--check"]).func)

--- a/tests/installer/run_tests.sh
+++ b/tests/installer/run_tests.sh
@@ -123,7 +123,8 @@ new_sandbox() {
 
 # run_install [VAR=VAL ...] — real install.sh, detached from any tty
 run_install() {
-    local envs=("HOME=$SB_HOME" "VASTAI_INSTALL_DIR=$SB_ROOT" "VASTAI_CLI_BASE_URL=$SERVER/good" "SHELL=/bin/bash" "$@")
+    # VAST_API_KEY=/XDG_CONFIG_HOME= keep a developer's real key from flipping the api-key hint.
+    local envs=("HOME=$SB_HOME" "VASTAI_INSTALL_DIR=$SB_ROOT" "VASTAI_CLI_BASE_URL=$SERVER/good" "SHELL=/bin/bash" "VAST_API_KEY=" "XDG_CONFIG_HOME=" "$@")
     [ -z "$HAVE_SETSID" ] && envs+=("VASTAI_NO_MODIFY_PATH=1")
     if [ -n "$HAVE_SETSID" ]; then
         setsid -w env "${envs[@]}" bash "$INSTALL_SH" >"$SB_OUT" 2>&1 </dev/null
@@ -137,7 +138,7 @@ run_install() {
 # which is the regression guarantee for the TTY-only array and $'...' paths. Needs script(1).
 run_install_tty() {
     local cmd=(env "HOME=$SB_HOME" "VASTAI_INSTALL_DIR=$SB_ROOT" \
-        "VASTAI_CLI_BASE_URL=$SERVER/good" "SHELL=/bin/bash" "$@" \
+        "VASTAI_CLI_BASE_URL=$SERVER/good" "SHELL=/bin/bash" "VAST_API_KEY=" "XDG_CONFIG_HOME=" "$@" \
         "${VASTAI_TEST_TTY_BASH:-/bin/bash}" "$INSTALL_SH")
     case "$(uname -s)" in
         Darwin*) script -q /dev/null "${cmd[@]}" >"$SB_OUT" 2>&1 </dev/null ;;
@@ -283,7 +284,7 @@ test_pip_shadowing() { # pip vastai earlier in PATH -> warning; sourcing env.sh 
         out_lacks "pip uninstall"
 }
 
-test_pip_shadowing_quiet() { # rc update resolves coexistence -> no warning, just the use-it-now hint
+test_pip_shadowing_quiet() { # rc update resolves coexistence -> no warning
     new_sandbox pipquiet
     command -v script >/dev/null 2>&1 || { echo "    (skipped: no script(1))"; return 0; }
     mkdir -p "$SB/pipbin" "$SB_HOME/.local/bin"
@@ -294,7 +295,7 @@ test_pip_shadowing_quiet() { # rc update resolves coexistence -> no warning, jus
     run_install_tty "PATH=$SB/pipbin:$SB_HOME/.local/bin:/usr/bin:/bin"
     assert "rc gained the env.sh line" grep -q 'env\.sh' "$SB_HOME/.bashrc" &&
     assert "no coexistence warning once resolved" out_lacks "another vastai" &&
-    assert "current-shell hint printed" out_contains "Use it now"
+    assert "install completed" out_contains "vastai 1.2.3 installed"
 }
 
 test_pip_shadowing_rerun() { # re-run with new shadowing: rc line idempotent, no spurious warning
@@ -315,7 +316,22 @@ test_pip_shadowing_rerun() { # re-run with new shadowing: rc line idempotent, no
     assert "rc line present exactly once" [ "$(grep -c 'env\.sh' "$SB_HOME/.bashrc")" -eq 1 ] &&
     assert "rc symlink survives" [ -L "$SB_HOME/.bashrc" ] &&
     assert "no spurious warning when rc already resolves precedence" out_lacks "another vastai" &&
-    assert "use-it-now hint printed for the shadowed shell" out_contains "Use it now"
+    assert "install completed" out_contains "vastai 1.2.3 installed"
+}
+
+test_api_key_hint() { # no key -> get-started hint; key on disk -> checkmark instead
+    new_sandbox nokey
+    run_install || { cat "$SB_OUT"; return 1; }
+    assert "fresh install shows the get-started hint" out_contains "Get started" &&
+    assert "no api-key checkmark without a key" out_lacks "API key" &&
+    assert "help hint always printed" out_contains "All commands" || return 1
+    new_sandbox haskey
+    mkdir -p "$SB_HOME/.config/vastai"
+    echo "k3y" > "$SB_HOME/.config/vastai/vast_api_key"
+    run_install || { cat "$SB_OUT"; return 1; }
+    assert "existing key suppresses the get-started hint" out_lacks "Get started" &&
+    assert "checkmark shown for the existing key" out_contains "API key: *✓ found" &&
+    assert "help hint always printed" out_contains "All commands"
 }
 
 test_completion_files_generated() { # static completion scripts precomputed under share/
@@ -380,7 +396,7 @@ test_progress_failure_shows_tool_error() { # the bar must not swallow diagnostic
 # Runner
 # ---------------------------------------------------------------------------
 
-ALL_TESTS=(fresh_install pinned_reinstall xdg_data_home_default wheel_url_install wheel_url_pin_fallback checksum_abort truncation_guard glibc_floor rc_safety env_sh pip_shadowing pip_shadowing_quiet pip_shadowing_rerun completion_files_generated tty_install progress_bar progress_opt_out progress_failure_shows_tool_error)
+ALL_TESTS=(fresh_install pinned_reinstall xdg_data_home_default wheel_url_install wheel_url_pin_fallback checksum_abort truncation_guard glibc_floor rc_safety env_sh pip_shadowing pip_shadowing_quiet pip_shadowing_rerun api_key_hint completion_files_generated tty_install progress_bar progress_opt_out progress_failure_shows_tool_error)
 # No "${@:-...}": expanding $@ with zero args under set -u is itself fatal on
 # old bash, and this harness must run under macOS's stock bash 3.2 (see
 # test_tty_install).

--- a/vastai/cli/commands/update.py
+++ b/vastai/cli/commands/update.py
@@ -27,7 +27,6 @@ EXIT_STALE = 10  # `update --check` exit code when a newer version exists
     argument("--version", dest="target_version", metavar="VERSION", help="install a specific version instead of the latest (also how you pin or roll back)"),
     usage="vastai update [--check | --version VERSION]",
     help="Update the CLI to the latest version",
-    hidden=True,  # still under testing — remove once ready to announce
     epilog=deindent("""
         Updates a CLI installed with the managed installer
         (curl -fsSL https://vast.ai/install.sh | bash). The new version is


### PR DESCRIPTION
## What's changed

**`scripts/install.sh`**
- Removed the `Use it now`, `Tab completion`, and `Update later` lines, plus the now-unused `NEEDS_PATH_HINT` machinery.
- The final "installed" line no longer repeats the install path (it's already in the opening `Installing … → path` line), and the remaining labels are padded to one aligned column.
- Added a `has_api_key` helper mirroring the CLI's lookup order (`VAST_API_KEY` env var, `${XDG_CONFIG_HOME:-~/.config}/vastai/vast_api_key`, legacy `~/.vast_api_key`).
- Final output for a first-time user:
  ```
  vastai 1.5.2 installed
    Get started:   vastai set api-key YOUR_API_KEY   (https://cloud.vast.ai/manage-keys/?tab=api-keys)
    All commands:  vastai --help
  ```
  and for a returning user with a key already configured:
  ```
  vastai 1.5.2 installed
    API key:       ✓ found
    All commands:  vastai --help
  ```
  The `✓` renders green at a TTY and plain when piped. `All commands` prints unconditionally.

**`vastai/cli/commands/update.py`** — removed `hidden=True`, so `vastai update` now shows in `--help` (its help line is "Update the CLI to the latest version"). `uninstall` remains hidden.

**Tests**
- `tests/installer/run_tests.sh`: new `api_key_hint` test covering both branches (hint shown without a key, checkmark + no hint with one); replaced the two `Use it now` assertions; the harness now pins `VAST_API_KEY=` and `XDG_CONFIG_HOME=` so a developer's real key can't flip the sandboxed installs.
- `tests/cli/test_parser.py`: split the old hidden-commands test into `test_update_is_visible_in_help` and `test_uninstall_is_hidden_from_help`. (The old `"\nupdate "` pattern could never match since help lines are indented — the visibility assertion now checks the command's help string.)

**Note:** dropping `Use it now` means someone whose shell resolves a stale pip-installed `vastai` gets no immediate-use hint anymore — they'll pick up the new binary on their next shell. The `another vastai is on your PATH` warning still covers the case where precedence couldn't be fixed.

## Test plan
- `tests/installer/run_tests.sh` — 19/19 pass (includes new `api_key_hint`)
- `poetry run pytest tests/cli/test_parser.py` — 57/57 pass