### PR TITLE
Add queue-mode serverless scaling support to SDK and CLI

### DIFF
--- a/tests/cli/test_endpoints_commands.py
+++ b/tests/cli/test_endpoints_commands.py
@@ -26,6 +26,38 @@ class TestCreateEndpoint:
         assert "/endptjobs/" in call_args[0][0]
 
 
+class TestCreateEndpointScalingConfig:
+    def test_create_endpoint_builds_scaling_config(self, parse_argv, patch_get_client, mock_response, capsys):
+        patch_get_client.post.return_value = mock_response(200, {"success": True, "id": 1})
+        args = parse_argv([
+            "create", "endpoint", "--endpoint_name", "test-ep",
+            "--scaling_mode", "queue", "--requests_per_worker", "2", "--idle_timeout", "30",
+        ])
+        args.func(args)
+        call_args = patch_get_client.post.call_args
+        blob = call_args.kwargs.get("json_data") or call_args[1].get("json_data")
+        assert blob["scaling_config"] == {"mode": "queue", "requests_per_worker": 2, "idle_timeout": 30.0}
+
+    def test_create_endpoint_without_scaling_mode_sends_none(self, parse_argv, patch_get_client, mock_response, capsys):
+        patch_get_client.post.return_value = mock_response(200, {"success": True, "id": 1})
+        args = parse_argv(["create", "endpoint", "--endpoint_name", "test-ep"])
+        args.func(args)
+        call_args = patch_get_client.post.call_args
+        blob = call_args.kwargs.get("json_data") or call_args[1].get("json_data")
+        assert blob["scaling_config"] is None
+
+    def test_update_endpoint_builds_scaling_config(self, parse_argv, patch_get_client, mock_response, capsys):
+        patch_get_client.put.return_value = mock_response(200, {"success": True})
+        args = parse_argv([
+            "update", "endpoint", "1",
+            "--scaling_mode", "queue", "--scaler", "queue_delay", "--queue_delay_target", "15",
+        ])
+        args.func(args)
+        call_args = patch_get_client.put.call_args
+        blob = call_args.kwargs.get("json_data") or call_args[1].get("json_data")
+        assert blob["scaling_config"] == {"mode": "queue", "scaler": "queue_delay", "queue_delay_target": 15.0}
+
+
 class TestDeleteEndpoint:
     def test_delete_endpoint(self, parse_argv, patch_get_client, mock_response, capsys):
         patch_get_client.delete.return_value = mock_response(200, {"success": True})

--- a/tests/serverless/test_endpoint_client.py
+++ b/tests/serverless/test_endpoint_client.py
@@ -485,3 +485,93 @@ class TestRouteResponse:
 
     def test_waiting_repr_contains_status(self) -> None:
         assert "WAITING" in repr(RouteResponse({"pending": True}))
