### PR TITLE
Deployments: fix silent failure modes in the @remote lifecycle

### DIFF
--- a/tests/serverless/test_deployment_client.py
+++ b/tests/serverless/test_deployment_client.py
@@ -1,0 +1,234 @@
+"""Deploy-mode client behaviour: call metadata, waiting, and warnings.
+
+Covers the client half of three fixes:
+
+* ``f.submit(...)`` returns a handle carrying the worker that served the call.
+  Previously the worker URL was on the transport response and thrown away, so
+  the only way to attribute a call was to return ``CONTAINER_ID`` from inside
+  your own payload.
+* ``ensure_ready(wait=...)`` blocks until workers are actually serving this
+  deployment's code version.
+* A worker-reported warning (e.g. a blocked event loop) reaches the caller.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from vastai.serverless.client.worker import Worker
+from vastai.serverless.remote import deploy as deploy_mode
+from vastai.serverless.remote.progress import WorkerStartupTimeout
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("VAST_API_KEY", "test-key")
+    return deploy_mode.Deployment(name="client-test", progress="off")
+
+
+def _wire(app, response: dict) -> None:
+    """Point the deployment at a fake endpoint returning ``response``."""
+    endpoint = SimpleNamespace(request=AsyncMock(return_value=response))
+    app._inner = deploy_mode._FullDeployment(
+        root_module="deploy", deployment=SimpleNamespace(endpoint=endpoint)
+    )
+
+
+def _ok(result, meta: dict | None = None, **extra) -> dict:
+    """A worker response in the real wire format.
+
+    serve mode returns ``{"result": serialize_ok(value), "meta": {...}}``, and
+    ``serialize_ok`` wraps the value as ``{"ok": <serialized>}``.
+    """
+    body = {"result": {"ok": result}}
+    if meta is not None:
+        body["meta"] = meta
+    return {"response": body, "status": 200, "text": "", **extra}
+
+
+def _worker(worker_id: int, status: str, version: int | None = None) -> Worker:
+    return Worker.from_dict(
+        {"id": worker_id, "status": status, "deployment_version_id": version}
+    )
+
+
+class TestPlainCallIsUnchanged:
+    async def test_await_returns_the_result_directly(self, app) -> None:
+        @app.remote(benchmark_dataset=[{"x": 1}])
+        async def double(x):
+            return x * 2
+
+        _wire(app, _ok(42))
+        assert await double(21) == 42
+
+    def test_decorator_preserves_function_identity(self, app) -> None:
+        @app.remote(benchmark_dataset=[{"x": 1}])
+        async def documented(x):
+            """A docstring worth keeping."""
+            return x
+
+        assert documented.__name__ == "documented"
+        assert documented.__doc__ == "A docstring worth keeping."
+
+
+class TestSubmitHandle:
+    async def test_submit_result_matches_a_plain_call(self, app) -> None:
+        @app.remote(benchmark_dataset=[{"x": 1}])
+        async def double(x):
+            return x * 2
+
+        _wire(app, _ok(42))
+        call = double.submit(21)
+        assert await call == 42
+
+    async def test_submit_exposes_the_serving_worker(self, app) -> None:
+        @app.remote(benchmark_dataset=[{"x": 1}])
+        async def double(x):
+            return x * 2
+
+        _wire(
+            app,
+            _ok(
+                42,
+                meta={
+                    "worker_id": 48601969,
+                    "gpu": "RTX 5090",
+                    "duration_ms": 712.5,
+                    "deployment_version_id": 3215,
+                },
+                url="https://1.2.3.4:30001",
+                latency=0.9,
+            ),
+        )
+        call = double.submit(21)
+        await call
+
+        assert call.worker_id == 48601969
+        assert call.gpu == "RTX 5090"
+        assert call.duration_ms == 712.5
+        assert call.deployment_version_id == 3215
+        assert call.worker_url == "https://1.2.3.4:30001"
+        assert call.latency == 0.9
+
+    async def test_attribution_across_a_gathered_batch(self, app) -> None:
+        """The reason this exists: proving whether a batch really fanned out."""
+        import collections
+
+        @app.remote(benchmark_dataset=[{"x": 1}])
+        async def work(x):
+            return x
+
+        _wire(app, _ok(1, meta={"worker_id": 7}))
+        calls = [work.submit(i) for i in range(5)]
+        await asyncio.gather(*calls)
+
+        assert collections.Counter(c.worker_id for c in calls) == {7: 5}
+
+    async def test_missing_meta_leaves_fields_none(self, app) -> None:
+        """Older workers do not send meta; this must not raise."""
+
+        @app.remote(benchmark_dataset=[{"x": 1}])
+        async def double(x):
+            return x * 2
+
+        _wire(app, _ok(42))
+        call = double.submit(21)
+        assert await call == 42
+        assert call.worker_id is None
+        assert call.gpu is None
+
+    def test_awaiting_an_undispatched_call_is_an_error(self) -> None:
+        call = deploy_mode.RemoteCall()
+        with pytest.raises(RuntimeError):
+            call.__await__()
+
+
+class TestWorkerWarningsReachTheCaller:
+    async def test_blocked_loop_warning_is_surfaced_once(self, app) -> None:
+        import logging
+
+        records = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record.getMessage())
+
+        @app.remote(benchmark_dataset=[{"x": 1}])
+        async def work(x):
+            return x
+
+        _wire(
+            app,
+            _ok(1, meta={"worker_id": 99, "warnings": ["event_loop_blocked"]}),
+        )
+
+        deploy_mode._WARNED.clear()
+        logger = logging.getLogger("vastai")
+        handler = _Capture()
+        logger.addHandler(handler)
+        level = logger.level
+        logger.setLevel(logging.WARNING)
+        try:
+            await work.submit(1)
+            await work.submit(2)  # same worker: must not warn twice
+        finally:
+            logger.removeHandler(handler)
+            logger.setLevel(level)
+
+        blocked = [m for m in records if "event loop was blocked" in m.lower()]
+        assert len(blocked) == 1, records
+        assert "asyncio.to_thread" in blocked[0]
+
+
+class TestWaitForWorkers:
+    async def test_returns_once_enough_workers_are_ready(self, app) -> None:
+        app._version_id = 3215
+        app.workers = AsyncMock(
+            return_value=[
+                _worker(1, "idle", 3215),
+                _worker(2, "idle", 3215),
+                _worker(3, "loading", 3215),
+            ]
+        )
+        ready = await app._wait_for_workers(2, timeout=5)
+        assert {w.id for w in ready} == {1, 2}
+
+    async def test_ignores_workers_on_a_superseded_version(self, app) -> None:
+        """The stale-rollout case: ready, but running the previous code."""
+        app._version_id = 3216
+        app.workers = AsyncMock(
+            return_value=[_worker(1, "idle", 3215), _worker(2, "idle", 3215)]
+        )
+        with pytest.raises(WorkerStartupTimeout):
+            await app._wait_for_workers(1, timeout=0.1)
+
+    async def test_accepts_workers_that_do_not_report_a_version(self, app) -> None:
+        """Backwards compatibility with workers predating the field."""
+        app._version_id = 3216
+        app.workers = AsyncMock(return_value=[_worker(1, "idle", None)])
+        ready = await app._wait_for_workers(1, timeout=5)
+        assert [w.id for w in ready] == [1]
+
+    async def test_timeout_reports_the_observed_states(self, app) -> None:
+        app._version_id = None
+        app.workers = AsyncMock(return_value=[_worker(1, "model_loading")])
+        with pytest.raises(WorkerStartupTimeout) as exc:
+            await app._wait_for_workers(1, timeout=0.1)
+        assert "loading model / benchmarking" in str(exc.value)
+
+    async def test_poll_errors_do_not_abort_the_wait(self, app) -> None:
+        app._version_id = None
+        calls = {"n": 0}
+
+        async def flaky():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("rate limited")
+            return [_worker(1, "idle")]
+
+        app.workers = flaky
+        ready = await app._wait_for_workers(1, timeout=30)
+        assert [w.id for w in ready] == [1]
+        assert calls["n"] >= 2

--- a/tests/serverless/test_deployment_version_guard.py
+++ b/tests/serverless/test_deployment_version_guard.py
@@ -1,0 +1,136 @@
+"""Tests for deployment version pinning across a rolling update.
+
+``ensure_ready()`` returns as soon as the tarball is uploaded and the rolling
+update is triggered — it does not wait for workers to converge. A call issued
+immediately afterwards could be answered by a worker still running the previous
+code, which surfaces as a confusing type error in the caller rather than as a
+deployment problem.
+
+The worker now rejects a request that names a different version with 409, and the
+client treats 409 as retryable so it re-routes to an updated worker.
+"""
+
+import pytest
+
+from vastai.serverless.client.connection import _retryable
+
+
+class TestRetryableStatuses:
+    def test_409_is_retryable_so_the_client_reroutes(self) -> None:
+        assert _retryable(409) is True
+
+    def test_previously_retryable_statuses_are_unchanged(self) -> None:
+        for status in (408, 429, 500, 502, 503, 599):
+            assert _retryable(status) is True
+
+    def test_other_client_errors_remain_terminal(self) -> None:
+        for status in (400, 401, 403, 404, 410, 422):
+            assert _retryable(status) is False
+
+
+async def _noop_remote(*, args: list = [], kwargs: dict = {}):
+    """Stand-in with the same signature the real wrapper has.
+
+    Keyword-only ``args``/``kwargs`` and nothing else, so a version hint that
+    leaked into the user payload would raise TypeError here instead of silently
+    working.
+    """
+    return {"ok": None}
+
+
+class TestWorkerVersionGuard:
+    """The worker-side half: refuse work meant for a different version."""
+
+    async def _post(self, testkit, body_extra: dict, worker_version):
+        """Drive one request through the handler and return the response.
+
+        Requests that pass the version guard go on to contact the (absent) model
+        server and come back 500; the assertions below only care that they were
+        *not* short-circuited with 409.
+        """
+        backend, handler = testkit.make_backend(allow_parallel=True)
+        backend.metrics.deployment_version_id = worker_version
+        backend.unsecured = True  # skip signature checks for this unit test
+        # The guard only applies to deployment (remote-dispatch) handlers.
+        handler.remote_function = _noop_remote
+
+        body = testkit.auth_payload()
+        # The client nests this inside "payload", next to its kwargs -- not at
+        # the top level of the envelope.
+        body["payload"].update(body_extra)
+        request = testkit.json_request(body)
+        try:
+            return await backend.create_handler(handler)(request)
+        finally:
+            session = backend.__dict__.get("session")
+            if session is not None and not session.closed:
+                await session.close()
+
+    async def test_rejects_a_call_for_a_newer_version(
+        self, serverless_backend_testkit
+    ) -> None:
+        response = await self._post(
+            serverless_backend_testkit,
+            {"expect_version_id": 3216},
+            worker_version=3215,
+        )
+        assert response.status == 409
+
+    async def test_serves_a_call_for_its_own_version(
+        self, serverless_backend_testkit
+    ) -> None:
+        response = await self._post(
+            serverless_backend_testkit,
+            {"expect_version_id": 3215},
+            worker_version=3215,
+        )
+        assert response.status != 409
+
+    async def test_serves_when_the_client_does_not_pin_a_version(
+        self, serverless_backend_testkit
+    ) -> None:
+        """Backwards compatibility: older clients send no expectation."""
+        response = await self._post(
+            serverless_backend_testkit, {}, worker_version=3215
+        )
+        assert response.status != 409
+
+    async def test_serves_when_the_worker_does_not_know_its_version(
+        self, serverless_backend_testkit
+    ) -> None:
+        """A non-deployment endpoint has no version; do not start 409-ing."""
+        response = await self._post(
+            serverless_backend_testkit,
+            {"expect_version_id": 3216},
+            worker_version=None,
+        )
+        assert response.status != 409
+
+    async def test_version_hint_is_not_passed_to_the_remote_function(
+        self, serverless_backend_testkit
+    ) -> None:
+        """The hint is transport metadata and must be stripped from the payload.
+
+        It travels nested beside the user's kwargs, so failing to remove it
+        splats an unexpected keyword argument into the wrapped function.
+        """
+        seen = {}
+
+        async def capture(*, args: list = [], kwargs: dict = {}):
+            seen["args"] = args
+            seen["kwargs"] = kwargs
+            return {"ok": None}
+
+        testkit = serverless_backend_testkit
+        backend, handler = testkit.make_backend(allow_parallel=True)
+        backend.metrics.deployment_version_id = 3215
+        backend.unsecured = True
+        handler.remote_function = capture
+
+        body = testkit.auth_payload()
+        body["payload"] = {"kwargs": {"x": 1}, "expect_version_id": 3215}
+        response = await backend.create_handler(handler)(testkit.json_request(body))
+
+        assert response.status == 200
+        assert seen["kwargs"] == {"x": 1}
+        assert "expect_version_id" not in seen["kwargs"]

--- a/tests/serverless/test_loop_lag_watchdog.py
+++ b/tests/serverless/test_loop_lag_watchdog.py
@@ -1,0 +1,193 @@
+"""Tests for the event-loop lag watchdog.
+
+Synchronous work inside an ``async def`` remote function holds the worker's event
+loop for its whole duration. Requests still succeed, so the client sees nothing
+wrong, but the metrics reporter cannot run: ``/worker_status/`` POSTs time out and
+the autoscaler can reclaim a worker that is in fact busy and making progress.
+Observed in the wild as a four-worker pool collapsing to one over a single batch.
+
+The watchdog measures how late its own sleep returns, which detects the condition
+directly regardless of what is blocking.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from vastai.serverless.server.lib import backend as backend_mod
+
+
+@pytest.fixture
+def metrics_env(monkeypatch, serverless_metrics_test_env):
+    for key, value in serverless_metrics_test_env.items():
+        monkeypatch.setenv(key, value)
+
+
+@pytest.fixture
+def backend_real_metrics(pyworker_backend, metrics_env):
+    """Backend from the shared fixture, but with a real Metrics attached.
+
+    ``pyworker_backend`` mocks Metrics, which is fine for most tests but useless
+    here — the watchdog's whole job is to mutate it.
+    """
+    from vastai.serverless.server.lib.metrics import Metrics
+
+    pyworker_backend.metrics = Metrics()
+    return pyworker_backend
+
+
+class TestMetricsLagRecording:
+    def test_record_loop_lag_tracks_the_peak(self, metrics_env) -> None:
+        from vastai.serverless.server.lib.metrics import Metrics
+
+        m = Metrics()
+        m.record_loop_lag(3.0)
+        m.record_loop_lag(9.5)
+        m.record_loop_lag(1.0)
+        assert m.loop_lag_max == 9.5
+
+    def test_record_loop_lag_sets_the_warning_flag(self, metrics_env) -> None:
+        from vastai.serverless.server.lib.metrics import Metrics
+
+        m = Metrics()
+        assert "event_loop_blocked" not in m.warnings
+        m.record_loop_lag(7.0)
+        assert "event_loop_blocked" in m.warnings
+        assert m.update_pending is True
+
+    def test_lag_is_reported_then_cleared_but_warning_is_sticky(
+        self, metrics_env
+    ) -> None:
+        """The peak is per-interval; the warning describes a code defect."""
+        from vastai.serverless.server.lib.metrics import Metrics
+
+        m = Metrics()
+        m.record_loop_lag(6.0)
+
+        # Simulate the post-send reset the sender performs.
+        m.loop_lag_max = 0.0
+        assert "event_loop_blocked" in m.warnings
+
+    def test_worker_status_payload_carries_lag_and_warnings(
+        self, metrics_env
+    ) -> None:
+        from vastai.serverless.server.lib.data_types import WorkerStatusData
+
+        # The dataclass must accept the new fields with defaults so older
+        # construction sites keep working.
+        data = WorkerStatusData(
+            id=1,
+            mtoken="t",
+            version="1.1.0",
+            loadtime=0.0,
+            cur_load=0.0,
+            rej_load=0.0,
+            new_load=0.0,
+            error_msg="",
+            max_perf=0.0,
+            cur_perf=0.0,
+            cur_capacity=0.0,
+            max_capacity=0.0,
+            num_requests_working=0,
+            num_requests_recieved=0,
+            additional_disk_usage=0.0,
+            working_request_idxs=[],
+            url="http://x",
+        )
+        assert data.deployment_version_id is None
+        assert data.loop_lag_max == 0.0
+        assert data.warnings == []
+
+
+class TestWatchdogDetectsBlocking:
+    async def test_watchdog_reports_a_blocked_loop(
+        self, monkeypatch, backend_real_metrics
+    ) -> None:
+        """A synchronous stall on the loop is detected and recorded."""
+        monkeypatch.setattr(backend_mod, "LOOP_LAG_PROBE_INTERVAL", 0.02)
+        monkeypatch.setattr(backend_mod, "LOOP_LAG_WARN_SECONDS", 0.05)
+
+        backend = backend_real_metrics
+        watchdog = asyncio.create_task(
+            backend._Backend__loop_lag_watchdog()
+        )
+        try:
+            await asyncio.sleep(0.05)
+            # Block the loop the way a synchronous remote function would.
+            time.sleep(0.3)
+            await asyncio.sleep(0.1)
+        finally:
+            watchdog.cancel()
+
+        assert backend.metrics.loop_lag_max > 0.05
+        assert "event_loop_blocked" in backend.metrics.warnings
+
+    async def test_watchdog_stays_quiet_on_a_healthy_loop(
+        self, monkeypatch, backend_real_metrics
+    ) -> None:
+        monkeypatch.setattr(backend_mod, "LOOP_LAG_PROBE_INTERVAL", 0.02)
+        monkeypatch.setattr(backend_mod, "LOOP_LAG_WARN_SECONDS", 1.0)
+
+        backend = backend_real_metrics
+        watchdog = asyncio.create_task(backend._Backend__loop_lag_watchdog())
+        try:
+            await asyncio.sleep(0.2)  # cooperative sleeps only
+        finally:
+            watchdog.cancel()
+
+        assert backend.metrics.loop_lag_max == 0.0
+        assert "event_loop_blocked" not in backend.metrics.warnings
+
+
+class TestBenchmarkRepresentativenessWarning:
+    def test_warns_when_real_traffic_is_far_slower_than_the_benchmark(
+        self, metrics_env
+    ) -> None:
+        """The silent failure that stops an endpoint from ever scaling up."""
+        from vastai.serverless.server.lib.data_types import RequestMetrics
+        from vastai.serverless.server.lib.metrics import Metrics
+
+        m = Metrics()
+        # Benchmarked on the cheapest sample, so it claims ~6x real throughput.
+        m.model_metrics.max_throughput = 20000.0
+
+        req = RequestMetrics(
+            request_idx=1, reqnum=1, workload=26000.0, status="Started"
+        )
+        req.work_started_at = 100.0
+        req.work_completed_at = 108.0  # ~3250 workload/s observed
+        m._check_benchmark_representative(req)
+
+        assert "benchmark_unrepresentative" in m.warnings
+
+    def test_no_warning_when_benchmark_matches_reality(self, metrics_env) -> None:
+        from vastai.serverless.server.lib.data_types import RequestMetrics
+        from vastai.serverless.server.lib.metrics import Metrics
+
+        m = Metrics()
+        m.model_metrics.max_throughput = 3000.0
+
+        req = RequestMetrics(
+            request_idx=1, reqnum=1, workload=26000.0, status="Started"
+        )
+        req.work_started_at = 100.0
+        req.work_completed_at = 108.0  # ~3250 observed, close to benchmark
+        m._check_benchmark_representative(req)
+
+        assert "benchmark_unrepresentative" not in m.warnings
+
+    def test_no_warning_before_a_benchmark_has_run(self, metrics_env) -> None:
+        from vastai.serverless.server.lib.data_types import RequestMetrics
+        from vastai.serverless.server.lib.metrics import Metrics
+
+        m = Metrics()
+        m.model_metrics.max_throughput = 0.0
+        req = RequestMetrics(
+            request_idx=1, reqnum=1, workload=100.0, status="Started"
+        )
+        req.work_started_at = 100.0
+        req.work_completed_at = 110.0
+        m._check_benchmark_representative(req)
+
+        assert "benchmark_unrepresentative" not in m.warnings

