### PR TITLE
Fix/auto 1912 remove test workers etc from cli

### DIFF
--- a/tests/cli/test_endpoints_commands.py
+++ b/tests/cli/test_endpoints_commands.py
@@ -49,21 +49,34 @@ class TestShowWorkergroups:
         assert "/autojobs/" in call_args[0][0]
 
 
-ENDPOINT_ONLY_SCALING_FLAGS = ("--target_util", "--cold_mult")
+WORKERGROUP_DEAD_FLAGS = (
+    ("--target_util", "0.9"),
+    ("--cold_mult", "2.5"),
+    ("--min_load", "100"),
+    ("--cold_workers", "5"),
+    ("--test_workers", "3"),
+)
+
+ENDPOINT_SCALING_FLAGS = (
+    ("--target_util", "0.9", 0.9),
+    ("--cold_mult", "2.5", 2.5),
+    ("--min_load", "100", 100.0),
+    ("--cold_workers", "5", 5),
+)
 
 
-class TestWorkergroupEndpointOnlyScalingFlags:
-    """target_util and cold_mult scale the endpoint group, never a workergroup."""
+class TestWorkergroupDeadScalingFlags:
+    """These scale the endpoint group or nothing at all; a workergroup never reads them."""
 
-    @pytest.mark.parametrize("flag", ENDPOINT_ONLY_SCALING_FLAGS)
-    def test_create_workergroup_rejects_flag(self, cli_parser, flag):
+    @pytest.mark.parametrize("flag,value", WORKERGROUP_DEAD_FLAGS)
+    def test_create_workergroup_rejects_flag(self, cli_parser, flag, value):
         with pytest.raises(SystemExit):
-            cli_parser.parse_args(["create", "workergroup", flag, "0.9"])
+            cli_parser.parse_args(["create", "workergroup", flag, value])
 
-    @pytest.mark.parametrize("flag", ENDPOINT_ONLY_SCALING_FLAGS)
-    def test_update_workergroup_rejects_flag(self, cli_parser, flag):
+    @pytest.mark.parametrize("flag,value", WORKERGROUP_DEAD_FLAGS)
+    def test_update_workergroup_rejects_flag(self, cli_parser, flag, value):
         with pytest.raises(SystemExit):
-            cli_parser.parse_args(["update", "workergroup", "1", flag, "0.9"])
+            cli_parser.parse_args(["update", "workergroup", "1", flag, value])
 
     def test_create_workergroup_payload_omits_fields(self, parse_argv, patch_get_client, mock_response):
         patch_get_client.post.return_value = mock_response(200, {"success": True, "id": 7})
@@ -71,21 +84,26 @@ class TestWorkergroupEndpointOnlyScalingFlags:
                            "--template_hash", "abc123"])
         args.func(args)
         payload = patch_get_client.post.call_args.kwargs["json_data"]
-        assert "target_util" not in payload
-        assert "cold_mult" not in payload
+        for flag, _ in WORKERGROUP_DEAD_FLAGS:
+            assert flag.lstrip("-") not in payload
 
     def test_update_workergroup_payload_omits_fields(self, parse_argv, patch_get_client, mock_response):
         patch_get_client.put.return_value = mock_response(200, {"success": True})
-        args = parse_argv(["update", "workergroup", "42", "--min_load", "100"])
+        args = parse_argv(["update", "workergroup", "42", "--gpu_ram", "32"])
         args.func(args)
         payload = patch_get_client.put.call_args.kwargs["json_data"]
-        assert "target_util" not in payload
-        assert "cold_mult" not in payload
+        for flag, _ in WORKERGROUP_DEAD_FLAGS:
+            assert flag.lstrip("-") not in payload
 
-    @pytest.mark.parametrize("flag", ENDPOINT_ONLY_SCALING_FLAGS)
-    def test_endpoint_commands_keep_flag(self, cli_parser, flag):
-        create = cli_parser.parse_args(["create", "endpoint", flag, "0.5"])
-        update = cli_parser.parse_args(["update", "endpoint", "1", flag, "0.5"])
+    @pytest.mark.parametrize("flag,value,expected", ENDPOINT_SCALING_FLAGS)
+    def test_endpoint_commands_keep_flag(self, cli_parser, flag, value, expected):
+        create = cli_parser.parse_args(["create", "endpoint", flag, value])
+        update = cli_parser.parse_args(["update", "endpoint", "1", flag, value])
         dest = flag.lstrip("-")
