### PR TITLE
docs(cli): document host_id as a search offers filter field

### DIFF
--- a/vast.py
+++ b/vast.py
@@ -4270,6 +4270,9 @@ def search__invoices(args):
             # search for reliable 4 gpu offers in Taiwan or Sweden
             vastai search offers 'reliability>0.99 num_gpus=4 geolocation in [TW,SE]'
 
+            # exclude offers from specific hosts (e.g. hosts that repeatedly failed for you)
+            vastai search offers 'gpu_name=RTX_4090 host_id notin [12345,67890]'
+
             # search for reliable RTX 3090 or 4090 gpus NOT in China or Vietnam
             vastai search offers 'reliability>0.99 gpu_name in ["RTX 4090", "RTX 3090"] geolocation notin [CN,VN]'
 
@@ -4316,6 +4319,7 @@ def search__invoices(args):
             gpu_frac:               float     Ratio of GPUs in the offer to gpus in the system
             gpu_display_active:     bool      True if the GPU has a display attached
             has_avx:                bool      CPU supports AVX instruction set.
+            host_id:                int       host id of the machine offering the instance. Works with operators =, !=, in, notin (e.g. host_id notin [12345,67890] to exclude specific hosts)
             id:                     int       instance unique ID
             inet_down:              float     internet download speed in Mb/s
             inet_down_cost:         float     internet download bandwidth cost in $/GB


### PR DESCRIPTION
## What

Adds `host_id` to the **Available fields** list in `vastai search offers --help`, and adds an example showing how to exclude specific hosts with `notin`.

## Why

`host_id` has always been filterable in offer search — including `host_id notin [...]` for excluding hosts — but it was absent from the help's field list (while `machine_id` was listed), so users had no way to discover it. Verified against the live API: `notin` excludes exactly the listed hosts for both authenticated and anonymous queries.

No behavior change — help text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)