--- a/tests/serverless/test_remote_options.py
+++ b/tests/serverless/test_remote_options.py
@@ -1,0 +1,108 @@
+"""Tests for the shared @remote option set.
+
+Deploy mode and serve mode each have their own ``remote()`` implementation. They
+used to declare their keyword options independently, which let them drift:
+``allow_parallel_requests`` and ``max_queue_time`` existed only in serve mode, so
+``@app.remote(allow_parallel_requests=True)`` raised TypeError at deploy time and
+the option was unreachable in practice. These tests pin the options to a single
+declaration so the two cannot diverge again.
+"""
+
+import inspect
+
+import pytest
+
+from vastai.serverless.remote import deploy as deploy_mode
+from vastai.serverless.remote import serve as serve_mode
+from vastai.serverless.remote.base import RemoteOptions, RemoteOptionsDict
+
+
+class TestRemoteOptionsDeclaration:
+    def test_dataclass_and_typeddict_declare_the_same_keys(self) -> None:
+        """The typing surface and the runtime surface must agree."""
+        assert RemoteOptions.field_names() == frozenset(
+            RemoteOptionsDict.__annotations__
+        )
+
+    def test_from_kwargs_applies_defaults(self) -> None:
+        opts = RemoteOptions.from_kwargs()
+        assert opts.benchmark_runs == 10
+        assert opts.allow_parallel_requests is False
+        assert opts.max_queue_time == 30.0
+        assert opts.benchmark_dataset is None
+
+    def test_from_kwargs_rejects_unknown_option_with_helpful_message(self) -> None:
+        with pytest.raises(TypeError) as exc:
+            RemoteOptions.from_kwargs(benchmark_datset=[{"x": 1}])
+        message = str(exc.value)
+        # names the offending key and lists the valid ones
+        assert "benchmark_datset" in message
+        assert "benchmark_dataset" in message
+
+    def test_from_kwargs_passes_through_known_options(self) -> None:
+        opts = RemoteOptions.from_kwargs(
+            allow_parallel_requests=True, max_queue_time=None, benchmark_runs=3
+        )
+        assert opts.allow_parallel_requests is True
+        assert opts.max_queue_time is None
+        assert opts.benchmark_runs == 3
+
+
+class TestRemoteSignatureParity:
+    def test_deploy_and_serve_accept_the_same_parameters(self) -> None:
+        """Regression guard: the two remote() signatures must not drift."""
+        deploy_params = set(inspect.signature(deploy_mode.Deployment.remote).parameters)
+        serve_params = set(inspect.signature(serve_mode.Deployment.remote).parameters)
+        assert deploy_params == serve_params
+
+    @pytest.mark.parametrize("mode", [deploy_mode, serve_mode])
+    def test_remote_accepts_every_declared_option(self, mode, monkeypatch) -> None:
+        """Every option in RemoteOptions is accepted by both implementations."""
+        monkeypatch.setenv("VAST_API_KEY", "test-key")
+        app = mode.Deployment(name="opts-test")
+
+        # A dummy value per option that is type-plausible.
+        kwargs = {
+            "benchmark_dataset": [{"x": 1}],
+            "benchmark_generator": None,
+            "benchmark_runs": 2,
+            "workload_calculator": lambda x=1: 1.0,
+            "allow_parallel_requests": True,
+            "max_queue_time": 12.5,
+        }
+        assert set(kwargs) == RemoteOptions.field_names()
+
+        # Must not raise. Previously allow_parallel_requests/max_queue_time
+        # raised TypeError in deploy mode.
+        decorator = app.remote(**kwargs)
+        assert callable(decorator)
+
+    def test_allow_parallel_requests_is_reachable_from_deploy_mode(
+        self, monkeypatch
+    ) -> None:
+        """The specific option that was unreachable before."""
+        monkeypatch.setenv("VAST_API_KEY", "test-key")
+        app = deploy_mode.Deployment(name="apr-test")
+        decorator = app.remote(
+            benchmark_dataset=[{"x": 1}], allow_parallel_requests=True
+        )
+        assert callable(decorator)
+
+    def test_serve_mode_records_the_resolved_options(self, monkeypatch) -> None:
+        """Serve mode is the side that acts on these; check they land."""
+        monkeypatch.setenv("VAST_API_KEY", "test-key")
+        app = serve_mode.Deployment(name="serve-opts")
+
+        @app.remote(
+            benchmark_dataset=[{"x": 1}],
+            allow_parallel_requests=True,
+            max_queue_time=7.0,
+            benchmark_runs=4,
+        )
+        async def f(x):
+            return x
+
+        (entry,) = app.remote_funcs.values()
+        assert entry.allow_parallel_requests is True
+        assert entry.max_queue_time == 7.0
+        assert entry.benchmark_runs == 4