-        assert getattr(create, dest) == 0.5
-        assert getattr(update, dest) == 0.5
+        assert getattr(create, dest) == expected
+        assert getattr(update, dest) == expected
+
+    @pytest.mark.parametrize("command", (["create", "endpoint"], ["update", "endpoint", "1"]))
+    def test_endpoint_commands_reject_test_workers(self, cli_parser, command):
+        with pytest.raises(SystemExit):
+            cli_parser.parse_args([*command, "--test_workers", "3"])

--- a/vast.py
+++ b/vast.py
@@ -2260,18 +2260,15 @@ def generate_ssh_key(auto_yes=False):
     argument("--launch_args",   help="launch args  string for create instance  ex: \"--onstart onstart_wget.sh  --env '-e ONSTART_PATH=https://s3.amazonaws.com/vast.ai/onstart_OOBA.sh' --image atinoda/text-generation-webui:default-nightly --disk 64\"", type=str),
     argument("--endpoint_name", help="deployment endpoint name (allows multiple workergroups to share same deployment endpoint)", type=str),
     argument("--endpoint_id",   help="deployment endpoint id (allows multiple workergroups to share same deployment endpoint)", type=int),
-    argument("--test_workers",help="number of workers to create to get an performance estimate for while initializing workergroup (default 3)", type=int, default=3),
     argument("--gpu_ram",     help="estimated GPU RAM req  (independent of search string)", type=float),
     argument("--search_params", help="search param string for search offers    ex: \"gpu_ram>=23 num_gpus=2 gpu_name=RTX_4090 inet_down>200 direct_port_count>2 disk_space>=64\"", type=str),
-    argument("--min_load", help="[NOTE: this field isn't currently used at the workergroup level] minimum floor load in perf units/s  (token/s for LLms)", type=float),
-    argument("--cold_workers",   help="min number of workers to keep 'cold' for this workergroup", type=int),
     argument("--auto_instance", help=argparse.SUPPRESS, type=str, default="prod"),
     usage="vastai workergroup create [OPTIONS]",
     help="Create a new autoscale group",
     epilog=deindent("""
         Create a new autoscaling group to manage a pool of worker instances.
                     
-        Example: vastai create workergroup --template_hash HASH  --endpoint_name "LLama" --test_workers 5
+        Example: vastai create workergroup --template_hash HASH  --endpoint_name "LLama"
         """),
 )
 def create__workergroup(args):
@@ -2287,7 +2284,7 @@ def create__workergroup(args):
         #query = {"verified": {"eq": True}, "external": {"eq": False}, "rentable": {"eq": True}, "rented": {"eq": False}}
     search_params = (args.search_params if args.search_params is not None else "" + query).strip()
 
-    json_blob = {"client_id": "me", "min_load": args.min_load, "cold_workers" : args.cold_workers, "test_workers" : args.test_workers, "template_hash": args.template_hash, "template_id": args.template_id, "search_params": search_params, "launch_args": args.launch_args, "gpu_ram": args.gpu_ram, "endpoint_name": args.endpoint_name, "endpoint_id": args.endpoint_id, "autoscaler_instance": args.auto_instance}
+    json_blob = {"client_id": "me", "template_hash": args.template_hash, "template_id": args.template_id, "search_params": search_params, "launch_args": args.launch_args, "gpu_ram": args.gpu_ram, "endpoint_name": args.endpoint_name, "endpoint_id": args.endpoint_id, "autoscaler_instance": args.auto_instance}
 
     if (args.explain):
         print("request json: ")
