### PR TITLE
fix(sdk): preprocess_search_query silently drops most of the query

### DIFF
--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -9,6 +9,7 @@ from vastai.api.query import (
     offers_fields, offers_alias, offers_mult,
     benchmarks_fields, templates_fields, invoices_fields,
 )
+from vastai.utils import preprocess_search_query
 
 
 @pytest.fixture
@@ -179,6 +180,109 @@ class TestParseQuery:
     def test_underscore_replaced_with_space_in_value(self):
         result = parse_query("gpu_name=RTX_4090", fields=offers_fields)
         assert result["gpu_name"]["eq"] == "RTX 4090"
+
+
+class TestPreprocessSearchQueryKeepsEveryTerm:
+    """``preprocess_search_query`` rebuilds the query from its own parse, so a
+    value form its grammar cannot read is not reported as an error -- the term
+    silently disappears, and so does every term after it. Every value form
+    ``parse_query`` accepts has to survive it.
+
+    Only a query carrying ``georegion=true`` or ``chunked=true`` is rebuilt at
+    all, so every case here carries one.
+    """
+
+    # The query shape SkyPilot's Vast provisioner sends. The quoted geolocation
+    # is the third term, so this used to preprocess to '' -- a search with no
+    # filters at all.
+    SKYPILOT_QUERY = ('chunked=true georegion=true geolocation="AS" '
+                      'disk_space>=40 num_gpus=1 gpu_name="L40S" '
+                      'cpu_ram>="64.0"')
+
+    def test_quoted_value_does_not_truncate_the_query(self):
+        geo, chunked, q = preprocess_search_query(self.SKYPILOT_QUERY)
+        assert geo is True
+        assert chunked is True
+        assert 'geolocation in [' in q and 'JP' in q
+        for term in ('disk_space >= 40', 'num_gpus = 1',
+                     'gpu_name = "L40S"', 'cpu_ram >= "64.0"'):
+            assert term in q
+
+    def test_quoted_value_containing_a_space_survives(self):
+        _geo, _chunked, q = preprocess_search_query(
+            'chunked = true gpu_name = "RTX 4090" num_gpus = 1')
+        assert 'gpu_name = "RTX 4090"' in q
+        assert 'num_gpus = 1' in q
+
+    def test_single_quoted_value_survives(self):
+        _geo, _chunked, q = preprocess_search_query(
+            "chunked = true gpu_name = 'RTX 4090' num_gpus = 1")
+        assert "gpu_name = 'RTX 4090'" in q
+        assert 'num_gpus = 1' in q
+
+    def test_decimal_value_keeps_its_fraction(self):
+        _geo, _chunked, q = preprocess_search_query(
+            'chunked = true duration > 2.5 num_gpus = 1')
+        assert 'duration > 2.5' in q
+
+    def test_decimal_value_does_not_swallow_later_terms(self):
+        """A decimal used to match only its integer part, then stop the parse."""
+        _geo, _chunked, q = preprocess_search_query(
+            'chunked = true reliability > 0.99 num_gpus = 1')
+        assert 'reliability > 0.99' in q
+        assert 'num_gpus = 1' in q
+
+    def test_bracketed_list_survives(self):
+        _geo, _chunked, q = preprocess_search_query(
+            'chunked = true geolocation in [JP,TW] num_gpus = 1')
+        assert 'geolocation in [JP,TW]' in q
+        assert 'num_gpus = 1' in q
+
+    def test_value_with_several_dots_survives(self):
+        _geo, _chunked, q = preprocess_search_query(
+            'chunked = true driver_version >= 535.104.05 num_gpus = 1')
+        assert 'driver_version >= 535.104.05' in q
+        assert 'num_gpus = 1' in q
+
+    def test_quoted_region_code_is_expanded(self):
+        """The region code is compared unquoted, so a quoted one still expands."""
+        geo, _chunked, q = preprocess_search_query(
+            'geolocation = "NA" georegion = true')
+        assert geo is True
+        assert 'geolocation in [CA,US]' in q
+
+    def test_unparsable_query_is_returned_untouched(self):
+        """What cannot be read in full is never rebuilt from a partial parse."""
+        query = 'chunked = true num_gpus'
+        assert preprocess_search_query(query) == (False, False, query)
+
+    def test_unparsable_query_warns(self, capsys):
+        """Passing it through changes what the search does -- the directives
+        stay in the query as if they were fields and nothing is expanded -- so
+        it cannot be silent."""
+        preprocess_search_query('chunked = true num_gpus')
+        assert 'Warning' in capsys.readouterr().err
+
+    def test_quoted_directive_is_recognised(self):
+        """A directive is compared unquoted, the same as a region code."""
+        _geo, chunked, q = preprocess_search_query('chunked="true" num_gpus=1')
+        assert chunked is True
+        assert 'chunked' not in q
+        assert 'num_gpus = 1' in q
+
+    def test_every_filter_reaches_the_parsed_query(self):
+        """End to end: preprocess -> parse_query. Before the fix this produced
+        an empty dict, so search_offers ran with no filters."""
+        _geo, _chunked, query_str = preprocess_search_query(
+            self.SKYPILOT_QUERY + ' duration>2.5')
+        query = parse_query(query_str, {}, offers_fields, offers_alias,
+                            offers_mult)
+        assert 'JP' in query['geolocation']['in']
+        assert query['disk_space'] == {'gte': '40'}
+        assert query['num_gpus'] == {'eq': '1'}
+        assert query['gpu_name'] == {'eq': 'L40S'}   # quotes stripped downstream
+        assert query['cpu_ram'] == {'gte': 64.0 * 1000}
+        assert query['duration'] == {'gt': 2.5 * 24 * 60 * 60}
 
 
 class TestFieldSets:

--- a/vastai/utils.py
+++ b/vastai/utils.py
@@ -306,25 +306,55 @@ def preprocess_search_query(query_str):
     Both ``georegion=true`` and ``chunked=true`` are stripped from the query
     before it reaches the API.
 
+    The query is rebuilt from the parse, so the grammar below has to accept
+    every value form :func:`vastai.api.query.parse_query` accepts -- otherwise a
+    term it cannot read is not an error, it is a filter that silently vanishes.
+    A query that cannot be parsed in full is warned about and returned
+    untouched, rather than rebuilt from a partial parse.
+
     Returns:
         A ``(georegion_active, chunked_active, processed_query_str)`` tuple.
     """
     if query_str is None:
         return False, False, query_str
 
-    from pyparsing import Word, alphas, alphanums, one_of, Group, ZeroOrMore
+    from pyparsing import (Word, alphas, alphanums, one_of, Group, ZeroOrMore,
+                           ParseException, QuotedString, Regex)
 
     key = Word(alphas + "_", alphanums + "_")
     operator = one_of("= in != > < >= <=")
-    value = Word(alphanums + "_")
+    # The three value forms parse_query's pattern allows, as four alternatives
+    # (a quoted string is spelt once per quote character):
+    # (\[[^\]]+\]|\"[^\"]+\"|[^ ]+). \S+ rather than [^ ]+, so a tab or newline
+    # cannot end up inside a token -- pyparsing already skips those between
+    # terms. Quotes and brackets stay in the token, so a term that is kept is
+    # re-emitted exactly as it arrived.
+    value = (QuotedString('"', unquote_results=False)
+             | QuotedString("'", unquote_results=False)
+             | Regex(r"\[[^\]]*\]")
+             | Regex(r"\S+"))
     expr = Group(key + operator + value)
     query = ZeroOrMore(expr)
-    parsed = query.parse_string(query_str)
+    try:
+        parsed = query.parse_string(query_str, parse_all=True)
+    except ParseException as exc:
+        # Silence here would be the original bug in a new shape: the caller
+        # would get a query that still carries the directives as if they were
+        # fields, with no expansion and no signal.
+        print(f"Warning: could not parse query, leaving it unchanged and not "
+              f"applying the georegion/chunked directives: {exc}",
+              file=sys.stderr)
+        return False, False, query_str
+
+    # Values keep their quotes so a term can be re-emitted verbatim, so every
+    # comparison against one has to see through them.
+    def unquoted(token):
+        return token.strip('"\'')
 
     directives = {'georegion', 'chunked'}
-    state = {}
-    for d in directives:
-        state[d] = any([d, '=', 'true'] == list(e) for e in parsed)
+    state = {d: any(e[0] == d and e[1] == '=' and unquoted(e[2]) == 'true'
+                    for e in parsed)
+             for d in directives}
 
     if not any(state.values()):
         return False, False, query_str
@@ -333,8 +363,9 @@ def preprocess_search_query(query_str):
     for e in parsed:
         if e[0] in directives:
             continue
-        elif e[0] == 'geolocation' and state['georegion'] and e[2] in _regions:
-            parts.append(f'geolocation in [{_regions[e[2]]}]')
+        region_code = unquoted(e[2])
+        if e[0] == 'geolocation' and state['georegion'] and region_code in _regions:
+            parts.append(f'geolocation in [{_regions[region_code]}]')
         else:
             parts.append(' '.join(e))
 


### PR DESCRIPTION
fix(sdk): preprocess_search_query silently drops most of the query

## Repro

No credentials and no SkyPilot needed — one function call on one string is the whole reproduction. Both blocks below are stock `vastai` 1.5.6 from PyPI.

    >>> from vastai.utils import preprocess_search_query
    >>> preprocess_search_query('chunked=true georegion=true geolocation="AS" '
    ...                         'disk_space>=40 num_gpus=1 gpu_name="L40S"')
    (True, True, '')

Every filter is gone. The search then runs unfiltered and returns whatever scores highest — wrong GPU, wrong region, wrong disk.

    >>> preprocess_search_query('chunked=true num_gpus=1 reliability>0.99')
    (False, True, 'num_gpus = 1 reliability > 0')

`reliability>0.99` becomes `reliability > 0`, which matches everything.

On this branch the first returns the full expanded query and the second keeps `> 0.99`.

## Cause

`preprocess_search_query` re-parses the query with its own grammar and rebuilds the query string from the result. The value token is `Word(alphanums + "_")`, which cannot match a
quote, a decimal point or a bracket, and `parse_string` is called without `parse_all=True`. `ZeroOrMore` stops at the first term it cannot read, the partial parse is accepted, and everything from that point on is dropped during the rebuild.

Neither failure is reported. A filter that cannot be parsed is not an error here — it is a filter that disappears.

`parse_query` accepts three value forms (`\[[^\]]+\]|\"[^\"]+\"|[^ ]+`), so any query valid there but invalid in this grammar is silently narrowed to a prefix.

## Fix

Two independent guards:

1. **The grammar accepts what `parse_query` accepts** — bracketed lists, quoted strings, and bare runs including decimals. Quotes and brackets stay in the token so a kept term is re-emitted exactly as it arrived.
2. **`parse_all=True`, and a query that cannot be parsed in full is returned untouched** with a warning on stderr, rather than rebuilt from a partial parse. Any future gap in the grammar now degrades to "leave the query alone" instead of "delete most of it".

The second guard is the one that matters long-term: it makes this class of bug impossible to reintroduce quietly.

Values now keep their quotes, so the two comparisons against a value — the region code and the `georegion`/`chunked` directives — go through a small `unquoted()` helper, and `chunked="true"` is recognised the same as `chunked=true`.

## Tests

`tests/api/test_query.py` — one case per value form that used to truncate (quoted, quoted-with-space, single-quoted, decimal, multi-dot version, bracketed list), plus the unparsable-query and warning paths, plus `test_every_filter_reaches_the_parsed_query`, which runs `preprocess_search_query` output through `parse_query` and asserts on the resulting filter dict. That last one fails on the user-visible consequence rather than on a string, and is what would have caught this originally.

Placed under `tests/api/` rather than beside the other `preprocess_search_query` tests in `tests/test_georegions.py`, because CI runs `pytest cli api sdk scripts` from `tests/` and never reaches the top-level test files — a regression test there would not run.

`tests/test_georegions.py` is unchanged and still passes. Full suite: 831 passed.

## Impact

SkyPilot's Vast provisioner builds exactly the query above (`sky/provision/vast/utils.py:launch`) — unchanged on master, on today's nightly `v1.0.0.dev20260828`, and in the current PyPI release `v0.13.0`. Against live offers, `L40S:1` in Asia returned 453 offers before the fix and 2 after; the 453 include RTX 5090s, other continents, other GPU counts, and hosts with 0.05 days of availability remaining. Downstream symptom: skypilot-org/skypilot#9733.