--- a/tests/serverless/test_remote_serve_behaviour.py
+++ b/tests/serverless/test_remote_serve_behaviour.py
@@ -1,0 +1,161 @@
+"""Serve-mode behaviour of @remote: benchmark datasets and sync offloading.
+
+Two defects motivated these tests:
+
+1. ``benchmark_dataset`` collapsed to a single entry. ``into_worker`` built
+   ``[{"kwargs": ... for item in dataset}]`` -- a dict comprehension with the
+   constant key ``"kwargs"`` inside a one-element list -- so every entry but the
+   last was silently discarded. The worker then benchmarked one arbitrary sample
+   while the docs promised a representative mix.
+
+2. A synchronous remote function body ran directly on the worker's event loop.
+   GPU work is almost always synchronous, and blocking the loop starves the
+   worker's ``/worker_status/`` reporting badly enough that the autoscaler can
+   reclaim the worker mid-batch. Plain ``def`` functions are now threaded.
+"""
+
+import asyncio
+import threading
+
+import pytest
+
+from vastai.serverless.remote import serve as serve_mode
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("VAST_API_KEY", "test-key")
+    return serve_mode.Deployment(name="serve-behaviour")
+
+
+@pytest.fixture
+def worker_env(monkeypatch, serverless_metrics_test_env):
+    """Env needed to construct a real Worker/Backend from a deployment."""
+    for key, value in serverless_metrics_test_env.items():
+        monkeypatch.setenv(key, value)
+
+
+class TestBenchmarkDatasetPreserved:
+    """Exercise the real into_worker path, not a reimplementation of it."""
+
+    def test_benchmark_samples_cover_every_dataset_entry(
+        self, app, worker_env
+    ) -> None:
+        @app.remote(benchmark_dataset=[{"x": 1}, {"x": 2}, {"x": 3}])
+        async def square(x):
+            return x * x
+
+        handler = app.into_worker().backend.benchmark_handler
+
+        # for_test() samples from the dataset, so over many draws every entry
+        # should appear. Before the fix only the last one ever could.
+        seen = set()
+        for _ in range(200):
+            payload = handler.make_benchmark_payload()
+            seen.add(payload.input["kwargs"]["x"])
+
+        assert seen == {1, 2, 3}, (
+            f"benchmark dataset collapsed; only saw {sorted(seen)}"
+        )
+
+    def test_single_entry_dataset_still_works(self, app, worker_env) -> None:
+        @app.remote(benchmark_dataset=[{"x": 42}])
+        async def square(x):
+            return x * x
+
+        handler = app.into_worker().backend.benchmark_handler
+        payload = handler.make_benchmark_payload()
+        assert payload.input["kwargs"]["x"] == 42
+
+    def test_multi_key_entries_are_preserved(self, app, worker_env) -> None:
+        @app.remote(benchmark_dataset=[{"frame": 0, "total": 4}, {"frame": 3, "total": 4}])
+        async def render(frame, total):
+            return frame
+
+        handler = app.into_worker().backend.benchmark_handler
+        seen = set()
+        for _ in range(200):
+            kwargs = handler.make_benchmark_payload().input["kwargs"]
+            assert set(kwargs) == {"frame", "total"}
+            seen.add(kwargs["frame"])
+        assert seen == {0, 3}
+
+
+class TestSyncFunctionOffloading:
+    async def test_sync_function_runs_off_the_event_loop(self, app) -> None:
+        """A plain `def` body must not execute on the loop thread."""
+        loop_thread = threading.get_ident()
+        seen = {}
+
+        @app.remote(benchmark_dataset=[{"x": 1}])
+        def blocking(x):
+            seen["thread"] = threading.get_ident()
+            return x * 2
+
+        (entry,) = app.remote_funcs.values()
+        wrapped = app._wrap_remote_func(
+            app.root_module, entry.func, entry.globals
+        )
+        result = await wrapped(kwargs={"x": 21})
+
+        assert result["ok"] == 42
+        assert seen["thread"] != loop_thread, (
+            "synchronous remote function ran on the event loop thread"
+        )
+
+    async def test_sync_function_does_not_block_the_loop(self, app) -> None:
+        """Other loop tasks keep running while a sync body is in flight."""
+        import time as _time
+
+        @app.remote(benchmark_dataset=[{"x": 1}])
+        def slow(x):
+            _time.sleep(0.3)
+            return x
+
+        (entry,) = app.remote_funcs.values()
+        wrapped = app._wrap_remote_func(app.root_module, entry.func, entry.globals)
+
+        ticks = 0
+
+        async def ticker():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.02)
+                ticks += 1
+
+        task = asyncio.create_task(ticker())
+        try:
+            await wrapped(kwargs={"x": 1})
+        finally:
+            task.cancel()
+
+        # If the body had blocked the loop, the ticker could not have advanced.
+        assert ticks > 3, f"event loop was starved; only {ticks} ticks"
+
+    async def test_async_function_still_runs_inline(self, app) -> None:
+        """async def bodies keep their existing behaviour."""
+        loop_thread = threading.get_ident()
+        seen = {}
+
+        @app.remote(benchmark_dataset=[{"x": 1}])
+        async def native(x):
+            seen["thread"] = threading.get_ident()
+            return x + 1
+
+        (entry,) = app.remote_funcs.values()
+        wrapped = app._wrap_remote_func(app.root_module, entry.func, entry.globals)
+        result = await wrapped(kwargs={"x": 1})
+
+        assert result["ok"] == 2
+        assert seen["thread"] == loop_thread
+
+    async def test_sync_function_errors_are_serialized_not_raised(self, app) -> None:
+        @app.remote(benchmark_dataset=[{"x": 1}])
+        def boom(x):
+            raise ValueError("nope")
+
+        (entry,) = app.remote_funcs.values()
+        wrapped = app._wrap_remote_func(app.root_module, entry.func, entry.globals)
+        result = await wrapped(kwargs={"x": 1})
+
+        assert "err" in result