@@ -7467,9 +7464,6 @@ def transfer__credit(args: argparse.Namespace):
 
 @parser.command(
     argument("id", help="id of autoscale group to update", type=int),
-    argument("--min_load", help="minimum floor load in perf units/s  (token/s for LLms)", type=float),
-    argument("--cold_workers",   help="min number of workers to keep 'cold' for this workergroup", type=int),
-    argument("--test_workers",help="number of workers to create to get an performance estimate for while initializing workergroup (default 3)", type=int),
     argument("--gpu_ram",   help="estimated GPU RAM req  (independent of search string)", type=float),
     argument("--template_hash",   help="template hash (**Note**: if you use this field, you can skip search_params, as they are automatically inferred from the template)", type=str),
     argument("--template_id",   help="template id", type=int),
@@ -7481,7 +7475,7 @@ def transfer__credit(args: argparse.Namespace):
     usage="vastai update workergroup WORKERGROUP_ID --endpoint_id ENDPOINT_ID [options]",
     help="Update an existing autoscale group",
     epilog=deindent("""
-        Example: vastai update workergroup 4242 --min_load 100 --search_params \"gpu_ram>=23 num_gpus=2 gpu_name=RTX_4090 inet_down>200 direct_port_count>2 disk_space>=64\" --launch_args \"--onstart onstart_wget.sh  --env '-e ONSTART_PATH=https://s3.amazonaws.com/public.vast.ai/onstart_OOBA.sh' --image atinoda/text-generation-webui:default-nightly --disk 64\" --gpu_ram 32.0 --endpoint_name "LLama" --endpoint_id 2
+        Example: vastai update workergroup 4242 --search_params \"gpu_ram>=23 num_gpus=2 gpu_name=RTX_4090 inet_down>200 direct_port_count>2 disk_space>=64\" --launch_args \"--onstart onstart_wget.sh  --env '-e ONSTART_PATH=https://s3.amazonaws.com/public.vast.ai/onstart_OOBA.sh' --image atinoda/text-generation-webui:default-nightly --disk 64\" --gpu_ram 32.0 --endpoint_name "LLama" --endpoint_id 2
     """),
 )
 def update__workergroup(args):
@@ -7493,7 +7487,7 @@ def update__workergroup(args):
         query = " verified=True rentable=True rented=False"
     if args.search_params is not None:
         query = args.search_params + query
-    json_blob = {"client_id": "me", "autojob_id": args.id, "min_load": args.min_load, "cold_workers": args.cold_workers, "test_workers" : args.test_workers, "template_hash": args.template_hash, "template_id": args.template_id, "search_params": query, "launch_args": args.launch_args, "gpu_ram": args.gpu_ram, "endpoint_name": args.endpoint_name, "endpoint_id": args.endpoint_id}
+    json_blob = {"client_id": "me", "autojob_id": args.id, "template_hash": args.template_hash, "template_id": args.template_id, "search_params": query, "launch_args": args.launch_args, "gpu_ram": args.gpu_ram, "endpoint_name": args.endpoint_name, "endpoint_id": args.endpoint_id}
     if (args.explain):
         print("request json: ")
         print(json_blob)

--- a/vast.py
+++ b/vast.py
@@ -2273,10 +2273,6 @@ def generate_ssh_key(auto_yes=False):
 )
 def create__workergroup(args):
     url = apiurl(args, "/autojobs/" )
-
-    # if args.launch_args_dict:
-    #     launch_args_dict = json.loads(args.launch_args_dict)
-    #     json_blob = {"client_id": "me", "min_load": args.min_load, "target_util": args.target_util, "cold_mult": args.cold_mult, "template_hash": args.template_hash, "template_id": args.template_id, "search_params": args.search_params, "launch_args_dict": launch_args_dict, "gpu_ram": args.gpu_ram, "endpoint_name": args.endpoint_name}
     if args.no_default:
         query = ""
     else:

--- a/vastai/api/endpoints.py
+++ b/vastai/api/endpoints.py
@@ -207,10 +207,7 @@ def create_workergroup(client, **kwargs):
             launch_args (str): Launch args string for create instance.
             endpoint_name (str): Deployment endpoint name.
             endpoint_id (int): Deployment endpoint ID.
-            test_workers (int): Number of test workers. Default 3.
             gpu_ram (float): Estimated GPU RAM requirement.
-            min_load (float): Minimum floor load.
-            cold_workers (int): Min cold workers.
             no_default (bool): Disable default search param query args.
             auto_instance (str): Autoscaler instance type. Default "prod".
 
