### PR TITLE
fix(cli): resolve .pub file paths in create ssh-key

### DIFF
--- a/tests/cli/test_keys_commands.py
+++ b/tests/cli/test_keys_commands.py
@@ -38,15 +38,67 @@ class TestShowApiKey:
         assert "/auth/apikeys/1/" in call_args[0][0]
 
 
+PUBLIC_KEY = "ssh-ed25519 NOT-REAL-KEY-MATERIAL user@host"
+
+# Only the "PRIVATE KEY" marker is inspected by get_ssh_key; no key material
+# needed, and none is committed.
+PRIVATE_KEY = "-----BEGIN OPENSSH PRIVATE KEY-----\nNOT-A-REAL-KEY\n-----END OPENSSH PRIVATE KEY-----\n"
+
+
 class TestCreateSshKey:
     def test_create_ssh_key(self, parse_argv, patch_get_client, mock_response, capsys):
         patch_get_client.post.return_value = mock_response(200, {"id": 1, "success": True})
-        args = parse_argv(["create", "ssh-key", "ssh-rsa AAAA... user@host"])
+        args = parse_argv(["create", "ssh-key", PUBLIC_KEY])
         args.func(args)
         patch_get_client.post.assert_called_once()
         call_args = patch_get_client.post.call_args
         assert "/ssh/" in call_args[0][0]
-        assert "ssh_key" in call_args[1]["json_data"]
+        # The key *material* must reach the API, not just the parameter name.
+        assert call_args[1]["json_data"]["ssh_key"] == PUBLIC_KEY
+
+    def test_create_ssh_key_reads_public_key_file(
+        self, parse_argv, patch_get_client, mock_response, tmp_path
+    ):
+        # `create ssh-key ~/.ssh/id_ed25519.pub` is the form the docs and this
+        # command's own help text prescribe.
+        key_file = tmp_path / "id_ed25519.pub"
+        key_file.write_text(PUBLIC_KEY + "\n")
+        patch_get_client.post.return_value = mock_response(200, {"id": 1, "success": True})
+
+        args = parse_argv(["create", "ssh-key", str(key_file)])
+        args.func(args)
+
+        # Exact match, not .strip(): get_ssh_key forwards file contents
+        # verbatim, trailing newline included, and that is what reaches the API.
+        sent = patch_get_client.post.call_args[1]["json_data"]["ssh_key"]
+        assert sent == PUBLIC_KEY + "\n"
+
+    def test_create_ssh_key_rejects_private_key(
+        self, parse_argv, patch_get_client, tmp_path
+    ):
+        key_file = tmp_path / "id_ed25519"
+        key_file.write_text(PRIVATE_KEY)
+
+        args = parse_argv(["create", "ssh-key", str(key_file)])
+        with pytest.raises(ValueError, match="private"):
+            args.func(args)
+        patch_get_client.post.assert_not_called()
+
+    def test_create_ssh_key_rejects_unreadable_path(
+        self, parse_argv, patch_get_client, tmp_path
+    ):
+        # Bare OSError subclasses (IsADirectoryError, PermissionError) escape
+        # main()'s handlers and print a traceback; ValueError renders cleanly.
+        args = parse_argv(["create", "ssh-key", str(tmp_path)])
+        with pytest.raises(ValueError, match="Couldn't read"):
+            args.func(args)
+        patch_get_client.post.assert_not_called()
+
+    def test_create_ssh_key_rejects_non_key_string(self, parse_argv, patch_get_client):
+        args = parse_argv(["create", "ssh-key", "/does/not/exist/id_ed25519.pub"])
+        with pytest.raises(ValueError, match="SSH public key"):
+            args.func(args)
+        patch_get_client.post.assert_not_called()
 
 
 class TestDeleteSshKey:

--- a/vastai/cli/commands/keys.py
+++ b/vastai/cli/commands/keys.py
@@ -130,6 +130,9 @@ def create__ssh_key(args):
     if not ssh_key_content:
         ssh_key_content = generate_ssh_key(args.yes)
     else:
+        # Accepts either a path to a .pub file or the key material itself,
+        # and rejects private keys / non-keys before they reach the account.
+        ssh_key_content = get_ssh_key(ssh_key_content)
         print("Adding provided SSH public key to account...")
 
     client = get_client(args)