--- a/tests/serverless/test_startup_progress.py
+++ b/tests/serverless/test_startup_progress.py
@@ -1,0 +1,177 @@
+"""Tests for deployment startup progress and the startup timeout.
+
+A deployment's first call blocks while an instance is rented, the image pulled,
+packages installed and the benchmark run. Previously the client printed nothing
+and waited forever, so a slow start and a hang were indistinguishable and the
+only way to see what was happening was to poll the raw endpoint-workers API by
+hand.
+
+Two things matter here beyond "it prints something":
+
+* One poller per deployment. ``asyncio.gather`` of a large batch must not create
+  one poller per call — the endpoint-workers API is rate limited.
+* A bounded wait, with the last observed worker states in the error.
+"""
+
+import asyncio
+
+import pytest
+
+from vastai.serverless.client.worker import Worker
+from vastai.serverless.remote.progress import (
+    MIN_POLL_INTERVAL,
+    StartupProgress,
+    WorkerStartupTimeout,
+)
+
+
+def _worker(worker_id: int, status: str) -> Worker:
+    return Worker.from_dict({"id": worker_id, "status": status})
+
+
+class TestPollerIsShared:
+    async def test_many_waiters_share_one_poll_task(self) -> None:
+        calls = 0
+
+        async def fetch():
+            nonlocal calls
+            calls += 1
+            return [_worker(1, "loading")]
+
+        p = StartupProgress("app", fetch, mode="off", poll_interval=0.01)
+        for _ in range(50):
+            p.acquire()
+        await asyncio.sleep(0.05)
+        task = p._task
+        for _ in range(50):
+            p.release()
+
+        # 50 concurrent callers, still a single polling task.
+        assert task is not None
+        assert calls < 20, f"poller ran {calls} times; expected one shared loop"
+
+    async def test_poller_stops_when_the_last_waiter_leaves(self) -> None:
+        async def fetch():
+            return []
+
+        p = StartupProgress("app", fetch, mode="off", poll_interval=0.01)
+        p.acquire()
+        p.acquire()
+        await asyncio.sleep(0.02)
+        p.release()
+        assert p._task is not None, "still one waiter, poller should live"
+        p.release()
+        assert p._task is None
+
+    def test_poll_interval_is_floored_to_respect_rate_limits(self) -> None:
+        p = StartupProgress("app", lambda: None, poll_interval=0.001)
+        assert p._poll_interval == MIN_POLL_INTERVAL
+
+    async def test_poll_failures_do_not_propagate(self) -> None:
+        """A rate-limit response must not break the request being waited on."""
+
+        async def fetch():
+            raise RuntimeError("HTTPTooManyRequests")
+
+        p = StartupProgress("app", fetch, mode="off", poll_interval=0.01)
+        p.acquire()
+        await asyncio.sleep(0.05)
+        assert not p._task.done() or p._task.cancelled()
+        p.release()
+
+
+class TestProgressRendering:
+    async def test_summary_groups_workers_by_phase(self) -> None:
+        workers = [
+            _worker(1, "idle"),
+            _worker(2, "loading"),
+            _worker(3, "loading"),
+            _worker(4, "model_loading"),
+        ]
+
+        async def fetch():
+            return workers
+
+        p = StartupProgress("app", fetch, mode="off")
+        p.acquire()
+        await asyncio.sleep(0)
+        p._workers = workers
+        summary = p._summary()
+        p.release()
+
+        assert "2 pulling image / installing" in summary
+        assert "1 loading model / benchmarking" in summary
+        assert "1 ready" in summary
+
+    async def test_summary_says_so_when_nothing_was_recruited(self) -> None:
+        async def fetch():
+            return []
+
+        p = StartupProgress("app", fetch, mode="off")
+        assert "no workers recruited yet" in p._summary()
+
+    def test_off_mode_renders_nothing(self, capsys) -> None:
+        p = StartupProgress("app", lambda: None, mode="off")
+        p._workers = [_worker(1, "loading")]
+        p._render()
+        assert capsys.readouterr().err == ""
+
+    def test_plain_mode_logs_instead_of_drawing(self) -> None:
+        # The "vastai" logger sets propagate=False and owns its handler, so
+        # caplog cannot see it; attach our own handler instead.
+        import logging
+
+        records: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        logger = logging.getLogger("vastai")
+        handler = _Capture()
+        logger.addHandler(handler)
+        previous_level = logger.level
+        logger.setLevel(logging.INFO)
+        try:
+            p = StartupProgress("app", lambda: None, mode="plain")
+            p._workers = [_worker(1, "loading")]
+            p._render()
+        finally:
+            logger.removeHandler(handler)
+            logger.setLevel(previous_level)
+
+        assert any("waiting for a worker" in r.getMessage() for r in records)
+        assert any("pulling image / installing" in r.getMessage() for r in records)
+
+    def test_elapsed_is_sane_before_acquire(self) -> None:
+        """A reporter rendered before acquire() must not claim hours elapsed."""
+        p = StartupProgress("app", lambda: None, mode="off")
+        assert 0 <= p._elapsed() < 5
+
+
+class TestWorkerStartupTimeout:
+    def test_message_lists_the_last_observed_worker_states(self) -> None:
+        exc = WorkerStartupTimeout(
+            "my-app", 900.0, [_worker(1, "loading"), _worker(2, "model_loading")]
+        )
+        message = str(exc)
+        assert "my-app" in message
+        assert "900" in message
+        assert "pulling image / installing" in message
+        assert "loading model / benchmarking" in message
+
+    def test_message_explains_an_empty_pool_differently(self) -> None:
+        exc = WorkerStartupTimeout("my-app", 60.0, [])
+        message = str(exc)
+        # No workers at all is a search/config problem, not a slow image pull.
+        assert "image.require" in message
+        assert "max_workers" in message
+
+    def test_it_is_a_timeout_error(self) -> None:
+        """So existing `except TimeoutError` handlers keep working."""
+        assert issubclass(WorkerStartupTimeout, TimeoutError)
+
+    def test_workers_are_available_for_programmatic_inspection(self) -> None:
+        exc = WorkerStartupTimeout("a", 1.0, [_worker(7, "stopped")])
+        assert [w.id for w in exc.workers] == [7]
+        assert exc.waited == 1.0

--- a/tests/serverless/test_worker_state.py
+++ b/tests/serverless/test_worker_state.py
@@ -1,0 +1,100 @@
+"""Tests for the client-side Worker view.
+
+Startup progress, ``ensure_ready(wait=...)`` and version pinning all read worker
+state through this dataclass, so the parsing and the phase mapping need to be
+right — including for older workers that do not report the newer fields.
+"""
+
+from vastai.serverless.client.worker import (
+    READY_STATES,
+    STOPPED_STATES,
+    Worker,
+)
+
+
+def _base(**overrides) -> dict:
+    d = {
+        "id": 123,
+        "status": "idle",
+        "cur_load": 1.0,
+        "new_load": 2.0,
+        "cur_load_rolling_avg": 3.0,
+        "cur_perf": 4.0,
+        "perf": 5.0,
+        "measured_perf": 6.0,
+        "dlperf": 7.0,
+        "reliability": 0.9,
+        "reqs_working": 2,
+        "disk_usage": 8.0,
+        "loaded_at": 100.0,
+        "started_at": 50.0,
+    }
+    d.update(overrides)
+    return d
+
+
+class TestWorkerNewFields:
+    def test_defaults_when_worker_omits_new_fields(self) -> None:
+        """An older worker reports none of these; parsing must not break."""
+        w = Worker.from_dict(_base())
+        assert w.deployment_version_id is None
+        assert w.loop_lag_max == 0.0
+        assert w.warnings == []
+
+    def test_parses_new_fields_when_present(self) -> None:
+        w = Worker.from_dict(
+            _base(
+                deployment_version_id=3215,
+                loop_lag_max=12.5,
+                warnings=["event_loop_blocked"],
+            )
+        )
+        assert w.deployment_version_id == 3215
+        assert w.loop_lag_max == 12.5
+        assert w.warnings == ["event_loop_blocked"]
+
+    def test_scalar_warning_is_coerced_to_a_list(self) -> None:
+        w = Worker.from_dict(_base(warnings="event_loop_blocked"))
+        assert w.warnings == ["event_loop_blocked"]
+
+    def test_version_id_is_coerced_to_int(self) -> None:
+        w = Worker.from_dict(_base(deployment_version_id="42"))
+        assert w.deployment_version_id == 42
+
+
+class TestWorkerPhase:
+    def test_ready_statuses_are_ready(self) -> None:
+        for status in READY_STATES:
+            assert Worker.from_dict(_base(status=status)).is_ready
+            assert Worker.from_dict(_base(status=status)).phase == "ready"
+
+    def test_startup_statuses_map_to_readable_phases(self) -> None:
+        cases = {
+            "creating": "renting instance",
+            "created": "renting instance",
+            "loading": "pulling image / installing",
+            "model_loading": "loading model / benchmarking",
+        }
+        for status, expected in cases.items():
+            w = Worker.from_dict(_base(status=status))
+            assert not w.is_ready
+            assert w.phase == expected
+
+    def test_stopped_statuses_report_themselves(self) -> None:
+        for status in ("stopped", "stopping", "exited"):
+            w = Worker.from_dict(_base(status=status))
+            assert not w.is_ready
+            assert w.phase == status
+            assert status in STOPPED_STATES
+
+    def test_unknown_status_falls_back_to_the_raw_value(self) -> None:
+        w = Worker.from_dict(_base(status="something_new"))
+        assert w.phase == "something_new"
+        assert not w.is_ready
+
+    def test_missing_status_does_not_crash(self) -> None:
+        d = _base()
+        del d["status"]
+        w = Worker.from_dict(d)
+        assert w.status == "UNKNOWN"
+        assert not w.is_ready

--- a/vastai/serverless/client/connection.py
+++ b/vastai/serverless/client/connection.py
@@ -10,7 +10,9 @@ from vastai.utils import VERSION
 _JITTER_CAP_SECONDS = 5.0
 
 def _retryable(status: int) -> bool:
-    return status in (408, 429) or (500 <= status < 600)
+    # 409 means the worker is serving a superseded deployment version, so
+    # retrying re-routes to one that has finished rolling.
+    return status in (408, 409, 429) or (500 <= status < 600)
 
 def _backoff_delay(attempt: int) -> float:
     # capped exponential backoff with jitter

--- a/vastai/serverless/client/worker.py
+++ b/vastai/serverless/client/worker.py
@@ -1,5 +1,23 @@
-from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple, Optional
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+# Worker statuses that mean "this worker can serve a request right now".
+READY_STATES = frozenset({"idle", "ready", "running"})
+
+# Statuses that mean the worker is still coming up, mapped to a short phase
+# label. Used to explain *what* a deployment is waiting on during startup.
+STARTUP_PHASES: Dict[str, str] = {
+    "creating": "renting instance",
+    "created": "renting instance",
+    "loading": "pulling image / installing",
+    "model_loading": "loading model / benchmarking",
+    "starting": "starting",
+    "rebooting": "rebooting",
+}
+
+# Statuses that mean the worker is not going to serve anything without help.
+STOPPED_STATES = frozenset({"stopped", "stopping", "exited", "error", "ERROR"})
+
 
 @dataclass
 class Worker:
@@ -17,11 +35,40 @@ class Worker:
     disk_usage: float
     loaded_at: float
     started_at: float