+
+    def test_queued_status_from_queue_mode_body(self) -> None:
+        """
+        Verifies RouteResponse surfaces queue-mode responses as QUEUED.
+
+        This test verifies by:
+        1. Constructing RouteResponse from a body with status "queued" and no url
+        2. Asserting status QUEUED with queue_position/queue_depth exposed
+
+        Assumptions:
+        - Queue-mode autoscaler sets status "queued" plus position/depth fields
+        """
+        r = RouteResponse({"request_idx": 7, "status": "queued", "queue_position": 2, "queue_depth": 5})
+        assert r.status == "QUEUED"
+        assert r.request_idx == 7
+        assert r.queue_position == 2
+        assert r.queue_depth == 5
+        assert r.get_url() is None
+
+    def test_queued_position_defaults_none_when_absent(self) -> None:
+        """
+        Verifies queue_position/queue_depth are None outside queue mode.
+
+        This test verifies by:
+        1. Constructing a WAITING response without queue fields
+        2. Asserting both properties are None
+
+        Assumptions:
+        - Properties read straight from the body dict
+        """
+        r = RouteResponse({"request_idx": 1})
+        assert r.status == "WAITING"
+        assert r.queue_position is None
+        assert r.queue_depth is None
+
+    def test_url_wins_over_queued_status(self) -> None:
+        """
+        Verifies READY takes precedence when a url is present.
+
+        This test verifies by:
+        1. Constructing a body with both url and status fields
+        2. Asserting READY
+
+        Assumptions:
+        - Assigned tasks always carry the worker url
+        """
+        r = RouteResponse({"url": "https://worker", "status": "queued"})
+        assert r.status == "READY"
+
+
+class TestEndpointSubmitTaskStatus:
+    """Endpoint.submit / task_status delegation to _route."""
+
+    @pytest.mark.asyncio
+    async def test_submit_routes_with_idx_zero(self, make_delegate_endpoint) -> None:
+        """
+        Verifies submit() delegates to _route with req_idx 0.
+
+        This test verifies by:
+        1. Patching _route with an AsyncMock
+        2. Calling submit and asserting the delegated arguments
+
+        Assumptions:
+        - submit is a thin wrapper over _route
+        """
+        ep = make_delegate_endpoint(name="n", endpoint_id=1, api_key="k")
+        ep._route = AsyncMock(return_value=RouteResponse({"request_idx": 3, "status": "queued"}))
+        r = await ep.submit(timeout=45.0)
+        ep._route.assert_awaited_once_with(cost=0.0, req_idx=0, timeout=45.0)
+        assert r.status == "QUEUED"
+        assert r.request_idx == 3
+
+    @pytest.mark.asyncio
+    async def test_task_status_routes_with_given_idx(self, make_delegate_endpoint) -> None:
+        """
+        Verifies task_status() polls _route with the task's request_idx.
+
+        This test verifies by:
+        1. Patching _route with an AsyncMock returning a READY body
+        2. Calling task_status(3) and asserting delegation and READY result
+
+        Assumptions:
+        - task_status is a thin wrapper over _route
+        """
+        ep = make_delegate_endpoint(name="n", endpoint_id=1, api_key="k")
+        ep._route = AsyncMock(return_value=RouteResponse({"request_idx": 3, "url": "https://worker"}))
+        r = await ep.task_status(3)
+        ep._route.assert_awaited_once_with(cost=0.0, req_idx=3, timeout=60.0)
+        assert r.status == "READY"
+        assert r.get_url() == "https://worker"

--- a/vast.py
+++ b/vast.py
@@ -2295,18 +2295,6 @@ def create__workergroup(args):
         print(r.text)
 
 
