### PR TITLE
docs(skill): lead with curl installer in SKILL.md

### DIFF
--- a/vastai/SKILL.md
+++ b/vastai/SKILL.md
@@ -16,7 +16,10 @@ Manage GPU instances, templates, volumes, serverless endpoints, SSH keys, and bi
 ## Install
 
 ```bash
-# PyPI (recommended)
+# Linux/macOS (recommended, no Python required)
+curl -fsSL https://vast.ai/install.sh | bash
+
+# or via PyPI (Windows, or if you'd rather use pip)
 pip install vastai
 ```
 


### PR DESCRIPTION
## Summary
- The CLI's own SKILL.md still listed `pip install vastai` as the "recommended" install method, contradicting README #486 which made the curl installer (`curl -fsSL https://vast.ai/install.sh | bash`) the primary path for Linux/macOS.
- This file is fetched live by AI agents (linked from vast.ai's llms.txt / skill.md / agent-skills index), so the stale guidance was actively served.

## Test plan
- [ ] Render/view the updated Install section renders correctly