### PR TITLE
fix(AUTO-1898): drop endpoint-only target_util and cold_mult from workergroup

### DIFF
--- a/tests/cli/test_endpoints_commands.py
+++ b/tests/cli/test_endpoints_commands.py
@@ -47,3 +47,45 @@ class TestShowWorkergroups:
         patch_get_client.get.assert_called_once()
         call_args = patch_get_client.get.call_args
         assert "/autojobs/" in call_args[0][0]
+
+
+ENDPOINT_ONLY_SCALING_FLAGS = ("--target_util", "--cold_mult")
+
+
+class TestWorkergroupEndpointOnlyScalingFlags:
+    """target_util and cold_mult scale the endpoint group, never a workergroup."""
+
+    @pytest.mark.parametrize("flag", ENDPOINT_ONLY_SCALING_FLAGS)
+    def test_create_workergroup_rejects_flag(self, cli_parser, flag):
+        with pytest.raises(SystemExit):
+            cli_parser.parse_args(["create", "workergroup", flag, "0.9"])
+
+    @pytest.mark.parametrize("flag", ENDPOINT_ONLY_SCALING_FLAGS)
+    def test_update_workergroup_rejects_flag(self, cli_parser, flag):
+        with pytest.raises(SystemExit):
+            cli_parser.parse_args(["update", "workergroup", "1", flag, "0.9"])
+
+    def test_create_workergroup_payload_omits_fields(self, parse_argv, patch_get_client, mock_response):
+        patch_get_client.post.return_value = mock_response(200, {"success": True, "id": 7})
+        args = parse_argv(["create", "workergroup", "--endpoint_id", "3",
+                           "--template_hash", "abc123"])
+        args.func(args)
+        payload = patch_get_client.post.call_args.kwargs["json_data"]
+        assert "target_util" not in payload
+        assert "cold_mult" not in payload
+
+    def test_update_workergroup_payload_omits_fields(self, parse_argv, patch_get_client, mock_response):
+        patch_get_client.put.return_value = mock_response(200, {"success": True})
+        args = parse_argv(["update", "workergroup", "42", "--min_load", "100"])
+        args.func(args)
+        payload = patch_get_client.put.call_args.kwargs["json_data"]
+        assert "target_util" not in payload
+        assert "cold_mult" not in payload
+
+    @pytest.mark.parametrize("flag", ENDPOINT_ONLY_SCALING_FLAGS)
+    def test_endpoint_commands_keep_flag(self, cli_parser, flag):
+        create = cli_parser.parse_args(["create", "endpoint", flag, "0.5"])
+        update = cli_parser.parse_args(["update", "endpoint", "1", flag, "0.5"])
+        dest = flag.lstrip("-")
+        assert getattr(create, dest) == 0.5
+        assert getattr(update, dest) == 0.5

--- a/vast.py
+++ b/vast.py
@@ -2264,8 +2264,6 @@ def generate_ssh_key(auto_yes=False):
     argument("--gpu_ram",     help="estimated GPU RAM req  (independent of search string)", type=float),
     argument("--search_params", help="search param string for search offers    ex: \"gpu_ram>=23 num_gpus=2 gpu_name=RTX_4090 inet_down>200 direct_port_count>2 disk_space>=64\"", type=str),
     argument("--min_load", help="[NOTE: this field isn't currently used at the workergroup level] minimum floor load in perf units/s  (token/s for LLms)", type=float),
-    argument("--target_util", help="[NOTE: this field isn't currently used at the workergroup level] target capacity utilization (fraction, max 1.0, default 0.9)", type=float),
-    argument("--cold_mult",   help="[NOTE: this field isn't currently used at the workergroup level]cold/stopped instance capacity target as multiple of hot capacity target (default 2.0)", type=float),
     argument("--cold_workers",   help="min number of workers to keep 'cold' for this workergroup", type=int),
     argument("--auto_instance", help=argparse.SUPPRESS, type=str, default="prod"),
     usage="vastai workergroup create [OPTIONS]",