+    # Which deployment code version this worker is actually serving. Lets a
+    # client tell a freshly-rolled worker from one still running the previous
+    # version. None when the endpoint is not a deployment, or when the worker
+    # predates this field.
+    deployment_version_id: Optional[int] = None
+    # Worst event-loop stall the worker observed since its last report, in
+    # seconds. A large value means a remote function is blocking the loop.
+    loop_lag_max: float = 0.0
+    # Self-reported problems, e.g. "event_loop_blocked".
+    warnings: List[str] = field(default_factory=list)
+
+    @property
+    def is_ready(self) -> bool:
+        return self.status in READY_STATES
+
+    @property
+    def phase(self) -> str:
+        """Human-readable description of what this worker is doing."""
+        if self.is_ready:
+            return "ready"
+        if self.status in STOPPED_STATES:
+            return self.status
+        return STARTUP_PHASES.get(self.status, self.status)
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "Worker":
         # Be resilient to missing / extra fields
         status = d.get("status") or "UNKNOWN"
+
+        version = d.get("deployment_version_id")
+
+        warnings = d.get("warnings") or []
+        if not isinstance(warnings, list):
+            warnings = [str(warnings)]
 
         return Worker(
             id=int(d.get("id")),
@@ -38,4 +85,7 @@ class Worker:
             disk_usage=float(d.get("disk_usage", 0.0)),
             loaded_at=float(d.get("loaded_at", 0.0)),
             started_at=float(d.get("started_at", 0.0)),
+            deployment_version_id=int(version) if version is not None else None,
+            loop_lag_max=float(d.get("loop_lag_max", 0.0)),
+            warnings=[str(w) for w in warnings],
         )

--- a/vastai/serverless/remote/base.py
+++ b/vastai/serverless/remote/base.py
@@ -12,7 +12,56 @@ from typing import (
 )
 from typing_extensions import Unpack
 from vastai.data import Query
+import dataclasses
 from dataclasses import dataclass
+
+
+class RemoteOptionsDict(TypedDict, total=False):
+    """Keyword options accepted by ``@Deployment.remote``.
+
+    Declared once so deploy mode and serve mode cannot drift apart. Keep the
+    keys in sync with :class:`RemoteOptions`; a test asserts they match.
+    """
+
+    benchmark_dataset: Optional[list[dict]]
+    benchmark_generator: Optional[Callable[[], dict]]
+    benchmark_runs: int
+    workload_calculator: Optional[Callable[..., float]]
+    allow_parallel_requests: bool
+    max_queue_time: Optional[float]
+
+
+@dataclass(frozen=True)
+class RemoteOptions:
+    """Resolved ``@remote`` options, with defaults applied."""
+
+    benchmark_dataset: Optional[list[dict]] = None
+    benchmark_generator: Optional[Callable[[], dict]] = None
+    benchmark_runs: int = 10
+    workload_calculator: Optional[Callable[..., float]] = None
+    # Serve-mode behaviour. These are read on the worker when it re-imports the
+    # deployment module, but they must be accepted in deploy mode too or the
+    # decorator raises before the code is ever packaged.
+    allow_parallel_requests: bool = False
+    max_queue_time: Optional[float] = 30.0
+
+    @classmethod
+    def field_names(cls) -> frozenset[str]:
+        return frozenset(f.name for f in dataclasses.fields(cls))
+
+    @classmethod
+    def from_kwargs(cls, **kwargs: Unpack[RemoteOptionsDict]) -> "RemoteOptions":
+        """Build options from decorator kwargs, rejecting unknown keys clearly."""
+        known = cls.field_names()
+        unknown = set(kwargs) - known
+        if unknown:
+            raise TypeError(
+                "@remote() got unexpected keyword argument(s): "
+                + ", ".join(sorted(unknown))
+                + ". Valid options: "
+                + ", ".join(sorted(known))
+            )
+        return cls(**kwargs)  # type: ignore[arg-type]
 
 
 class DockerLogin(TypedDict, total=False):
@@ -193,11 +242,7 @@ class Deployment_(ABC):
     def remote(
         self,
         f: Callable[P, Awaitable[Any]] | None = None,
-        *,
-        benchmark_dataset: list[dict] | None = None,
-        benchmark_generator: Callable[[], dict] | None = None,
-        benchmark_runs: int = 10,
-        workload_calculator: Callable[..., float] | None = None,
+        **opts: Unpack[RemoteOptionsDict],
     ) -> (
         Callable[P, Awaitable[Any]]
         | Callable[[Callable[P, Awaitable[Any]]], Callable[P, Awaitable[Any]]]

--- a/vastai/serverless/remote/deploy.py
+++ b/vastai/serverless/remote/deploy.py
@@ -1,3 +1,4 @@
+import functools
 import inspect
 import threading
 import time
@@ -11,8 +12,18 @@ from vastai import AsyncClient
 from vastai._base import _APIKEY_SENTINEL
 from vastai.data.deployment import DeploymentConfig
 from vastai.serverless.client import ManagedDeployment
+from vastai.serverless.client.worker import Worker
 from . import serialization
-from .base import Deployment_, Config, DockerLogin, Image, Autoscaling
+from .base import (
+    Autoscaling,
+    Config,
+    Deployment_,
+    DockerLogin,
+    Image,
+    RemoteOptions,
+    RemoteOptionsDict,
+)
+from .progress import StartupProgress, WorkerStartupTimeout
 from .utils import create_deployment_tarball, compute_deployment_hash
 from os.path import getsize
 import tempfile
@@ -104,6 +115,75 @@ class _FullDeployment:
     deployment: ManagedDeployment
 
 
+_WARNED: set[tuple[str, Any]] = set()
+
+_WARNING_TEXT = {
+    "event_loop_blocked": (
+        "Worker {worker} reported its event loop was blocked. A synchronous "
+        "remote function body starves the worker's health reporting and the "
+        "worker may be reclaimed mid-batch. Define the function with plain "
+        "`def` (it will be threaded automatically) or wrap the work in "
+        "`asyncio.to_thread(...)`."
+    ),
+}
+
+
+def _warn_once(code: str, worker: Any) -> None:
+    """Surface a worker-reported problem to the caller, once per worker."""
+    key = (code, worker)
+    if key in _WARNED:
+        return
+    _WARNED.add(key)
+    template = _WARNING_TEXT.get(code)
+    if template is None:
+        logger.warning(f"Worker {worker} reported: {code}")
+    else:
+        logger.warning(template.format(worker=worker))
+
+
+class RemoteCall:
+    """An in-flight remote call that also reports where it ran.
+
+    ``await f(x)`` stays the simple path. When you need to know which worker
+    served a call — to verify a batch really spread across the pool, say — use
+    ``f.submit(x)`` and read the attributes after awaiting::
+
+        calls = [render.submit(i) for i in range(32)]
+        results = await asyncio.gather(*calls)
+        Counter(c.worker_id for c in calls)
+    """
+
+    __slots__ = (
+        "_coro",
+        "worker_id",
+        "worker_url",
+        "gpu",
+        "latency",
+        "duration_ms",
+        "deployment_version_id",
+    )
+
+    def __init__(self) -> None:
+        self._coro: Optional[Awaitable[Any]] = None
+        self.worker_id: Optional[int] = None
+        self.worker_url: Optional[str] = None
+        self.gpu: Optional[str] = None
+        self.latency: Optional[float] = None
+        self.duration_ms: Optional[float] = None
+        self.deployment_version_id: Optional[int] = None
+
+    def __await__(self):
+        if self._coro is None:
+            raise RuntimeError("RemoteCall was not dispatched")
+        return self._coro.__await__()
+
+    def __repr__(self) -> str:
+        return (
+            f"<RemoteCall worker={self.worker_id} gpu={self.gpu} "
+            f"latency={self.latency}>"
+        )
+
+
 P = ParamSpec("P")
 
 
@@ -115,6 +195,8 @@ class Deployment(Deployment_):  # TODO: Async Context Manager compatible with cl
         autoscaler_instance="prod",
         autoscaler_url: Optional[str] = None,
         webserver_url="https://console.vast.ai",
+        progress: str = "auto",
+        startup_timeout: float | None = 900.0,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -129,6 +211,34 @@ class Deployment(Deployment_):  # TODO: Async Context Manager compatible with cl
         self._autoscaling: Autoscaling | None = None
         self._ttl = ttl
         self._inner: _FullDeployment | None = None
+        # "auto" | "live" | "plain" | "off"
+        self._progress_mode = progress
+        # Refuse to block forever waiting for a worker that may never arrive.
+        self._startup_timeout = startup_timeout
+        self._progress: Optional[StartupProgress] = None
+        self._version_id: Optional[int] = None
+
+    # -- worker introspection ------------------------------------------------
+
+    async def workers(self) -> list[Worker]:
+        """Current workers for this deployment's endpoint.
+
+        Useful on its own, and the data source for startup progress and for
+        ``ensure_ready(wait=...)``.
+        """
+        if not isinstance(self._inner, _FullDeployment):
+            raise Exception("Deployment is not ready. Call .ensure_ready() first!")
+        endpoint = await self._inner.deployment.endpoint._get_routing_endpoint()
+        return await self.client.get_endpoint_workers(endpoint)
+
+    def _get_progress(self) -> StartupProgress:
+        if self._progress is None:
+            self._progress = StartupProgress(
+                name=self.name or "deployment",
+                fetch_workers=self.workers,
+                mode=self._progress_mode,
+            )
+        return self._progress
 
     def _compile_env(self, checked_image: Image) -> str:
         envs = [f"-p {port}:{port}/{type_}" for port, type_ in checked_image._ports]
@@ -225,7 +335,24 @@ class Deployment(Deployment_):  # TODO: Async Context Manager compatible with cl
             deployment.sync_heartbeat()
             time.sleep(interval)
 
-    async def async_ensure_ready(self):
+    async def async_ensure_ready(
+        self,
+        wait: bool | int = False,
+        timeout: float | None = None,
+        require_version: bool = True,
+    ):
+        """Register (and if needed upload) the deployment.
+
+        Args:
+            wait: ``False`` returns as soon as the deployment is registered —
+                the historical behaviour. ``True`` waits for one worker to be
+                serving this exact code version; an int waits for that many.
+            timeout: Seconds to wait when ``wait`` is set. Defaults to the
+                deployment's ``startup_timeout``.
+            require_version: Reject workers still serving a superseded version,
+                so a call made right after a rolling update cannot be answered
+                by the previous code.
+        """
         if not isinstance(self.root_module, str):
             raise Exception(
                 "Trying to deploy a deployment not yet bound to a Python module. Have any remote functions been registered?"
@@ -260,6 +387,12 @@ class Deployment(Deployment_):  # TODO: Async Context Manager compatible with cl
                         f"soft_update but no workergroup found for endpoint {deployment.endpoint_id}, skipping update_workers"
                     )
             self._inner = _FullDeployment(self.root_module, deployment)
+            if require_version:
+                try:
+                    self._version_id = (await deployment.get()).current_version_id
+                except Exception as ex:  # non-fatal: fall back to no pinning
+                    logger.debug(f"Could not resolve deployment version: {ex}")
+                    self._version_id = None
             if self._ttl is not None:
                 threading.Thread(
                     target=self._heartbeat_thread,
@@ -268,8 +401,74 @@ class Deployment(Deployment_):  # TODO: Async Context Manager compatible with cl
                 ).start()
         logger.info(f"Deployment '{self.name}' is ready (id={deployment.id})")
 
-    def ensure_ready(self):
-        asyncio.run(self.async_ensure_ready())
+        if wait:
+            want = 1 if wait is True else int(wait)
+            await self._wait_for_workers(
+                want,
+                timeout if timeout is not None else self._startup_timeout,
+                require_version=require_version,
+            )
+
+    async def _wait_for_workers(
+        self, want: int, timeout: float | None, require_version: bool = True
+    ) -> list[Worker]:
+        """Block until ``want`` workers can serve this deployment's version."""
+        deadline = None if timeout is None else time.monotonic() + timeout
+        progress = self._get_progress()
+        progress.acquire()
+        started = time.monotonic()
+        delay = 2.0
+        try:
+            while True:
+                try:
+                    workers = await self.workers()
+                except Exception as ex:
+                    logger.debug(f"worker poll failed while waiting: {ex}")
+                    workers = []
+
+                ready = [w for w in workers if w.is_ready]
+                if require_version and self._version_id is not None:
+                    # Treat "unknown version" as acceptable so older workers
+                    # that do not report the field are not excluded outright.
+                    ready = [
+                        w
+                        for w in ready
+                        if w.deployment_version_id in (None, self._version_id)
+                    ]
+                if len(ready) >= want:
+                    logger.info(
+                        f"Deployment '{self.name}': {len(ready)} worker(s) ready"
+                    )
+                    return ready
+
+                if deadline is None:
+                    await asyncio.sleep(delay)
+                else:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise WorkerStartupTimeout(
+                            self.name or "deployment",
+                            time.monotonic() - started,
+                            workers,
+                        )
+                    # Never sleep past the deadline, or a short timeout would
+                    # be rounded up to a whole backoff interval.
+                    await asyncio.sleep(min(delay, remaining))
+                delay = min(delay * 1.5, 10.0)
+        finally:
+            progress.release()
+
+    def ensure_ready(
+        self,
+        wait: bool | int = False,
+        timeout: float | None = None,
+        require_version: bool = True,
+    ):
+        asyncio.run(
+            self.async_ensure_ready(
+                wait=wait, timeout=timeout, require_version=require_version
+            )
+        )
 
     def _unwrap_worker_response(self, response: dict[str, Any]) -> serialization.JSON:
         try:
@@ -279,41 +478,102 @@ class Deployment(Deployment_):  # TODO: Async Context Manager compatible with cl
                 f"Remote function call failed with status code {response['status']}: {response['text']}"
             )
 