-def _build_scaling_config(args):
-    if args.scaling_mode is None:
-        return None
-    config = {"mode": args.scaling_mode}
-    if args.scaler is not None:              config["scaler"] = args.scaler
-    if args.requests_per_worker is not None: config["requests_per_worker"] = args.requests_per_worker
-    if args.queue_delay_target is not None:  config["queue_delay_target"] = args.queue_delay_target
-    if args.idle_timeout is not None:        config["idle_timeout"] = args.idle_timeout
-    if args.cold_ttl is not None:            config["cold_ttl"] = args.cold_ttl
-    return config
-
-
 @parser.command(
     argument("--min_load", help="minimum floor load in perf units/s  (token/s for LLms)", type=float, default=0.0),
     argument("--min_cold_load", help="minimum floor load in perf units/s (token/s for LLms), but allow handling with cold workers", type=float, default=0.0),
@@ -2318,12 +2306,6 @@ def _build_scaling_config(args):
     argument("--max_queue_time", help="maximum seconds requests may be queued on each worker (default 30.0)", type=float),
     argument("--target_queue_time", help="target seconds for the queue to be cleared (default 10.0)", type=float),
     argument("--inactivity_timeout", help="seconds of no traffic before the endpoint can scale to zero active workers", type=int),
-    argument("--scaling_mode", help="autoscaling strategy: 'target' (classic load/perf based) or 'queue' (request-queue based, one task per worker slot)", type=str, choices=["target", "queue"]),
-    argument("--scaler", help="queue mode: scale on 'request_count' (default) or 'queue_delay'", type=str, choices=["request_count", "queue_delay"]),
-    argument("--requests_per_worker", help="queue mode: tasks per worker (also per-worker concurrency, default 1)", type=int),
-    argument("--queue_delay_target", help="queue mode: seconds a task may wait before it counts toward scale-up (queue_delay scaler, default 5.0)", type=float),
-    argument("--idle_timeout", help="queue mode: seconds a worker may sit idle before being stopped (default 60.0)", type=float),
-    argument("--cold_ttl", help="queue mode: seconds stopped beyond the cold_workers floor before destroy; 0 disables (default 3600.0)", type=float),
     argument("--auto_instance", help=argparse.SUPPRESS, type=str, default="prod"),
 
     usage="vastai create endpoint [OPTIONS]",
@@ -2337,7 +2319,7 @@ def _build_scaling_config(args):
 def create__endpoint(args):
     url = apiurl(args, "/endptjobs/" )
 
-    json_blob = {"client_id": "me", "min_load": args.min_load, "min_cold_load":args.min_cold_load, "target_util": args.target_util, "cold_mult": args.cold_mult, "cold_workers" : args.cold_workers, "max_workers" : args.max_workers, "endpoint_name": args.endpoint_name, "max_queue_time": args.max_queue_time, "target_queue_time": args.target_queue_time, "inactivity_timeout": args.inactivity_timeout, "autoscaler_instance": args.auto_instance, "scaling_config": _build_scaling_config(args)}
+    json_blob = {"client_id": "me", "min_load": args.min_load, "min_cold_load":args.min_cold_load, "target_util": args.target_util, "cold_mult": args.cold_mult, "cold_workers" : args.cold_workers, "max_workers" : args.max_workers, "endpoint_name": args.endpoint_name, "max_queue_time": args.max_queue_time, "target_queue_time": args.target_queue_time, "inactivity_timeout": args.inactivity_timeout, "autoscaler_instance": args.auto_instance}
 
     if (args.explain):
         print("request json: ")
@@ -7533,12 +7515,6 @@ def update__workergroup(args):
     argument("--max_queue_time", help="maximum seconds requests may be queued on each worker (default 30.0)", type=float),
     argument("--target_queue_time", help="target seconds for the queue to be cleared (default 10.0)", type=float),
     argument("--inactivity_timeout", help="seconds of no traffic before the endpoint can scale to zero active workers", type=int),
-    argument("--scaling_mode", help="autoscaling strategy: 'target' (classic load/perf based) or 'queue' (request-queue based, one task per worker slot)", type=str, choices=["target", "queue"]),
-    argument("--scaler", help="queue mode: scale on 'request_count' (default) or 'queue_delay'", type=str, choices=["request_count", "queue_delay"]),
-    argument("--requests_per_worker", help="queue mode: tasks per worker (also per-worker concurrency, default 1)", type=int),
-    argument("--queue_delay_target", help="queue mode: seconds a task may wait before it counts toward scale-up (queue_delay scaler, default 5.0)", type=float),
-    argument("--idle_timeout", help="queue mode: seconds a worker may sit idle before being stopped (default 60.0)", type=float),
-    argument("--cold_ttl", help="queue mode: seconds stopped beyond the cold_workers floor before destroy; 0 disables (default 3600.0)", type=float),
     usage="vastai update endpoint ID [OPTIONS]",
     help="Update an existing endpoint group",
     epilog=deindent("""
@@ -7548,7 +7524,7 @@ def update__workergroup(args):
 def update__endpoint(args):
     id  = args.id
     url = apiurl(args, f"/endptjobs/{id}/" )
-    json_blob = {"client_id": "me", "endptjob_id": args.id, "min_load": args.min_load, "min_cold_load":args.min_cold_load,"target_util": args.target_util, "cold_mult": args.cold_mult, "cold_workers": args.cold_workers, "max_workers" : args.max_workers, "endpoint_name": args.endpoint_name, "max_queue_time": args.max_queue_time, "target_queue_time": args.target_queue_time, "inactivity_timeout": args.inactivity_timeout, "endpoint_state": args.endpoint_state, "autoscaler_instance":args.auto_instance, "scaling_config": _build_scaling_config(args)}
+    json_blob = {"client_id": "me", "endptjob_id": args.id, "min_load": args.min_load, "min_cold_load":args.min_cold_load,"target_util": args.target_util, "cold_mult": args.cold_mult, "cold_workers": args.cold_workers, "max_workers" : args.max_workers, "endpoint_name": args.endpoint_name, "max_queue_time": args.max_queue_time, "target_queue_time": args.target_queue_time, "inactivity_timeout": args.inactivity_timeout, "endpoint_state": args.endpoint_state, "autoscaler_instance":args.auto_instance}
     if (args.explain):
         print("request json: ")
         print(json_blob)

--- a/vast.py
+++ b/vast.py
@@ -2295,6 +2295,18 @@ def create__workergroup(args):
         print(r.text)
 
 
+def _build_scaling_config(args):
+    if args.scaling_mode is None:
+        return None
+    config = {"mode": args.scaling_mode}
+    if args.scaler is not None:              config["scaler"] = args.scaler
+    if args.requests_per_worker is not None: config["requests_per_worker"] = args.requests_per_worker
+    if args.queue_delay_target is not None:  config["queue_delay_target"] = args.queue_delay_target
+    if args.idle_timeout is not None:        config["idle_timeout"] = args.idle_timeout
+    if args.cold_ttl is not None:            config["cold_ttl"] = args.cold_ttl
+    return config
+
+
 @parser.command(
     argument("--min_load", help="minimum floor load in perf units/s  (token/s for LLms)", type=float, default=0.0),
     argument("--min_cold_load", help="minimum floor load in perf units/s (token/s for LLms), but allow handling with cold workers", type=float, default=0.0),
@@ -2306,6 +2318,12 @@ def create__workergroup(args):
     argument("--max_queue_time", help="maximum seconds requests may be queued on each worker (default 30.0)", type=float),
     argument("--target_queue_time", help="target seconds for the queue to be cleared (default 10.0)", type=float),
     argument("--inactivity_timeout", help="seconds of no traffic before the endpoint can scale to zero active workers", type=int),
+    argument("--scaling_mode", help="autoscaling strategy: 'target' (classic load/perf based) or 'queue' (request-queue based, one task per worker slot)", type=str, choices=["target", "queue"]),
+    argument("--scaler", help="queue mode: scale on 'request_count' (default) or 'queue_delay'", type=str, choices=["request_count", "queue_delay"]),
+    argument("--requests_per_worker", help="queue mode: tasks per worker (also per-worker concurrency, default 1)", type=int),
+    argument("--queue_delay_target", help="queue mode: seconds a task may wait before it counts toward scale-up (queue_delay scaler, default 5.0)", type=float),
+    argument("--idle_timeout", help="queue mode: seconds a worker may sit idle before being stopped (default 60.0)", type=float),
+    argument("--cold_ttl", help="queue mode: seconds stopped beyond the cold_workers floor before destroy; 0 disables (default 3600.0)", type=float),
     argument("--auto_instance", help=argparse.SUPPRESS, type=str, default="prod"),
 
     usage="vastai create endpoint [OPTIONS]",
@@ -2319,7 +2337,7 @@ def create__workergroup(args):
 def create__endpoint(args):
     url = apiurl(args, "/endptjobs/" )
 
-    json_blob = {"client_id": "me", "min_load": args.min_load, "min_cold_load":args.min_cold_load, "target_util": args.target_util, "cold_mult": args.cold_mult, "cold_workers" : args.cold_workers, "max_workers" : args.max_workers, "endpoint_name": args.endpoint_name, "max_queue_time": args.max_queue_time, "target_queue_time": args.target_queue_time, "inactivity_timeout": args.inactivity_timeout, "autoscaler_instance": args.auto_instance}
+    json_blob = {"client_id": "me", "min_load": args.min_load, "min_cold_load":args.min_cold_load, "target_util": args.target_util, "cold_mult": args.cold_mult, "cold_workers" : args.cold_workers, "max_workers" : args.max_workers, "endpoint_name": args.endpoint_name, "max_queue_time": args.max_queue_time, "target_queue_time": args.target_queue_time, "inactivity_timeout": args.inactivity_timeout, "autoscaler_instance": args.auto_instance, "scaling_config": _build_scaling_config(args)}
 
     if (args.explain):
         print("request json: ")
@@ -7515,6 +7533,12 @@ def update__workergroup(args):
     argument("--max_queue_time", help="maximum seconds requests may be queued on each worker (default 30.0)", type=float),
     argument("--target_queue_time", help="target seconds for the queue to be cleared (default 10.0)", type=float),
     argument("--inactivity_timeout", help="seconds of no traffic before the endpoint can scale to zero active workers", type=int),
+    argument("--scaling_mode", help="autoscaling strategy: 'target' (classic load/perf based) or 'queue' (request-queue based, one task per worker slot)", type=str, choices=["target", "queue"]),
+    argument("--scaler", help="queue mode: scale on 'request_count' (default) or 'queue_delay'", type=str, choices=["request_count", "queue_delay"]),
+    argument("--requests_per_worker", help="queue mode: tasks per worker (also per-worker concurrency, default 1)", type=int),
+    argument("--queue_delay_target", help="queue mode: seconds a task may wait before it counts toward scale-up (queue_delay scaler, default 5.0)", type=float),
+    argument("--idle_timeout", help="queue mode: seconds a worker may sit idle before being stopped (default 60.0)", type=float),
+    argument("--cold_ttl", help="queue mode: seconds stopped beyond the cold_workers floor before destroy; 0 disables (default 3600.0)", type=float),
     usage="vastai update endpoint ID [OPTIONS]",
     help="Update an existing endpoint group",
     epilog=deindent("""
@@ -7524,7 +7548,7 @@ def update__workergroup(args):
 def update__endpoint(args):
     id  = args.id
     url = apiurl(args, f"/endptjobs/{id}/" )
-    json_blob = {"client_id": "me", "endptjob_id": args.id, "min_load": args.min_load, "min_cold_load":args.min_cold_load,"target_util": args.target_util, "cold_mult": args.cold_mult, "cold_workers": args.cold_workers, "max_workers" : args.max_workers, "endpoint_name": args.endpoint_name, "max_queue_time": args.max_queue_time, "target_queue_time": args.target_queue_time, "inactivity_timeout": args.inactivity_timeout, "endpoint_state": args.endpoint_state, "autoscaler_instance":args.auto_instance}
+    json_blob = {"client_id": "me", "endptjob_id": args.id, "min_load": args.min_load, "min_cold_load":args.min_cold_load,"target_util": args.target_util, "cold_mult": args.cold_mult, "cold_workers": args.cold_workers, "max_workers" : args.max_workers, "endpoint_name": args.endpoint_name, "max_queue_time": args.max_queue_time, "target_queue_time": args.target_queue_time, "inactivity_timeout": args.inactivity_timeout, "endpoint_state": args.endpoint_state, "autoscaler_instance":args.auto_instance, "scaling_config": _build_scaling_config(args)}
     if (args.explain):
         print("request json: ")
         print(json_blob)

--- a/vastai/api/endpoints.py
+++ b/vastai/api/endpoints.py
@@ -46,6 +46,9 @@ def create_endpoint(client, **kwargs):
             max_workers (int): Max workers for the endpoint group. Default 20.
             endpoint_name (str): Deployment endpoint name.
             auto_instance (str): Autoscaler instance type. Default "prod".
+            scaling_config (dict): Queue-scaling settings, e.g.
+                {"mode": "queue", "requests_per_worker": 1, "idle_timeout": 60.0}.
+                Omit (or None) for the classic load/perf based scaling.
 
     Returns:
         dict: API response data.
@@ -63,6 +66,7 @@ def create_endpoint(client, **kwargs):
         "target_queue_time": kwargs.get("target_queue_time"),
         "inactivity_timeout": kwargs.get("inactivity_timeout"),
         "autoscaler_instance": kwargs.get("auto_instance", "prod"),
+        "scaling_config": kwargs.get("scaling_config"),
     }
 
     r = client.post("/endptjobs/", json_data=json_blob)
@@ -98,6 +102,7 @@ def update_endpoint(client, id, **kwargs):
         "target_queue_time": kwargs.get("target_queue_time"),
         "inactivity_timeout": kwargs.get("inactivity_timeout"),
         "autoscaler_instance": kwargs.get("auto_instance", "prod"),
+        "scaling_config": kwargs.get("scaling_config"),
     }
     r = client.put(f"/endptjobs/{id}/", json_data=json_blob)
     r.raise_for_status()