@@ -228,9 +225,6 @@ def create_workergroup(client, **kwargs):
 
     json_blob = {
         "client_id": "me",
-        "min_load": kwargs.get("min_load"),
-        "cold_workers": kwargs.get("cold_workers"),
-        "test_workers": kwargs.get("test_workers", 3),
         "template_hash": kwargs.get("template_hash"),
         "template_id": kwargs.get("template_id"),
         "search_params": search_params,
@@ -271,9 +265,6 @@ def update_workergroup(client, id, **kwargs):
     json_blob = {
         "client_id": "me",
         "autojob_id": id,
-        "min_load": kwargs.get("min_load"),
-        "cold_workers": kwargs.get("cold_workers"),
-        "test_workers": kwargs.get("test_workers"),
         "template_hash": kwargs.get("template_hash"),
         "template_id": kwargs.get("template_id"),
         "search_params": search_params,

--- a/vastai/cli/commands/endpoints.py
+++ b/vastai/cli/commands/endpoints.py
@@ -218,18 +218,15 @@ def get__endpt_workers(args):
     argument("--launch_args",   help="launch args  string for create instance  ex: \"--onstart onstart_wget.sh  --env '-e ONSTART_PATH=https://s3.amazonaws.com/vast.ai/onstart_OOBA.sh' --image atinoda/text-generation-webui:default-nightly --disk 64\"", type=str),
     argument("--endpoint_name", help="deployment endpoint name (allows multiple workergroups to share same deployment endpoint)", type=str),
     argument("--endpoint_id",   help="deployment endpoint id (allows multiple workergroups to share same deployment endpoint)", type=int),
-    argument("--test_workers",help="number of workers to create to get an performance estimate for while initializing workergroup (default 3)", type=int, default=3),
     argument("--gpu_ram",     help="estimated GPU RAM req  (independent of search string)", type=float),
     argument("--search_params", help="search param string for search offers    ex: \"gpu_ram>=23 num_gpus=2 gpu_name=RTX_4090 inet_down>200 direct_port_count>2 disk_space>=64\"", type=str),
-    argument("--min_load", help="[NOTE: this field isn't currently used at the workergroup level] minimum floor load in perf units/s  (token/s for LLms)", type=float),
-    argument("--cold_workers",   help="min number of workers to keep 'cold' for this workergroup", type=int),
     argument("--auto_instance", help=argparse.SUPPRESS, type=str, default="prod"),
     usage="vastai create workergroup [OPTIONS]",
     help="Create a new autoscale group",
     epilog=deindent("""
         Create a new autoscaling group to manage a pool of worker instances.
 
-        Example: vastai create workergroup --template_hash HASH  --endpoint_name "LLama" --test_workers 5
+        Example: vastai create workergroup --template_hash HASH  --endpoint_name "LLama"
     """),
 )
 def create__workergroup(args):
@@ -244,9 +241,8 @@ def create__workergroup(args):
             client, template_hash=args.template_hash, template_id=args.template_id,
             no_default=args.no_default, launch_args=args.launch_args,
             endpoint_name=args.endpoint_name, endpoint_id=args.endpoint_id,
-            test_workers=args.test_workers, gpu_ram=args.gpu_ram,
-            search_params=args.search_params, min_load=args.min_load,
-            cold_workers=args.cold_workers, auto_instance=args.auto_instance,
+            gpu_ram=args.gpu_ram, search_params=args.search_params,
+            auto_instance=args.auto_instance,
         )
         print("workergroup create {}".format(result))
     except Exception as e:
@@ -281,9 +277,6 @@ def show__workergroups(args):
 
 @parser.command(
     argument("id", help="id of autoscale group to update", type=int),
-    argument("--min_load", help="minimum floor load in perf units/s  (token/s for LLms)", type=float),
-    argument("--cold_workers",   help="min number of workers to keep 'cold' for this workergroup", type=int),
-    argument("--test_workers",help="number of workers to create to get an performance estimate for while initializing workergroup (default 3)", type=int),
     argument("--gpu_ram",   help="estimated GPU RAM req  (independent of search string)", type=float),
     argument("--template_hash",   help="template hash (**Note**: if you use this field, you can skip search_params, as they are automatically inferred from the template)", type=str),
     argument("--template_id",   help="template id", type=int),
@@ -295,7 +288,7 @@ def show__workergroups(args):
     usage="vastai update workergroup WORKERGROUP_ID --endpoint_id ENDPOINT_ID [options]",
     help="Update an existing autoscale group",
     epilog=deindent("""
-        Example: vastai update workergroup 4242 --min_load 100 --search_params \"gpu_ram>=23 num_gpus=2 gpu_name=RTX_4090 inet_down>200 direct_port_count>2 disk_space>=64\" --launch_args \"--onstart onstart_wget.sh  --env '-e ONSTART_PATH=https://s3.amazonaws.com/public.vast.ai/onstart_OOBA.sh' --image atinoda/text-generation-webui:default-nightly --disk 64\" --gpu_ram 32.0 --endpoint_name "LLama" --endpoint_id 2
+        Example: vastai update workergroup 4242 --search_params \"gpu_ram>=23 num_gpus=2 gpu_name=RTX_4090 inet_down>200 direct_port_count>2 disk_space>=64\" --launch_args \"--onstart onstart_wget.sh  --env '-e ONSTART_PATH=https://s3.amazonaws.com/public.vast.ai/onstart_OOBA.sh' --image atinoda/text-generation-webui:default-nightly --disk 64\" --gpu_ram 32.0 --endpoint_name "LLama" --endpoint_id 2
     """),
 )
 def update__workergroup(args):