--- a/vastai/cli/util.py
+++ b/vastai/cli/util.py
@@ -275,8 +275,22 @@ def get_ssh_key(argstr):
     ssh_key = argstr
     # Including a path to a public key is pretty reasonable.
     if os.path.exists(argstr):
-        with open(argstr) as f:
-            ssh_key = f.read()
+        try:
+            with open(argstr) as f:
+                ssh_key = f.read()
+        except OSError as e:
+            # A directory or an unreadable file would otherwise surface as a
+            # raw traceback: main() only handles HTTPError and ValueError.
+            raise ValueError(deindent(f"""
+                Couldn't read an SSH public key from:
+
+                {argstr}
+
+                {e}
+
+                Point this at your public key file, usually
+                ~/.ssh/id_ed25519.pub, or pass the key itself.
+            """, add_separator=False))
 
     if "PRIVATE KEY" in ssh_key:
         raise ValueError(deindent("""


### PR DESCRIPTION
## Problem

`create ssh-key` imports `get_ssh_key` and then never calls it — it passes `args.ssh_key` straight to the API:

```python
from vastai.cli.util import get_ssh_key, generate_ssh_key   # imported, unused

ssh_key_content = args.ssh_key
...
result = keys_api.create_ssh_key(client, ssh_key=ssh_key_content)
```

So the form the hello-world guide and this command's own epilog prescribe:

```
vastai create ssh-key ~/.ssh/id_ed25519.pub
```

stores the literal string `/home/you/.ssh/id_ed25519.pub` as the account's public key:

```
$ vastai show ssh-keys
[{'id': 1276050, ..., 'public_key': '/Users/me/.ssh/id_ed25519.pub', ...}]
```

The command prints success. The key is silently useless. The first symptom is `Permission denied (publickey)` on an instance that is already created and already billing.

## Cause

`update ssh-key` and `attach ssh` both call `get_ssh_key`; only `create` misses it — so the one broken path is the account-level one new users are walked through first. The unused import is the tell: the call was dropped, most likely when the commands moved into `vastai/cli/commands/`. This restores the behavior originally requested in #133.

## Fix

One line, routing through the existing helper:

```python
ssh_key_content = get_ssh_key(ssh_key_content)
```

That also picks up `get_ssh_key`'s two guards: a private key or a non-key string now raises before anything is sent, rather than being stored verbatim.

Routing `create` through the helper newly exposed one crash: `get_ssh_key`'s `open()` raises bare `OSError` subclasses, which `main()` doesn't handle (it catches `HTTPError` and `ValueError` only), so `vastai create ssh-key ~/.ssh` printed a raw traceback. Those are now converted to `ValueError` with a message in the same shape as the function's two existing ones. `update ssh-key` and `attach ssh` get the same treatment for free.

## Test plan

The existing test asserted only that the parameter was present:

```python
assert "ssh_key" in call_args[1]["json_data"]
```

true for any value, including a file path — which is why the regression went unnoticed. It now asserts the exact string sent, alongside four new cases: a `.pub` path is read, a private key is rejected, a non-key string is rejected, an unreadable path raises cleanly.

- [x] `pytest tests/cli/test_keys_commands.py` — 4 failed / 6 passed before, **10 passed** after
- [x] `pytest tests/cli tests/sdk` (covers `update`/`attach`, which share `get_ssh_key`) — **532 passed**
- [x] Full `pytest tests/` — 12 failed / 12 errors, identical on clean `master` (tar-utils and credential-requiring suites), unrelated to this change

## Follow-up (not in this PR)

- `vast.py` carries the identical bug at `create__ssh_key` (its own `get_ssh_key` sits unused at line 1310). Left alone deliberately: it's marked `DEPRECATED`, isn't in the wheel, and recent behavior fixes have been package-only — the last one mirrored there was the #471 credential fix. Happy to mirror it if you'd rather.
- `get_ssh_key` uses `os.path.exists` without `expanduser`, so a *quoted* `"~/.ssh/id_ed25519.pub"` still falls through as a literal. Unquoted paths are shell-expanded and unaffected.

Re-fixes #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code) - actually reviewed by a human before marking as ready for review 👋🏽