--- a/vastai/cli/commands/endpoints.py
+++ b/vastai/cli/commands/endpoints.py
@@ -21,6 +21,8 @@ def _build_scaling_config(args):
         config["scaler"] = args.scaler
     if args.requests_per_worker is not None:
         config["requests_per_worker"] = args.requests_per_worker
+    if args.min_active_workers is not None:
+        config["min_active_workers"] = args.min_active_workers
     if args.queue_delay_target is not None:
         config["queue_delay_target"] = args.queue_delay_target
     if args.idle_timeout is not None:
@@ -48,6 +50,7 @@ def _build_scaling_config(args):
     argument("--scaling_mode", help="autoscaling strategy: 'target' (classic load/perf based) or 'queue' (request-queue based, one task per worker slot)", type=str, choices=["target", "queue"]),
     argument("--scaler", help="queue mode: scale on 'request_count' (default) or 'queue_delay'", type=str, choices=["request_count", "queue_delay"]),
     argument("--requests_per_worker", help="queue mode: tasks per worker (also per-worker concurrency, default 1)", type=int),
+    argument("--min_active_workers", help="queue mode: always-on floor of running workers, kept alive even with an empty queue (default 0)", type=int),
     argument("--queue_delay_target", help="queue mode: seconds a task may wait before it counts toward scale-up (queue_delay scaler, default 5.0)", type=float),
     argument("--idle_timeout", help="queue mode: seconds a worker may sit idle before being stopped (default 60.0)", type=float),
     argument("--cold_ttl", help="queue mode: seconds stopped beyond the cold_workers floor before destroy; 0 disables (default 3600.0)", type=float),