@@ -303,8 +296,7 @@ def update__workergroup(args):
     client = get_client(args)
     result = endpoints_api.update_workergroup(
         client, id=args.id,
-        min_load=args.min_load, cold_workers=args.cold_workers,
-        test_workers=args.test_workers, gpu_ram=args.gpu_ram,
+        gpu_ram=args.gpu_ram,
         template_hash=args.template_hash, template_id=args.template_id,
         search_params=args.search_params, no_default=args.no_default,
         launch_args=args.launch_args, endpoint_name=args.endpoint_name,

--- a/vastai/data/workergroup.py
+++ b/vastai/data/workergroup.py
@@ -18,13 +18,8 @@ class WorkergroupConfig:
     template_hash: Optional[str] = None
     template_id: Optional[int] = None
     launch_args: Optional[str] = None
-    min_load: Optional[float] = None
     min_cold_load: Optional[float] = None
-    target_util: Optional[float] = None
-    cold_mult: Optional[float] = None
-    cold_workers: Optional[int] = None
     max_workers: Optional[int] = None
-    test_workers: Optional[int] = None
     gpu_ram: Optional[float] = None
     autoscaler_instance: Optional[str] = None
     docker_login_user: Optional[str] = None


### PR DESCRIPTION
## AUTO-1912: drop dead `test_workers`, `cold_workers`, and `min_load` from the workergroup CLI

CLI-only slice of AUTO-1909. `vastai create workergroup` and `vastai update workergroup` exposed `--test_workers`, `--cold_workers`, and `--min_load`, none of which do anything at the workergroup level. Advertising them invites users to tune knobs that have no effect. Same treatment AUTO-1898 (#500) gave `--target_util` and `--cold_mult`.

No webserver or autoscaler change. No UI or docs-site change; those are separate slices of AUTO-1909.

### Why these are dead

Checked against the autoscaler source, not the help text:

- **`min_load`** is parsed into `Autogroup::min_load_` (`autoscaler.cpp:714`) and never read. The only consumer is `asm_ratio_manager.cpp:620-625`, which takes an `Endptgroup` (it touches `min_cold_load_`, a field `Autogroup` doesn't have).
- **`cold_workers`** isn't even parsed for `Autogroup`. `autoscaler.cpp:749` is inside the `Endptgroup` overload of `parse_group`; the `Autogroup` overload has no such line. Only sim/scenario code ever sets `Autogroup::cold_workers_`.
- **`test_workers`** does not appear in the autoscaler at all. The backend writes it to `autoscale_jobs.test_workers` and echoes it in `show workergroups`; nothing reads it.

### Changes

| File | What |
|---|---|
| `vastai/cli/commands/endpoints.py` | Three flags and their call-site kwargs removed from `create__workergroup` and `update__workergroup`; both epilog examples stripped of `--test_workers 5` / `--min_load 100` |
| `vastai/api/endpoints.py` | Three keys removed from the `create_workergroup` / `update_workergroup` `json_blob`s and from the `create_workergroup` docstring |
| `vast.py` | Same removals mirrored in the deprecated monolith, plus a commented-out `json_blob` that referenced three now-nonexistent `args.*` |
| `vastai/data/workergroup.py` | `WorkergroupConfig` loses all five fields: these three plus `target_util` / `cold_mult`, which AUTO-1898 deliberately left behind |
| `tests/cli/test_endpoints_commands.py` | `TestWorkergroupEndpointOnlyScalingFlags` → `TestWorkergroupDeadScalingFlags`, parameterized over all five |

`create_endpoint` / `update_endpoint` and their identically named keys are untouched. `sdk.py` needed no change; both workergroup wrappers are `**kwargs` passthroughs.

### Wire compatibility

Non-breaking for existing callers. The CLI already sent these as `None` unless explicitly passed, and the backend treats `None` as inherit-from-endpoint. The workergroup pydantic models are `extra='ignore'`, so dropping the keys entirely needs no backend coordination.

### Behavior changes worth knowing