-    async def _dispatch(self, f_name, globals, sig, args, kwargs) -> Any:
+    def _record_call_meta(self, call: "RemoteCall | None", response: dict) -> None:
+        """Populate a RemoteCall from the transport + worker metadata.
+
+        The worker URL and latency were always available on the transport
+        response; the worker id and GPU come from the ``meta`` block that serve
+        mode attaches alongside ``result``.
+        """
+        if call is None:
+            return
+        call.worker_url = response.get("url")
+        call.latency = response.get("latency")
+        meta = {}
+        inner = response.get("response")
+        if isinstance(inner, dict):
+            meta = inner.get("meta") or {}
+        call.worker_id = meta.get("worker_id")
+        call.gpu = meta.get("gpu")
+        call.deployment_version_id = meta.get("deployment_version_id")
+        call.duration_ms = meta.get("duration_ms")
+        for warning in meta.get("warnings") or []:
+            _warn_once(warning, call.worker_id)
+
+    async def _dispatch(
+        self, f_name, globals, sig, args, kwargs, call: "RemoteCall | None" = None
+    ) -> Any:
         if not isinstance(self._inner, _FullDeployment):
             raise Exception("Deployment is not ready. Call .ensure_ready() first!")
         bound_args = sig.bind(*args, **kwargs)
         bound_args.apply_defaults()
         route = "/remote/" + "/".join(f_name)
         logger.debug(f"Dispatching remote call to {route}")
+
+        payload = {
+            "kwargs": {
+                k: serialization.serialize(v, self._inner.root_module)
+                for k, v in bound_args.arguments.items()
+            }
+        }
+        # Let the worker reject the call if it is serving superseded code, so a
+        # rolling update cannot silently answer with the previous version.
+        if self._version_id is not None:
+            payload["expect_version_id"] = self._version_id
+
+        response = await self._request_with_progress(route, payload)
+        self._record_call_meta(call, response)
+
         return serialization.deserialize_unwrap_error(
-            self._unwrap_worker_response(
-                await self._inner.deployment.endpoint.request(
-                    route,
-                    {
-                        "kwargs": {
-                            k: serialization.serialize(v, self._inner.root_module)
-                            for k, v in bound_args.arguments.items()
-                        }
-                    },
-                )
-            ),
+            self._unwrap_worker_response(response),
             self._inner.root_module,
             globals,
         )
 
+    async def _request_with_progress(self, route: str, payload: dict) -> dict:
+        """Issue the request, reporting startup progress while it waits.
+
+        The transport blocks internally polling for a routable worker. There is
+        no callback out of it, so progress is reported by a shared poller and
+        the overall wait is bounded by ``startup_timeout``.
+        """
+        assert isinstance(self._inner, _FullDeployment)
+        progress = self._get_progress()
+        progress.acquire()
+        started = time.monotonic()
+        try:
+            coro = self._inner.deployment.endpoint.request(route, payload)
+            if self._startup_timeout is None:
+                return await coro
+            try:
+                return await asyncio.wait_for(coro, timeout=self._startup_timeout)
+            except asyncio.TimeoutError:
+                raise WorkerStartupTimeout(
+                    self.name or "deployment",
+                    time.monotonic() - started,
+                    progress.last_workers,
+                ) from None
+        finally:
+            progress.release()
+
+    def _submit(self, f_name, globals, sig, args, kwargs) -> "RemoteCall":
+        """Dispatch a call and return an awaitable handle carrying metadata."""
+        call = RemoteCall()
+        call._coro = self._dispatch(f_name, globals, sig, args, kwargs, call=call)
+        return call
+
     def remote(
         self,
         f: Callable[P, Awaitable[Any]] | None = None,
-        *,
-        benchmark_dataset: list[dict] | None = None,
-        benchmark_generator: Callable[[], dict] | None = None,
-        benchmark_runs: int = 10,
-        workload_calculator: Callable[..., float] | None = None,
+        **opts: Unpack[RemoteOptionsDict],
     ) -> (
         Callable[P, Awaitable[Any]]
         | Callable[[Callable[P, Awaitable[Any]]], Callable[P, Awaitable[Any]]]
     ):
+        # Validate here so a bad option fails at decoration time with a useful
+        # message, even though only serve mode acts on most of them.
+        RemoteOptions.from_kwargs(**opts)
+
         def decorator(
             f: Callable[P, Awaitable[Any]], **_
         ) -> Callable[P, Awaitable[Any]]:
@@ -325,6 +585,12 @@ class Deployment(Deployment_):  # TODO: Async Context Manager compatible with cl
             def inner(*args: P.args, **kwargs: P.kwargs) -> Awaitable[Any]:
                 return self._dispatch(f_rel_name, f_globals, sig, args, kwargs)
 
+            functools.update_wrapper(inner, f)
+            # Opt-in richer handle: `call = f.submit(...)` then `await call`
+            # exposes which worker served it. See RemoteCall.
+            inner.submit = (  # type: ignore[attr-defined]
+                lambda *a, **kw: self._submit(f_rel_name, f_globals, sig, a, kw)
+            )
             return inner
 
         if f is not None:

--- a/vastai/serverless/remote/progress.py
+++ b/vastai/serverless/remote/progress.py
@@ -1,0 +1,199 @@
+"""Startup progress reporting for deployments.
+
+A deployment's first call blocks while the serverless engine rents an instance,
+pulls the image, installs packages, loads contexts and runs the startup
+benchmark. That can take anywhere from under a minute to several minutes, and
+without any output the caller cannot tell a slow start from a hang.
+
+:class:`StartupProgress` polls worker state on a single shared task per
+deployment and renders it, so one ``asyncio.gather`` of a hundred calls does not
+produce a hundred pollers (the endpoint-workers API is rate limited).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import time
+from typing import Awaitable, Callable, List, Optional, Sequence
+
+from vastai.serverless.client.worker import Worker
+
+logger = logging.getLogger("vastai")
+
+# The endpoint-workers API is rate limited; never poll faster than this.
+MIN_POLL_INTERVAL = 5.0
+# How often to redraw / re-log when nothing has changed.
+LOG_INTERVAL = 15.0
+
+
+class WorkerStartupTimeout(TimeoutError):
+    """Raised when no worker becomes ready within the allotted time.
+
+    Carries the last observed worker states so the message explains *what* the
+    deployment was waiting on rather than just that it gave up.
+    """
+
+    def __init__(self, name: str, waited: float, workers: Sequence[Worker]):
+        self.name = name
+        self.waited = waited
+        self.workers = list(workers)
+        super().__init__(self._render())
+
+    def _render(self) -> str:
+        head = (
+            f"Deployment {self.name!r}: no worker became ready after "
+            f"{self.waited:.0f}s."
+        )
+        if not self.workers:
+            return (
+                head + " No workers were recruited at all — check that your"
+                " image.require(...) filters match available offers, and that"
+                " the endpoint's max_workers is above zero."
+            )
+        lines = [head, "Last observed worker states:"]
+        for w in self.workers:
+            lines.append(f"  {w.id}  {w.phase}")
+        lines.append(
+            "If workers are stuck in 'loading', the image or packages may be"
+            " large; raise timeout=. If they cycle to 'stopped', check the"
+            " worker logs for a failing startup or benchmark."
+        )
+        return "\n".join(lines)
+
+
+def _supports_live_output() -> bool:
+    if os.environ.get("VAST_PROGRESS") == "plain":
+        return False
+    if os.environ.get("VAST_PROGRESS") == "live":
+        return True
+    if os.environ.get("CI"):
+        return False
+    try:
+        return sys.stderr.isatty()
+    except Exception:
+        return False
+
+
+class StartupProgress:
+    """Renders what a deployment is waiting on while it has no ready worker.
+
+    Started lazily by the first blocked call and stopped as soon as any call
+    gets routed. ``mode`` is "auto" (live line on a TTY, throttled log lines
+    otherwise), "plain", "live" or "off".
+    """
+
+    def __init__(
+        self,
+        name: str,
+        fetch_workers: Callable[[], Awaitable[List[Worker]]],
+        mode: str = "auto",
+        poll_interval: float = MIN_POLL_INTERVAL,
+    ):
+        self.name = name
+        self._fetch = fetch_workers
+        self._mode = mode
+        self._poll_interval = max(poll_interval, MIN_POLL_INTERVAL)
+        self._task: Optional[asyncio.Task] = None
+        self._waiters = 0
+        # Set again on first acquire(); initialised here so a reporter that is
+        # rendered before being acquired does not report a nonsense elapsed.
+        self._started_at = time.monotonic()
+        self._last_render = 0.0
+        self._last_line_len = 0
+        self._workers: List[Worker] = []
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def acquire(self) -> None:
+        """Register one blocked caller; starts the poller on the first."""
+        self._waiters += 1
+        if self._task is None or self._task.done():
+            self._started_at = time.monotonic()
+            self._task = asyncio.create_task(self._run())
+
+    def release(self) -> None:
+        """Deregister a caller; stops the poller when the last one leaves."""
+        self._waiters = max(0, self._waiters - 1)
+        if self._waiters == 0:
+            self._stop()
+
+    def _stop(self) -> None:
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+        self._task = None
+        self._clear_line()
+
+    @property
+    def last_workers(self) -> List[Worker]:
+        return list(self._workers)
+
+    @property
+    def enabled(self) -> bool:
+        return self._mode != "off"
+
+    # -- internals ---------------------------------------------------------
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                try:
+                    self._workers = await self._fetch()
+                except Exception as ex:  # never let reporting break a request
+                    logger.debug(f"progress: worker poll failed: {ex}")
+                self._render()
+                await asyncio.sleep(self._poll_interval)
+        except asyncio.CancelledError:
+            raise
+
+    def _elapsed(self) -> float:
+        return time.monotonic() - self._started_at
+
+    def _summary(self) -> str:
+        if not self._workers:
+            return "no workers recruited yet"
+        counts: dict[str, int] = {}
+        for w in self._workers:
+            counts[w.phase] = counts.get(w.phase, 0) + 1
+        return ", ".join(f"{n} {phase}" for phase, n in sorted(counts.items()))
+
+    def _render(self) -> None:
+        if not self.enabled:
+            return
+        now = time.monotonic()
+        live = self._mode in ("live",) or (
+            self._mode == "auto" and _supports_live_output()
+        )
+        if live:
+            self._render_live()
+        elif now - self._last_render >= LOG_INTERVAL:
+            self._last_render = now
+            logger.info(
+                f"{self.name}: waiting for a worker "
+                f"({self._waiters} call(s) queued, {self._elapsed():.0f}s) — "
+                f"{self._summary()}"
+            )
+
+    def _render_live(self) -> None:
+        line = (
+            f"{self.name}: waiting for a worker "
+            f"({self._waiters} queued, {self._elapsed():.0f}s) — {self._summary()}"
+        )
+        try:
+            pad = " " * max(0, self._last_line_len - len(line))
+            sys.stderr.write("\r" + line + pad)
+            sys.stderr.flush()
+            self._last_line_len = len(line)
+        except Exception:
+            pass
+
+    def _clear_line(self) -> None:
+        if self._last_line_len:
+            try:
+                sys.stderr.write("\r" + " " * self._last_line_len + "\r")
+                sys.stderr.flush()
+            except Exception:
+                pass
+            self._last_line_len = 0

--- a/vastai/serverless/remote/serve.py
+++ b/vastai/serverless/remote/serve.py
@@ -1,6 +1,8 @@
-from .base import Config, Deployment_
+from .base import Config, Deployment_, RemoteOptions, RemoteOptionsDict
 from ..server.worker import Worker, WorkerConfig, HandlerConfig, BenchmarkConfig
 from .serialization import serialize, deserialize, serialize_ok, serialize_err
+from typing_extensions import Unpack
+import inspect
 from typing import (
     ParamSpec,
     Type,
@@ -84,13 +86,25 @@ class Deployment(Deployment_, AsyncContextManager):
         self.contexts = {}  # invalidate contexts
 
     def _wrap_remote_func(
-        self, root_module: str, func: Callable[..., Awaitable[Any]], func_globals: dict
+        self, root_module: str, func: Callable[..., Any], func_globals: dict
     ) -> Callable[..., Awaitable[Any]]:
         """Wrap a remote function with serialization/deserialization.
 
         Expects payload: {"args": [serialized_args], "kwargs": {serialized_kwargs}}
         Returns: {"ok": serialized_result} on success, {"err": serialized_exception} on failure.