@@ -129,6 +132,7 @@ def show__endpoints(args):
     argument("--scaling_mode", help="autoscaling strategy: 'target' (classic load/perf based) or 'queue' (request-queue based, one task per worker slot)", type=str, choices=["target", "queue"]),
     argument("--scaler", help="queue mode: scale on 'request_count' (default) or 'queue_delay'", type=str, choices=["request_count", "queue_delay"]),
     argument("--requests_per_worker", help="queue mode: tasks per worker (also per-worker concurrency, default 1)", type=int),
+    argument("--min_active_workers", help="queue mode: always-on floor of running workers, kept alive even with an empty queue (default 0)", type=int),
     argument("--queue_delay_target", help="queue mode: seconds a task may wait before it counts toward scale-up (queue_delay scaler, default 5.0)", type=float),
     argument("--idle_timeout", help="queue mode: seconds a worker may sit idle before being stopped (default 60.0)", type=float),
     argument("--cold_ttl", help="queue mode: seconds stopped beyond the cold_workers floor before destroy; 0 disables (default 3600.0)", type=float),

--- a/vastai/cli/commands/endpoints.py
+++ b/vastai/cli/commands/endpoints.py
@@ -13,6 +13,22 @@ from vastai.cli.utils import get_parser as _get_parser, get_client  # noqa: F401
 
 parser = _get_parser()
 