@@ -2289,7 +2287,7 @@ def create__workergroup(args):
         #query = {"verified": {"eq": True}, "external": {"eq": False}, "rentable": {"eq": True}, "rented": {"eq": False}}
     search_params = (args.search_params if args.search_params is not None else "" + query).strip()
 
-    json_blob = {"client_id": "me", "min_load": args.min_load, "target_util": args.target_util, "cold_mult": args.cold_mult, "cold_workers" : args.cold_workers, "test_workers" : args.test_workers, "template_hash": args.template_hash, "template_id": args.template_id, "search_params": search_params, "launch_args": args.launch_args, "gpu_ram": args.gpu_ram, "endpoint_name": args.endpoint_name, "endpoint_id": args.endpoint_id, "autoscaler_instance": args.auto_instance}
+    json_blob = {"client_id": "me", "min_load": args.min_load, "cold_workers" : args.cold_workers, "test_workers" : args.test_workers, "template_hash": args.template_hash, "template_id": args.template_id, "search_params": search_params, "launch_args": args.launch_args, "gpu_ram": args.gpu_ram, "endpoint_name": args.endpoint_name, "endpoint_id": args.endpoint_id, "autoscaler_instance": args.auto_instance}
 
     if (args.explain):
         print("request json: ")
@@ -7470,8 +7468,6 @@ def transfer__credit(args: argparse.Namespace):
 @parser.command(
     argument("id", help="id of autoscale group to update", type=int),
     argument("--min_load", help="minimum floor load in perf units/s  (token/s for LLms)", type=float),
-    argument("--target_util",      help="target capacity utilization (fraction, max 1.0, default 0.9)", type=float),
-    argument("--cold_mult",   help="cold/stopped instance capacity target as multiple of hot capacity target (default 2.5)", type=float),
     argument("--cold_workers",   help="min number of workers to keep 'cold' for this workergroup", type=int),
     argument("--test_workers",help="number of workers to create to get an performance estimate for while initializing workergroup (default 3)", type=int),
     argument("--gpu_ram",   help="estimated GPU RAM req  (independent of search string)", type=float),
@@ -7485,7 +7481,7 @@ def transfer__credit(args: argparse.Namespace):
     usage="vastai update workergroup WORKERGROUP_ID --endpoint_id ENDPOINT_ID [options]",
     help="Update an existing autoscale group",
     epilog=deindent("""
-        Example: vastai update workergroup 4242 --min_load 100 --target_util 0.9 --cold_mult 2.0 --search_params \"gpu_ram>=23 num_gpus=2 gpu_name=RTX_4090 inet_down>200 direct_port_count>2 disk_space>=64\" --launch_args \"--onstart onstart_wget.sh  --env '-e ONSTART_PATH=https://s3.amazonaws.com/public.vast.ai/onstart_OOBA.sh' --image atinoda/text-generation-webui:default-nightly --disk 64\" --gpu_ram 32.0 --endpoint_name "LLama" --endpoint_id 2
+        Example: vastai update workergroup 4242 --min_load 100 --search_params \"gpu_ram>=23 num_gpus=2 gpu_name=RTX_4090 inet_down>200 direct_port_count>2 disk_space>=64\" --launch_args \"--onstart onstart_wget.sh  --env '-e ONSTART_PATH=https://s3.amazonaws.com/public.vast.ai/onstart_OOBA.sh' --image atinoda/text-generation-webui:default-nightly --disk 64\" --gpu_ram 32.0 --endpoint_name "LLama" --endpoint_id 2
     """),
 )
 def update__workergroup(args):
@@ -7497,7 +7493,7 @@ def update__workergroup(args):
         query = " verified=True rentable=True rented=False"
     if args.search_params is not None:
         query = args.search_params + query