+
+        A plain ``def`` function is run via ``asyncio.to_thread`` rather than
+        inline. GPU work is almost always synchronous, and running it on the
+        event loop starves the worker's health reporting badly enough that the
+        autoscaler can reclaim the worker mid-batch. Threading it by default
+        makes the obvious way to write a remote function the correct one.
         """
+        is_async = inspect.iscoroutinefunction(func)
+        if not is_async:
+            logger.debug(
+                f"Remote function {getattr(func, '__name__', func)!r} is "
+                f"synchronous; it will run in a worker thread."
+            )
 
         async def wrapper(*, args: list = [], kwargs: dict = {}) -> dict:
             deserialized_args = [
@@ -100,7 +114,12 @@ class Deployment(Deployment_, AsyncContextManager):
                 k: deserialize(v, root_module, func_globals) for k, v in kwargs.items()
             }
             try:
-                result = await func(*deserialized_args, **deserialized_kwargs)
+                if is_async:
+                    result = await func(*deserialized_args, **deserialized_kwargs)
+                else:
+                    result = await asyncio.to_thread(
+                        func, *deserialized_args, **deserialized_kwargs
+                    )
                 return serialize_ok(result, root_module)
             except Exception as e:
                 return serialize_err(e, root_module)
@@ -147,14 +166,20 @@ class Deployment(Deployment_, AsyncContextManager):
                     # format a real client sends (the wrapper deserializes them).
                     dataset = entry.benchmark_dataset
                     if dataset is not None:
+                        # Note the brace placement: the comprehension must be
+                        # over the list, not over the dict. Previously the
+                        # `for` sat inside the braces, making this a dict
+                        # comprehension with the constant key "kwargs" wrapped
+                        # in a 1-element list -- every entry but the last was
+                        # silently discarded.
                         dataset = [
                             {
                                 "kwargs": {
                                     k: serialize(v, self.root_module)
                                     for k, v in item.items()
                                 }
-                                for item in dataset
                             }
+                            for item in dataset
                         ]
                     benchmark_generator = None
                     if entry.benchmark_generator is not None:
@@ -206,28 +231,24 @@ class Deployment(Deployment_, AsyncContextManager):
     def remote(
         self,
         f: Callable[P, Awaitable[Any]] | None = None,
-        *,
-        allow_parallel_requests: bool = False,
-        max_queue_time: float = 30.0,
-        benchmark_dataset: list[dict] | None = None,
-        benchmark_generator: Callable[[], dict] | None = None,
-        benchmark_runs: int = 10,
-        workload_calculator: Callable[..., float] | None = None,
+        **opts: Unpack[RemoteOptionsDict],
     ) -> (
         Callable[P, Awaitable[Any]]
         | Callable[[Callable[P, Awaitable[Any]]], Callable[P, Awaitable[Any]]]
     ):
+        resolved = RemoteOptions.from_kwargs(**opts)
+
         def decorator(f: Callable[P, Awaitable[Any]]) -> Callable[P, Awaitable[Any]]:
             key = self.relativize(f)
             self.remote_funcs[key] = RemoteFunc(
                 func=f,
                 globals=f.__globals__,
-                allow_parallel_requests=allow_parallel_requests,
-                max_queue_time=max_queue_time,
-                benchmark_dataset=benchmark_dataset,
-                benchmark_generator=benchmark_generator,
-                benchmark_runs=benchmark_runs,
-                workload_calculator=workload_calculator,
+                allow_parallel_requests=resolved.allow_parallel_requests,
+                max_queue_time=resolved.max_queue_time,
+                benchmark_dataset=resolved.benchmark_dataset,
+                benchmark_generator=resolved.benchmark_generator,
+                benchmark_runs=resolved.benchmark_runs,
+                workload_calculator=resolved.workload_calculator,
             )
             return f
 

--- a/vastai/serverless/server/lib/backend.py
+++ b/vastai/serverless/server/lib/backend.py
@@ -62,6 +62,12 @@ LOG_POLL_INTERVAL = 0.1
 SESSION_GC_INTERVAL = 5.0
 BENCHMARK_INDICATOR_FILE = ".has_benchmark"
 MAX_PUBKEY_FETCH_ATTEMPTS = 5
+# How often the event-loop watchdog checks whether its own sleep returned late.
+LOOP_LAG_PROBE_INTERVAL = 0.5
+# Stalls above this are reported. Generous enough not to fire on ordinary GC
+# pauses or a burst of deserialization, tight enough to catch a blocking
+# remote function well before the autoscaler gives up on the worker.
+LOOP_LAG_WARN_SECONDS = float(os.environ.get("VAST_LOOP_LAG_WARN", "5.0"))
 
 
 @dataclasses.dataclass
@@ -435,11 +441,45 @@ class Backend:
         """use this function to forward requests to the model endpoint"""
         try:
             data = await request.json()
+            # The client nests the expected deployment version alongside its
+            # kwargs. Strip it before the payload is parsed, or it would be
+            # splatted into the remote function as an unexpected keyword
+            # argument. Only deployments send it, so plain PyWorker payloads
+            # are left untouched.
+            expected_version = None
+            if handler.remote_function is not None and isinstance(
+                data.get("payload"), dict
+            ):
+                expected_version = data["payload"].pop("expect_version_id", None)
             auth_data, payload, session_id = handler.get_data_from_request(data)
         except JsonDataException as e:
             return web.json_response(data=e.message, status=422)
         except json.JSONDecodeError:
             return web.json_response(dict(error="invalid JSON"), status=422)
+
+        # A rolling update leaves old and new workers serving side by side. If
+        # the caller told us which version it expects, refuse the request rather
+        # than answering with superseded code -- the client treats 409 as
+        # retryable and re-routes to a worker that has finished updating.
+        mine = self.metrics.deployment_version_id
+        if (
+            expected_version is not None
+            and mine is not None
+            and int(expected_version) != int(mine)
+        ):
+            log.debug(
+                f"Rejecting request for version {expected_version}; "
+                f"this worker serves {mine}"
+            )
+            return web.json_response(
+                {
+                    "error": "deployment version mismatch",
+                    "expected": int(expected_version),
+                    "serving": int(mine),
+                },
+                status=409,
+            )
+
         workload = payload.count_workload()
         request_metrics: RequestMetrics = RequestMetrics(
             request_idx=auth_data.request_idx,
@@ -486,10 +526,15 @@ class Backend:
                     # fake ClientResponse → generate_client_response path
                     # to avoid double-serialization of large payloads.
                     remote_func_params = payload.generate_payload_json()
+                    started = time.monotonic()
                     result = await handler.call_remote_dispatch_function(
                         params=remote_func_params
                     )
-                    res = web.json_response({"result": result})
+                    # Attach worker identity so the caller can see where the
+                    # call ran without smuggling it through its own payload.
+                    res = web.json_response(
+                        {"result": result, "meta": self.__call_meta(started)}
+                    )
                 else:
                     response = await self.__call_backend(
                         handler=handler, payload=payload
@@ -651,6 +696,7 @@ class Backend:
                 self.__healthcheck(),
                 self.metrics._send_delete_requests_loop(),
                 self.__session_gc_loop(),
+                self.__loop_lag_watchdog(),
             )
         else:
             await gather(
@@ -660,6 +706,45 @@ class Backend:
                 self.__healthcheck(),
                 self.metrics._send_delete_requests_loop(),
                 self.__session_gc_loop(),
+                self.__loop_lag_watchdog(),
+            )
+
+    def __call_meta(self, started: float) -> Dict[str, Any]:
+        """Identity/diagnostics returned alongside a remote function result."""
+        return {
+            "worker_id": self.metrics.id,
+            "gpu": os.environ.get("GPU_NAME"),
+            "deployment_version_id": self.metrics.deployment_version_id,
+            "duration_ms": round((time.monotonic() - started) * 1000, 1),
+            "warnings": sorted(self.metrics.warnings),
+        }
+
+    async def __loop_lag_watchdog(self) -> NoReturn:
+        """Detect a remote function that is blocking the event loop.
+
+        Synchronous work inside an ``async def`` handler holds the loop for its
+        whole duration. Requests still succeed, so nothing looks wrong from the
+        client, but neither this task nor the metrics reporter can run on time --
+        the worker stops sending ``/worker_status/`` and the autoscaler may
+        reclaim it as unhealthy while it is in fact busy and making progress.
+
+        Measuring how late our own sleep returns detects that directly and
+        cheaply.
+        """
+        while True:
+            started = time.monotonic()
+            await sleep(LOOP_LAG_PROBE_INTERVAL)
+            lag = (time.monotonic() - started) - LOOP_LAG_PROBE_INTERVAL
+            if lag <= LOOP_LAG_WARN_SECONDS:
+                continue
+            self.metrics.record_loop_lag(lag)
+            log.warning(
+                f"Event loop blocked for {lag:.1f}s (threshold "
+                f"{LOOP_LAG_WARN_SECONDS:.1f}s). Synchronous work in a remote "
+                f"function starves this worker's health reporting and it may be "
+                f"reclaimed mid-request. Define the function with plain `def` "
+                f"so it is threaded automatically, or wrap the blocking call in "
+                f"`asyncio.to_thread(...)`."
             )
 
     async def __lifecycle_startup(self) -> None:

--- a/vastai/serverless/server/lib/data_types.py
+++ b/vastai/serverless/server/lib/data_types.py
@@ -361,6 +361,13 @@ class WorkerStatusData:
     additional_disk_usage: float
     working_request_idxs: list[int]
     url: str
+    # Which deployment code version this worker is serving, so a client can
+    # distinguish a rolled worker from one still running the previous version.
+    deployment_version_id: Optional[int] = None
+    # Worst event-loop stall observed since the last report, in seconds.
+    loop_lag_max: float = 0.0
+    # Self-reported problems, e.g. ["event_loop_blocked"].
+    warnings: list[str] = field(default_factory=list)
 
 
 class LogAction(Enum):

--- a/vastai/serverless/server/lib/metrics.py
+++ b/vastai/serverless/server/lib/metrics.py
@@ -13,8 +13,17 @@ from typing import Awaitable, NoReturn, List
 
 METRICS_UPDATE_INTERVAL = 1
 DELETE_REQUESTS_INTERVAL = 1
+# Warn when benchmarked throughput exceeds observed throughput by this factor.
+BENCHMARK_DIVERGENCE_FACTOR = 3.0
 
 log = logging.getLogger(__file__)
+
+
+def _int_or_none(value) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 @cache
@@ -39,7 +48,25 @@ class Metrics:
     url: str = field(default_factory=get_url)
     system_metrics: SystemMetrics = field(default_factory=SystemMetrics.empty)
     model_metrics: ModelMetrics = field(default_factory=ModelMetrics.empty)
+    deployment_version_id: int | None = field(
+        default_factory=lambda: _int_or_none(os.environ.get("DEPLOYMENT_VERSION_ID"))
+    )
+    # Worst event-loop stall since the last report, reset when metrics are sent.
+    loop_lag_max: float = 0.0
+    # Sticky problem flags reported to the autoscaler and on to clients.
+    warnings: set = field(default_factory=set)
     _session: ClientSession | None = field(default=None, init=False, repr=False)
+
+    def record_loop_lag(self, lag: float) -> None:
+        """Note an event-loop stall detected by the backend's watchdog."""
+        if lag > self.loop_lag_max:
+            self.loop_lag_max = lag
+        self.warnings.add("event_loop_blocked")
+        self.update_pending = True
+
+    def record_warning(self, code: str) -> None:
+        self.warnings.add(code)
+        self.update_pending = True
 
     async def http(self) -> ClientSession:
         if self._session is None:
@@ -102,6 +129,35 @@ class Metrics:
         request.status = "Success"
         request.success = True
         self.update_pending = True
+        self._check_benchmark_representative(request)
+
+    def _check_benchmark_representative(self, request: RequestMetrics) -> None:
+        """Warn when real traffic is far more expensive than the benchmark was.
+
+        ``max_throughput`` comes from benchmarking one sample input and is the
+        denominator in every queue-time estimate. Benchmark an unrepresentative
+        sample and the worker advertises throughput it does not have, queue time
+        looks short, and the endpoint never scales. That failure is silent, so
+        say something the first time real traffic contradicts the benchmark.
+        """
+        if "benchmark_unrepresentative" in self.warnings:
+            return
+        throughput = self.model_metrics.max_throughput
+        if throughput <= 0 or request.workload <= 0:
+            return
+        elapsed = request.work_completed_at - request.work_started_at
+        if elapsed <= 0:
+            return
+        observed = request.workload / elapsed
+        if observed * BENCHMARK_DIVERGENCE_FACTOR < throughput:
+            self.record_warning("benchmark_unrepresentative")
+            log.warning(
+                f"Benchmarked throughput is {throughput:.0f} workload/s but this "
+                f"request achieved {observed:.0f}. The benchmark sample looks "
+                f"cheaper than real traffic, so this worker is advertising more "
+                f"capacity than it has and the endpoint may not scale up when it "
+                f"should. Benchmark a representative input."
+            )
 
     def _request_errored(self, request: RequestMetrics, message: str) -> None:
         """
@@ -256,6 +312,9 @@ class Metrics:
                 cur_capacity=0,
                 max_capacity=0,
                 url=self.url,
+                deployment_version_id=self.deployment_version_id,
+                loop_lag_max=self.loop_lag_max,
+                warnings=sorted(self.warnings),
             )
 
         async def send_data(report_addr: str) -> bool:
@@ -306,4 +365,9 @@ class Metrics:
         if sent:
             self.update_pending = False
             self.model_metrics.reset()
+            # loop_lag_max is a per-interval peak, so clear it once reported.
+            # `warnings` is intentionally sticky: a worker that blocked its loop
+            # once should keep saying so, since the condition is a code defect
+            # rather than a transient load spike.
+            self.loop_lag_max = 0.0
             self.last_metric_update = time.time()


### PR DESCRIPTION
Five fixes for defects found while building deployment examples against live GPUs. Each one failed silently: calls returned correct results while quietly costing capacity, so the symptom looked like "GPU serverless is slow" rather than a bug.

1. @remote option parity (base.py, deploy.py, serve.py) allow_parallel_requests and max_queue_time existed only in serve mode's remote(), so @app.remote(allow_parallel_requests=True) raised TypeError at deploy time and the option was unreachable. Options are now declared once as RemoteOptions/RemoteOptionsDict and both modes accept the same set, with a clearer error for unknown keys and a test asserting signature parity so they cannot drift again.

2. benchmark_dataset kept only its last entry (serve.py) into_worker built [{"kwargs": ... for item in dataset}] -- a dict comprehension with the constant key "kwargs" wrapped in a one-element list -- so every entry but the last was discarded and the worker benchmarked one arbitrary sample.

3. Synchronous remote functions blocked the worker's event loop (serve.py, backend.py, metrics.py) GPU work is synchronous, and running it on the loop starves the metrics reporter: /worker_status/ POSTs time out and the autoscaler reclaims a worker that is busy and making progress. Observed as a four-worker pool collapsing to one over a single batch. A plain `def` remote function is now run via asyncio.to_thread, so the obvious way to write one is correct; a watchdog measures loop lag and reports "event_loop_blocked" upstream and to the caller for the async case.

4. Startup was silent and unbounded (progress.py, deploy.py) The first call blocked with no output and no timeout, so a slow image pull and a hang were indistinguishable. Adds a shared, rate-limit aware progress reporter (one poller per deployment, not per call) and a bounded wait raising WorkerStartupTimeout with the last observed worker states.

5. Rolling updates could answer with superseded code (backend.py, connection.py, deploy.py) ensure_ready() returns once the update is triggered, not once workers converge, so the next call could hit a worker still running the old version -- surfacing as a type error in the caller. Clients now pin the expected version, the worker answers 409 on mismatch, and 409 is retryable so the request re-routes. ensure_ready(wait=N) blocks until N workers serve the current version.

Also: worker identity (id, GPU, duration) is returned alongside remote results and exposed via f.submit(), replacing the need to smuggle CONTAINER_ID through your own payload; and a warning fires when observed throughput diverges from the benchmark, which is what silently prevents an endpoint from scaling up.

Adds 68 tests. Full suite: 1331 passed, unchanged pre-existing failures in test_tar_utils.py and tests/live.