+def _build_scaling_config(args):
+    if args.scaling_mode is None:
+        return None
+    config = {"mode": args.scaling_mode}
+    if args.scaler is not None:
+        config["scaler"] = args.scaler
+    if args.requests_per_worker is not None:
+        config["requests_per_worker"] = args.requests_per_worker
+    if args.queue_delay_target is not None:
+        config["queue_delay_target"] = args.queue_delay_target
+    if args.idle_timeout is not None:
+        config["idle_timeout"] = args.idle_timeout
+    if args.cold_ttl is not None:
+        config["cold_ttl"] = args.cold_ttl
+    return config
+
 
 # ---------------------------------------------------------------------------
 # endpoints
@@ -29,6 +45,12 @@ parser = _get_parser()
     argument("--max_queue_time", help="maximum seconds requests may be queued on each worker (default 30.0)", type=float),
     argument("--target_queue_time", help="target seconds for the queue to be cleared (default 10.0)", type=float),
     argument("--inactivity_timeout", help="seconds of no traffic before the endpoint can scale to zero active workers", type=int),
+    argument("--scaling_mode", help="autoscaling strategy: 'target' (classic load/perf based) or 'queue' (request-queue based, one task per worker slot)", type=str, choices=["target", "queue"]),
+    argument("--scaler", help="queue mode: scale on 'request_count' (default) or 'queue_delay'", type=str, choices=["request_count", "queue_delay"]),
+    argument("--requests_per_worker", help="queue mode: tasks per worker (also per-worker concurrency, default 1)", type=int),
+    argument("--queue_delay_target", help="queue mode: seconds a task may wait before it counts toward scale-up (queue_delay scaler, default 5.0)", type=float),
+    argument("--idle_timeout", help="queue mode: seconds a worker may sit idle before being stopped (default 60.0)", type=float),
+    argument("--cold_ttl", help="queue mode: seconds stopped beyond the cold_workers floor before destroy; 0 disables (default 3600.0)", type=float),
     argument("--auto_instance", help=argparse.SUPPRESS, type=str, default="prod"),
     usage="vastai create endpoint [OPTIONS]",
     help="Create a new endpoint group",
@@ -57,6 +79,7 @@ def create__endpoint(args):
         endpoint_name=args.endpoint_name, auto_instance=args.auto_instance,
         max_queue_time=args.max_queue_time, target_queue_time=args.target_queue_time,
         inactivity_timeout=args.inactivity_timeout,
