### PR TITLE
fix(cli): prompt to set api key on 401 when none is configured (CLN-3748)

### DIFF
--- a/tests/cli/test_main_error_handling.py
+++ b/tests/cli/test_main_error_handling.py
@@ -97,6 +97,23 @@ class TestRunCommandSessionExpiredRetry:
         out = capsys.readouterr().out
         assert "vastai tfa login" in out
 
+    def test_401_with_no_api_key_configured_prompts_to_set_one(self, tmp_path, monkeypatch, capsys):
+        tfa_file = tmp_path / "vast_tfa_key"  # does not exist
+        api_file = tmp_path / "vast_api_key"  # does not exist
+        monkeypatch.delenv("VAST_API_KEY", raising=False)
+
+        func = MagicMock(side_effect=[_http_error(401, "Please log in or sign up")])
+        args = _args(func=func)
+
+        with patch("vastai.cli.main.TFAKEY_FILE", str(tfa_file)), \
+             patch("vastai.cli.main.APIKEY_FILE", str(api_file)):
+            run_command(args)
+
+        err = capsys.readouterr().err
+        assert "No API key is configured." in err
+        assert "vastai set api-key <KEY>" in err
+        assert "https://console.vast.ai/manage-keys/" in err
+
     def test_plain_404_without_tfa_key_file_is_not_treated_as_session_expiry(self, tmp_path, capsys):
         tfa_file = tmp_path / "vast_tfa_key"  # does not exist
         api_file = tmp_path / "vast_api_key"

--- a/vastai/cli/main.py
+++ b/vastai/cli/main.py
@@ -68,7 +68,13 @@ def _emit_error(args, status_code, message):
             except OSError:
                 pass
 
-        if env and file_key:
+        key_missing = not env and not file_key
+
+        if key_missing:
+            print("  No API key is configured.", file=sys.stderr)
+            print("  Run: vastai set api-key <KEY>", file=sys.stderr)
+            print("  Create a key at https://console.vast.ai/manage-keys/", file=sys.stderr)
+        elif env and file_key:
             print(f"  Sent key from $VAST_API_KEY (ends in {format_key_suffix(env)}). Env var overrides the file.", file=sys.stderr)
             print(f"  Unset the VAST_API_KEY env var to use the saved key in {APIKEY_FILE} (ends in {format_key_suffix(file_key)}) instead.", file=sys.stderr)
         elif env:


### PR DESCRIPTION
Jira: [CLN-3748](https://vastai.atlassian.net/browse/CLN-3748)

## Summary
- When a request fails with 401 and neither `$VAST_API_KEY` nor the saved key file has a key, print a clear prompt (`vastai set api-key <KEY>` + link to create one) instead of a bare `Failed with error 401: ...`.
- Named the "neither key source present" condition as `key_missing` for readability.

## Test plan
- [x] Added `test_401_with_no_api_key_configured_prompts_to_set_one` covering the new message.
- [x] `poetry run pytest tests/cli/` — 432 passed.