### PR TITLE
fix(cli): resolve .pub file paths in `create ssh-key`

### DIFF
--- a/tests/cli/test_keys_commands.py
+++ b/tests/cli/test_keys_commands.py
@@ -38,15 +38,60 @@ class TestShowApiKey:
         assert "/auth/apikeys/1/" in call_args[0][0]
 
 
+PUBLIC_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyMaterial user@host"
+
+PRIVATE_KEY = """-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+-----END OPENSSH PRIVATE KEY-----
+"""
+
+
 class TestCreateSshKey:
     def test_create_ssh_key(self, parse_argv, patch_get_client, mock_response, capsys):
         patch_get_client.post.return_value = mock_response(200, {"id": 1, "success": True})
-        args = parse_argv(["create", "ssh-key", "ssh-rsa AAAA... user@host"])
+        args = parse_argv(["create", "ssh-key", PUBLIC_KEY])
         args.func(args)
         patch_get_client.post.assert_called_once()
         call_args = patch_get_client.post.call_args
         assert "/ssh/" in call_args[0][0]
-        assert "ssh_key" in call_args[1]["json_data"]
+        # The key *material* must reach the API, not just the parameter name.
+        assert call_args[1]["json_data"]["ssh_key"] == PUBLIC_KEY
+
+    def test_create_ssh_key_reads_public_key_file(
+        self, parse_argv, patch_get_client, mock_response, tmp_path
+    ):
+        """A path to a .pub file is read; the path string itself is never sent.
+
+        `vastai create ssh-key ~/.ssh/id_ed25519.pub` is the form the docs and
+        this command's own help text tell users to run.
+        """
+        key_file = tmp_path / "id_ed25519.pub"
+        key_file.write_text(PUBLIC_KEY + "\n")
+        patch_get_client.post.return_value = mock_response(200, {"id": 1, "success": True})
+
+        args = parse_argv(["create", "ssh-key", str(key_file)])
+        args.func(args)
+
+        sent = patch_get_client.post.call_args[1]["json_data"]["ssh_key"]
+        assert sent.strip() == PUBLIC_KEY
+        assert str(key_file) not in sent
+
+    def test_create_ssh_key_rejects_private_key(
+        self, parse_argv, patch_get_client, tmp_path
+    ):
+        key_file = tmp_path / "id_ed25519"
+        key_file.write_text(PRIVATE_KEY)
+
+        args = parse_argv(["create", "ssh-key", str(key_file)])
+        with pytest.raises(ValueError, match="private"):
+            args.func(args)
+        patch_get_client.post.assert_not_called()
+
+    def test_create_ssh_key_rejects_non_key_string(self, parse_argv, patch_get_client):
+        args = parse_argv(["create", "ssh-key", "/does/not/exist/id_ed25519.pub"])
+        with pytest.raises(ValueError, match="SSH public key"):
+            args.func(args)
+        patch_get_client.post.assert_not_called()
 
 
 class TestDeleteSshKey:

--- a/vastai/cli/commands/keys.py
+++ b/vastai/cli/commands/keys.py
@@ -130,6 +130,9 @@ def create__ssh_key(args):
     if not ssh_key_content:
         ssh_key_content = generate_ssh_key(args.yes)
     else:
+        # Accepts either a path to a .pub file or the key material itself,
+        # and rejects private keys / non-keys before they reach the account.
+        ssh_key_content = get_ssh_key(ssh_key_content)
         print("Adding provided SSH public key to account...")
 
     client = get_client(args)


### PR DESCRIPTION
## The bug

`create ssh-key` imports `get_ssh_key` and then never calls it — it passes `args.ssh_key` straight to the API:

```python
from vastai.cli.util import get_ssh_key, generate_ssh_key   # imported, unused

ssh_key_content = args.ssh_key
...
result = keys_api.create_ssh_key(client, ssh_key=ssh_key_content)
```

So running the form the [hello-world guide](https://docs.vast.ai/cli/hello-world) and the command's own epilog prescribe:

```
vastai create ssh-key ~/.ssh/id_ed25519.pub
```

stores the literal string `/home/you/.ssh/id_ed25519.pub` as the account's public key:

```
$ vastai show ssh-keys
[{'id': 1276050, ..., 'public_key': '/Users/me/.ssh/id_ed25519.pub', ...}]
```

The command prints success. The key is silently useless. The first symptom is `Permission denied (publickey)` on an instance that has already been created and is already billing.

`update ssh-key` and `attach ssh` both call `get_ssh_key`; only `create` misses it — so the one broken path is the account-level one that new users are walked through first. This restores the behavior originally requested in #133.

## The fix

One line, routing through the existing helper:

```python
ssh_key_content = get_ssh_key(ssh_key_content)
```

That also picks up `get_ssh_key`'s two guards: a private key or a non-key string now raises before anything is sent, rather than being stored verbatim.

## Why it wasn't caught

The existing test asserted only that the parameter was present:

```python
assert "ssh_key" in call_args[1]["json_data"]
```

which holds for any value, including a file path. It now asserts the key material itself, plus three new cases: a `.pub` path is read, a private key is rejected, a non-key string is rejected. All three fail on `master` and pass with the fix.

## Verification

```
$ pytest tests/cli/test_keys_commands.py -q     # before fix
3 failed, 6 passed

$ pytest tests/cli/test_keys_commands.py -q     # after fix
9 passed

$ pytest tests/cli tests/sdk -q
531 passed
```

Full `pytest tests/` shows 12 failed / 12 errors both with and without this change (tar-utils and credential-requiring suites) — identical on clean `master`, unrelated to this PR.

## Not addressed here

`get_ssh_key` uses `os.path.exists` without `expanduser`, so a *quoted* `"~/.ssh/id_ed25519.pub"` still falls through as a literal string. Unquoted paths are shell-expanded and unaffected. That's a shared helper touching `update`/`attach` too, so I left it out to keep this focused — happy to follow up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code) - And reviewed by Kyle's eyes