-    json_blob = {"client_id": "me", "autojob_id": args.id, "min_load": args.min_load, "target_util": args.target_util, "cold_mult": args.cold_mult, "cold_workers": args.cold_workers, "test_workers" : args.test_workers, "template_hash": args.template_hash, "template_id": args.template_id, "search_params": query, "launch_args": args.launch_args, "gpu_ram": args.gpu_ram, "endpoint_name": args.endpoint_name, "endpoint_id": args.endpoint_id}
+    json_blob = {"client_id": "me", "autojob_id": args.id, "min_load": args.min_load, "cold_workers": args.cold_workers, "test_workers" : args.test_workers, "template_hash": args.template_hash, "template_id": args.template_id, "search_params": query, "launch_args": args.launch_args, "gpu_ram": args.gpu_ram, "endpoint_name": args.endpoint_name, "endpoint_id": args.endpoint_id}
     if (args.explain):
         print("request json: ")
         print(json_blob)

--- a/vastai/api/endpoints.py
+++ b/vastai/api/endpoints.py
@@ -210,8 +210,6 @@ def create_workergroup(client, **kwargs):
             test_workers (int): Number of test workers. Default 3.
             gpu_ram (float): Estimated GPU RAM requirement.
             min_load (float): Minimum floor load.
-            target_util (float): Target capacity utilization.
-            cold_mult (float): Cold capacity target multiple.
             cold_workers (int): Min cold workers.
             no_default (bool): Disable default search param query args.
             auto_instance (str): Autoscaler instance type. Default "prod".
@@ -231,8 +229,6 @@ def create_workergroup(client, **kwargs):
     json_blob = {
         "client_id": "me",
         "min_load": kwargs.get("min_load"),
-        "target_util": kwargs.get("target_util"),
-        "cold_mult": kwargs.get("cold_mult"),
         "cold_workers": kwargs.get("cold_workers"),
         "test_workers": kwargs.get("test_workers", 3),
         "template_hash": kwargs.get("template_hash"),
@@ -276,8 +272,6 @@ def update_workergroup(client, id, **kwargs):
         "client_id": "me",
         "autojob_id": id,
         "min_load": kwargs.get("min_load"),
-        "target_util": kwargs.get("target_util"),
-        "cold_mult": kwargs.get("cold_mult"),
         "cold_workers": kwargs.get("cold_workers"),
         "test_workers": kwargs.get("test_workers"),
         "template_hash": kwargs.get("template_hash"),

--- a/vastai/cli/commands/endpoints.py
+++ b/vastai/cli/commands/endpoints.py
@@ -222,14 +222,15 @@ def get__endpt_workers(args):
     argument("--gpu_ram",     help="estimated GPU RAM req  (independent of search string)", type=float),
     argument("--search_params", help="search param string for search offers    ex: \"gpu_ram>=23 num_gpus=2 gpu_name=RTX_4090 inet_down>200 direct_port_count>2 disk_space>=64\"", type=str),
     argument("--min_load", help="[NOTE: this field isn't currently used at the workergroup level] minimum floor load in perf units/s  (token/s for LLms)", type=float),
-    argument("--target_util", help="[NOTE: this field isn't currently used at the workergroup level] target capacity utilization (fraction, max 1.0, default 0.9)", type=float),
-    argument("--cold_mult",   help="[NOTE: this field isn't currently used at the workergroup level]cold/stopped instance capacity target as multiple of hot capacity target (default 2.0)", type=float),
     argument("--cold_workers",   help="min number of workers to keep 'cold' for this workergroup", type=int),
     argument("--auto_instance", help=argparse.SUPPRESS, type=str, default="prod"),
     usage="vastai create workergroup [OPTIONS]",
     help="Create a new autoscale group",
     epilog=deindent("""
         Create a new autoscaling group to manage a pool of worker instances.
+
+        target_util and cold_mult are endpoint-level; set them with 'vastai create endpoint'
+        or 'vastai update endpoint'.
 
         Example: vastai create workergroup --template_hash HASH  --endpoint_name "LLama" --test_workers 5
     """),
@@ -248,7 +249,6 @@ def create__workergroup(args):
             endpoint_name=args.endpoint_name, endpoint_id=args.endpoint_id,
             test_workers=args.test_workers, gpu_ram=args.gpu_ram,
             search_params=args.search_params, min_load=args.min_load,
-            target_util=args.target_util, cold_mult=args.cold_mult,
             cold_workers=args.cold_workers, auto_instance=args.auto_instance,
         )
         print("workergroup create {}".format(result))