+        scaling_config=_build_scaling_config(args),
     )
     if args.raw:
         return result
@@ -103,6 +126,12 @@ def show__endpoints(args):
     argument("--max_queue_time", help="maximum seconds requests may be queued on each worker (default 30.0)", type=float),
     argument("--target_queue_time", help="target seconds for the queue to be cleared (default 10.0)", type=float),
     argument("--inactivity_timeout", help="seconds of no traffic before the endpoint can scale to zero active workers", type=int),
+    argument("--scaling_mode", help="autoscaling strategy: 'target' (classic load/perf based) or 'queue' (request-queue based, one task per worker slot)", type=str, choices=["target", "queue"]),
+    argument("--scaler", help="queue mode: scale on 'request_count' (default) or 'queue_delay'", type=str, choices=["request_count", "queue_delay"]),
+    argument("--requests_per_worker", help="queue mode: tasks per worker (also per-worker concurrency, default 1)", type=int),
+    argument("--queue_delay_target", help="queue mode: seconds a task may wait before it counts toward scale-up (queue_delay scaler, default 5.0)", type=float),
+    argument("--idle_timeout", help="queue mode: seconds a worker may sit idle before being stopped (default 60.0)", type=float),
+    argument("--cold_ttl", help="queue mode: seconds stopped beyond the cold_workers floor before destroy; 0 disables (default 3600.0)", type=float),
     usage="vastai update endpoint ID [OPTIONS]",
     help="Update an existing endpoint group",
     epilog=deindent("""
@@ -121,6 +150,7 @@ def update__endpoint(args):
         auto_instance=args.auto_instance,
         max_queue_time=args.max_queue_time, target_queue_time=args.target_queue_time,
         inactivity_timeout=args.inactivity_timeout,
+        scaling_config=_build_scaling_config(args),
     )
     if args.raw:
         return result

--- a/vastai/cli/commands/endpoints.py
+++ b/vastai/cli/commands/endpoints.py
@@ -23,6 +23,8 @@ def _build_scaling_config(args):
         config["requests_per_worker"] = args.requests_per_worker
     if args.min_active_workers is not None:
         config["min_active_workers"] = args.min_active_workers
+    if args.cold_buffer_mult is not None:
+        config["cold_buffer_mult"] = args.cold_buffer_mult
     if args.queue_delay_target is not None:
         config["queue_delay_target"] = args.queue_delay_target
     if args.idle_timeout is not None:
@@ -51,6 +53,7 @@ def _build_scaling_config(args):
     argument("--scaler", help="queue mode: scale on 'request_count' (default) or 'queue_delay'", type=str, choices=["request_count", "queue_delay"]),
     argument("--requests_per_worker", help="queue mode: tasks per worker (also per-worker concurrency, default 1)", type=int),
     argument("--min_active_workers", help="queue mode: always-on floor of running workers, kept alive even with an empty queue (default 0)", type=int),
+    argument("--cold_buffer_mult", help="queue mode: keep total live workers >= target_active * mult; surplus parks stopped for warm starts (default 1.0)", type=float),
     argument("--queue_delay_target", help="queue mode: seconds a task may wait before it counts toward scale-up (queue_delay scaler, default 5.0)", type=float),
     argument("--idle_timeout", help="queue mode: seconds a worker may sit idle before being stopped (default 60.0)", type=float),
     argument("--cold_ttl", help="queue mode: seconds stopped beyond the cold_workers floor before destroy; 0 disables (default 3600.0)", type=float),
@@ -133,6 +136,7 @@ def show__endpoints(args):
     argument("--scaler", help="queue mode: scale on 'request_count' (default) or 'queue_delay'", type=str, choices=["request_count", "queue_delay"]),
     argument("--requests_per_worker", help="queue mode: tasks per worker (also per-worker concurrency, default 1)", type=int),
     argument("--min_active_workers", help="queue mode: always-on floor of running workers, kept alive even with an empty queue (default 0)", type=int),
+    argument("--cold_buffer_mult", help="queue mode: keep total live workers >= target_active * mult; surplus parks stopped for warm starts (default 1.0)", type=float),
     argument("--queue_delay_target", help="queue mode: seconds a task may wait before it counts toward scale-up (queue_delay scaler, default 5.0)", type=float),
     argument("--idle_timeout", help="queue mode: seconds a worker may sit idle before being stopped (default 60.0)", type=float),
     argument("--cold_ttl", help="queue mode: seconds stopped beyond the cold_workers floor before destroy; 0 disables (default 3600.0)", type=float),

--- a/vastai/serverless/client/client.py
+++ b/vastai/serverless/client/client.py
@@ -13,6 +13,7 @@ from vastai.data.deployment import (
 )
 from vastai.data.workergroup import WorkergroupConfig
 import asyncio
+import socket
 import aiohttp
 import ssl
 import os
@@ -186,9 +187,24 @@ class _ServerlessBase(Generic[R]):
             return await self._transport_owner._get_session()
         if self._session is None or self._session.closed:
             self.logger.info("Started aiohttp ClientSession")
-            connector = aiohttp.TCPConnector(
-                limit=self.connection_limit, ssl=await self.get_ssl_context()
-            )
+            # TCP keepalives so long-running worker requests (minutes of silence while the
+            # model computes) survive NAT/conntrack idle timeouts on the path to the worker.
+            def _keepalive_socket_factory(addr_info):
+                family, sock_type, proto = addr_info[0], addr_info[1], addr_info[2]
+                sock = socket.socket(family=family, type=sock_type, proto=proto)
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+                for name, val in (("TCP_KEEPIDLE", 30), ("TCP_KEEPINTVL", 15), ("TCP_KEEPCNT", 8)):
+                    if hasattr(socket, name):
+                        sock.setsockopt(socket.IPPROTO_TCP, getattr(socket, name), val)
+                return sock
+
+            import inspect
+            connector_kwargs = {"limit": self.connection_limit, "ssl": await self.get_ssl_context()}
+            if "socket_factory" in inspect.signature(aiohttp.TCPConnector.__init__).parameters:
+                connector_kwargs["socket_factory"] = _keepalive_socket_factory
+            else:
+                self.logger.warning("aiohttp %s lacks TCPConnector socket_factory; long requests may hit NAT idle timeouts", aiohttp.__version__)
+            connector = aiohttp.TCPConnector(**connector_kwargs)
             self._session = aiohttp.ClientSession(connector=connector)
         return self._session
 

--- a/vastai/serverless/client/endpoint.py
+++ b/vastai/serverless/client/endpoint.py
@@ -164,6 +164,16 @@ class Endpoint_(Generic[R]):
     def get_workers(self):
         return self.client.get_endpoint_workers(self)
 
+    async def submit(self, timeout: float = 60.0) -> "RouteResponse":
+        """Submit a task to a queue-mode endpoint. Returns a RouteResponse whose
+        request_idx identifies the task for subsequent task_status polls."""
+        return await self._route(cost=0.0, req_idx=0, timeout=timeout)
+
+    async def task_status(self, request_idx: int, timeout: float = 60.0) -> "RouteResponse":
+        """Poll a previously submitted task. READY means a worker was assigned and
+        the response body carries its url; QUEUED carries queue_position/queue_depth."""
+        return await self._route(cost=0.0, req_idx=request_idx, timeout=timeout)
+
     async def _route(
         self, cost: float = 0.0, req_idx: int = 0, timeout: float = 60.0
     ) -> "RouteResponse":
@@ -219,13 +229,22 @@ class RouteResponse:
             self.request_idx = 0
         if "url" in body.keys():
             self.status = "READY"
-            self.body = body
+        elif body.get("status") == "queued":
+            self.status = "QUEUED"
         else:
             self.status = "WAITING"
-            self.body = body
+        self.body = body
 
     def get_url(self):
         return self.body.get("url")
+
+    @property
+    def queue_position(self):
+        return self.body.get("queue_position")
+
+    @property
+    def queue_depth(self):
+        return self.body.get("queue_depth")
 
 
 # Backward-compatible alias — works for instantiation at runtime.


### PR DESCRIPTION
- RouteResponse: surface autoscaler queue-mode responses as QUEUED with queue_position/queue_depth (READY still keyed on url presence)
- Endpoint.submit() / Endpoint.task_status(): explicit submit-then-poll helpers over the existing /route/ protocol
- vastai create/update endpoint: --scaling_mode, --scaler, --requests_per_worker, --queue_delay_target, --idle_timeout, --cold_ttl build the endpoint scaling_config
- tests for QUEUED parsing and submit/task_status delegation