@@ -285,8 +285,6 @@ def show__workergroups(args):
 @parser.command(
     argument("id", help="id of autoscale group to update", type=int),
     argument("--min_load", help="minimum floor load in perf units/s  (token/s for LLms)", type=float),
-    argument("--target_util",      help="target capacity utilization (fraction, max 1.0, default 0.9)", type=float),
-    argument("--cold_mult",   help="cold/stopped instance capacity target as multiple of hot capacity target (default 2.5)", type=float),
     argument("--cold_workers",   help="min number of workers to keep 'cold' for this workergroup", type=int),
     argument("--test_workers",help="number of workers to create to get an performance estimate for while initializing workergroup (default 3)", type=int),
     argument("--gpu_ram",   help="estimated GPU RAM req  (independent of search string)", type=float),
@@ -300,7 +298,9 @@ def show__workergroups(args):
     usage="vastai update workergroup WORKERGROUP_ID --endpoint_id ENDPOINT_ID [options]",
     help="Update an existing autoscale group",
     epilog=deindent("""
-        Example: vastai update workergroup 4242 --min_load 100 --target_util 0.9 --cold_mult 2.0 --search_params \"gpu_ram>=23 num_gpus=2 gpu_name=RTX_4090 inet_down>200 direct_port_count>2 disk_space>=64\" --launch_args \"--onstart onstart_wget.sh  --env '-e ONSTART_PATH=https://s3.amazonaws.com/public.vast.ai/onstart_OOBA.sh' --image atinoda/text-generation-webui:default-nightly --disk 64\" --gpu_ram 32.0 --endpoint_name "LLama" --endpoint_id 2
+        target_util and cold_mult are endpoint-level; set them with 'vastai update endpoint'.
+
+        Example: vastai update workergroup 4242 --min_load 100 --search_params \"gpu_ram>=23 num_gpus=2 gpu_name=RTX_4090 inet_down>200 direct_port_count>2 disk_space>=64\" --launch_args \"--onstart onstart_wget.sh  --env '-e ONSTART_PATH=https://s3.amazonaws.com/public.vast.ai/onstart_OOBA.sh' --image atinoda/text-generation-webui:default-nightly --disk 64\" --gpu_ram 32.0 --endpoint_name "LLama" --endpoint_id 2
     """),
 )
 def update__workergroup(args):
@@ -308,8 +308,7 @@ def update__workergroup(args):
     client = get_client(args)
     result = endpoints_api.update_workergroup(
         client, id=args.id,
-        min_load=args.min_load, target_util=args.target_util,
-        cold_mult=args.cold_mult, cold_workers=args.cold_workers,
+        min_load=args.min_load, cold_workers=args.cold_workers,
         test_workers=args.test_workers, gpu_ram=args.gpu_ram,
         template_hash=args.template_hash, template_id=args.template_id,
         search_params=args.search_params, no_default=args.no_default,

--- a/vastai/cli/commands/endpoints.py
+++ b/vastai/cli/commands/endpoints.py
@@ -229,9 +229,6 @@ def get__endpt_workers(args):
     epilog=deindent("""
         Create a new autoscaling group to manage a pool of worker instances.
 
-        target_util and cold_mult are endpoint-level; set them with 'vastai create endpoint'
-        or 'vastai update endpoint'.
-
         Example: vastai create workergroup --template_hash HASH  --endpoint_name "LLama" --test_workers 5
     """),
 )
@@ -298,8 +295,6 @@ def show__workergroups(args):
     usage="vastai update workergroup WORKERGROUP_ID --endpoint_id ENDPOINT_ID [options]",
     help="Update an existing autoscale group",
     epilog=deindent("""
-        target_util and cold_mult are endpoint-level; set them with 'vastai update endpoint'.
-
         Example: vastai update workergroup 4242 --min_load 100 --search_params \"gpu_ram>=23 num_gpus=2 gpu_name=RTX_4090 inet_down>200 direct_port_count>2 disk_space>=64\" --launch_args \"--onstart onstart_wget.sh  --env '-e ONSTART_PATH=https://s3.amazonaws.com/public.vast.ai/onstart_OOBA.sh' --image atinoda/text-generation-webui:default-nightly --disk 64\" --gpu_ram 32.0 --endpoint_name "LLama" --endpoint_id 2
     """),
 )


### PR DESCRIPTION
## AUTO-1898: drop endpoint-only `target_util` and `cold_mult` from the workergroup CLI

`--target_util` and `--cold_mult` are endpoint-level scaling knobs. The workergroup
commands have accepted them for a long time, and `create workergroup --help` even
carried a `[NOTE: this field isn't currently used at the workergroup level]` on each.
This removes them so the flags live only where they do something.

### Why they're dead

The autoscaler parses `target_util`/`cold_mult` onto `Autogroup` (`autoscaler.cpp`
`parse_group`) and then never reads them — they're echoed back in sim serialization and
settable via scenario events, and that's it. The only consumer of these values is
`asm_ratio_manager.cpp`, where the group is an `Endptgroup`. `benchmarks.py` already
skips them for exactly this reason ("the autoscaler reads both from the endpoint group,
not the workergroup — verified via autoscaler.cpp"), and the web UI already strips them
from workergroup payloads.

### Changes

- `vastai/cli/commands/endpoints.py` — remove both flags from `create workergroup` and
  `update workergroup` and from the `endpoints_api` call sites; each epilog now says
  where the knobs actually live.
- `vastai/api/endpoints.py` — remove both keys from the `create_workergroup` /
  `update_workergroup` request bodies and from the docstring args. Endpoint functions
  untouched.
- `vast.py` — same removal in the deprecated monolith, so the two clients agree.
- `tests/cli/test_endpoints_commands.py` — new coverage: both flags rejected by both
  workergroup commands, neither key present in the POST/PUT body, and both still
  accepted by `create endpoint` / `update endpoint`.

### Backend impact: none

No server change is needed and no coordination is required in either direction. The
workergroup param models are `extra='ignore'`, so older CLIs keep working, and the
payload previously sent `"target_util": None` whenever the flag was unused — which the
server already treats as "inherit from the endpoint". For every call that wasn't passing
the flags, the wire format is unchanged.

### Behavior change

`create workergroup --endpoint_name <name>` for an endpoint that doesn't exist yet makes
the server create it, and it used to seed that new endpoint with these values. Such
endpoints now get the server defaults (`target_util` 0.9, `cold_mult` 3.0). Create the
endpoint explicitly first if you need non-defaults.

### Breaking

`vastai create|update workergroup --target_util X` (or `--cold_mult`) now exits 2 with
"unrecognized arguments". The values were being discarded by the autoscaler anyway, so
no scaling behavior changes for anyone — except the endpoint-creation case above.

### Out of scope

- `WorkergroupConfig` still declares both fields, so the async serverless client and
  `VastAI().create_workergroup(target_util=...)` still send them (server ignores them).
  Worth a follow-up so the SDK stops silently swallowing the value.
- `min_load` is equally inert at the workergroup level and is left as-is.
- Removing the `autoscale_jobs` columns / the backend params is a separate cleanup
  (migration + autoscaler + openapi snapshot).

### Testing

- `pytest tests/cli tests/test_legacy_vast.py tests/test_data_objects.py tests/scripts`
  → 606 passed.
- Full suite matches its pre-change baseline exactly (365 pre-existing failures from a
  venv without `pytest-asyncio`/`pyOpenSSL`), plus the 8 new tests.
- `vastai create workergroup --help` and `vastai update workergroup --help` verified.

### Follow-up chores

- Regenerate the `vast-ai/docs` pages for these two commands; `verify_cli_sdk_docs.py
  --check-params` will report parameter drift until then.
- `tests/compat_test.sh` will show an expected `--help` DIFF for both commands.
