### PR TITLE
feat(cli): show instance backups and their download URLs

### DIFF
--- a/vastai/api/storage.py
+++ b/vastai/api/storage.py
@@ -221,6 +221,47 @@ def show_volumes(client, type="all"):
     return processed
 
 
+def show_instance_backups(client, contract_id=None):
+    """List the backups Vast has taken of the caller's instances and volumes.
+
+    GET /instance_backups/
+
+    Args:
+        client: VastClient instance.
+        contract_id (int): Restrict to one instance or volume contract id.
+
+    Returns:
+        list: Backup rows, newest first.
+    """
+    query_args = {}
+    if contract_id is not None:
+        query_args["contract_id"] = contract_id
+    r = client.get("/instance_backups/", query_args=query_args)
+    r.raise_for_status()
+    return r.json()["backups"]
+
+
+def instance_backup_files(client, contract_id):
+    """Objects stored for one backup, plus a short-lived token to fetch them.
+
+    GET /instance_backups/<contract_id>/download/
+
+    The returned URLs are not usable alone: each request must carry the
+    authorization_token. `truncated` is True when the backup holds more objects
+    than were listed.
+
+    Args:
+        client: VastClient instance.
+        contract_id (int): Instance or volume contract id.
+
+    Returns:
+        dict: authorization_token, expires_in_sec, truncated, files.
+    """
+    r = client.get(f"/instance_backups/{contract_id}/download/")
+    r.raise_for_status()
+    return r.json()
+
+
 def create_volume(client, id, size=15, name=None):
     """Create a new volume.
 

--- a/vastai/cli/commands/storage.py
+++ b/vastai/cli/commands/storage.py
@@ -9,6 +9,7 @@ from vastai.cli.parser import argument
 from vastai.cli.display import (
     display_table, vol_displayable_fields, nw_vol_displayable_fields,
     volume_fields, connection_fields, deindent,
+    instance_backup_fields, instance_backup_file_fields,
 )
 from vastai.cli.display import strip_strings
 from vastai.cli.util import (
@@ -649,6 +650,92 @@ def show__volumes(args):
         return processed
     else:
         display_table(processed, volume_fields, replace_spaces=False)
+
+
+# ---------------------------------------------------------------------------
+# show instance-backups / show instance-backup-files
+# ---------------------------------------------------------------------------
+
+@parser.command(
+    argument("--contract-id", help="only show backups of this instance or volume contract id", type=int),
+    usage="vastai show instance-backups [OPTIONS]",
+    help="Show backups Vast has taken of your instances.",
+    epilog=deindent("""
+        Lists the backups Vast has taken of your instances and volumes, newest first. These
+        are created by Vast (for example before a machine is decommissioned), not by you.
+
+        Status is pending while the copy runs, then success or error. A backup outlives the
+        instance it came from, so entries stay listed after the instance is gone.
+
+        Restore one into a running instance with `vastai copy`, naming vast.CONTRACT_ID as
+        the source. An instance's own filesystem sits under upper/:
+
+            vastai show instance-backups
+            vastai copy vast.12345678:/upper/workspace 99887766:/workspace
+
+        A backed-up volume has no upper/ -- its contents sit at the root of its own
+        contract id:
+
+            vastai copy vast.12345679:/ 99887766:/volumes/data
+
+        To pull the objects down directly instead of restoring into an instance, see
+        `vastai show instance-backup-files CONTRACT_ID`.
+
+        Example: vastai show instance-backups --contract-id 12345678
+    """),
+)
+def show__instance_backups(args):
+    """Show backups Vast has taken of your instances."""
+    client = get_client(args)
+    rows = storage_api.show_instance_backups(client, contract_id=args.contract_id)
+    if args.raw:
+        return rows
+    now = time.time()
+    for row in rows:
+        row["age_hours"] = (now - (row.get("created_at") or now)) / 3600.0
+        # A backup whose contract has been archived out of the live tables reports no type.
+        row["type"] = row.get("type") or "unknown"
+        row["info"] = strip_strings(row.get("info") or "")
+    display_table(rows, instance_backup_fields, replace_spaces=False)
+
+
+@parser.command(
+    argument("contract_id", help="instance or volume contract id whose backup to list", type=int),
+    usage="vastai show instance-backup-files CONTRACT_ID [OPTIONS]",
+    help="List the stored objects of one backup, with direct download URLs.",
+    epilog=deindent("""
+        Lists the objects stored for one backup and prints a short-lived token for fetching
+        them. The URLs do not work on their own -- every request must carry the token:
+
+            curl -H "Authorization: <token>" -o model.safetensors "<url>"
+
+        The token covers only this backup and expires (the lifetime is printed), so re-run
+        this command rather than saving it.
+
+        If the listing reports itself truncated, the backup holds more objects than are
+        shown; restore with `vastai copy vast.CONTRACT_ID:/ INSTANCE_ID:/path` instead of
+        fetching file by file.
+
+        Example: vastai show instance-backup-files 12345678
+    """),
+)
+def show__instance_backup_files(args):
+    """List the stored objects of one backup, with direct download URLs."""
+    client = get_client(args)
+    blob = storage_api.instance_backup_files(client, args.contract_id)
+    if args.raw:
+        return blob
+    files = blob.get("files") or []
+    for row in files:
+        row["size_mb"] = (row.get("size") or 0) / 1e6
+    print("authorization token: {}".format(blob.get("authorization_token")))
+    print("expires in: {} seconds".format(blob.get("expires_in_sec")))
+    if blob.get("truncated"):
+        print("WARNING: listing truncated -- this backup holds more objects than shown below.")
+    if not files:
+        print("No objects stored for this backup yet.")
+        return
+    display_table(files, instance_backup_file_fields, replace_spaces=False)
 
 
 # ---------------------------------------------------------------------------

--- a/vastai/cli/display.py
+++ b/vastai/cli/display.py
@@ -218,6 +218,22 @@ overlay_fields = (
     ("instance_count", "Instances", "{}", None, True),
     ("instances", "Instance IDs", "{}", None, True),
 )
+instance_backup_fields = (
+    ("id", "ID", "{}", None, True),
+    ("contract_id", "Contract", "{}", None, True),
+    ("type", "Type", "{}", None, True),
+    ("machine_id", "Machine", "{}", None, True),
+    ("status", "Status", "{}", None, True),
+    ("age_hours", "Age(hours)", "{:0.2f}", None, True),
+    ("info", "Info", "{}", None, True),
+)
+
+instance_backup_file_fields = (
+    ("name", "Name", "{}", None, True),
+    ("size_mb", "Size(MB)", "{:0.2f}", None, False),
+    ("url", "URL", "{}", None, True),
+)
+
 volume_fields = (
     ("id", "ID", "{}", None, True),
     ("cluster_id", "Cluster ID", "{}", None, True),

--- a/vastai/sdk.py
+++ b/vastai/sdk.py
@@ -834,6 +834,14 @@ class VastAI:
         """Show stats on owned volumes."""
         return storage.show_volumes(self.client, type=type)
 
+    def show_instance_backups(self, contract_id: Optional[int] = None) -> list[dict]:
+        """List the backups Vast has taken of your instances and volumes."""
+        return storage.show_instance_backups(self.client, contract_id=contract_id)
+
+    def instance_backup_files(self, contract_id: int) -> dict:
+        """Objects stored for one backup, plus a short-lived token to fetch them."""
+        return storage.instance_backup_files(self.client, contract_id)
+
     def create_volume(self, id: int, size: float = 15, name: Optional[str] = None) -> dict:
         """Create a new volume from an offer ID."""
         return storage.create_volume(self.client, id, size=size, name=name)


### PR DESCRIPTION
Vast takes backups of customer instances and volumes into a company-managed bucket (e.g. before a machine is decommissioned). Customers currently have no way to see those backups exist, let alone retrieve them. This adds the read side.

## Commands

```
vastai show instance-backups [--contract-id N]   # list, newest first
vastai show instance-backup-files CONTRACT_ID    # objects + short-lived download token
```

Backing API (already on the webserver): `GET /api/v0/instance_backups/` and `GET /api/v0/instance_backups/{contract_id}/download/`.

## Changes

| File | +lines |
|---|---|
| `vastai/api/storage.py` | 41 |
| `vastai/cli/commands/storage.py` | 87 |
| `vastai/cli/display.py` | 16 |
| `vastai/sdk.py` | 8 |

Additive only — 152 insertions, no deletions.

## Notes for review

- **`vastai/` only.** The deprecated `vast.py` is untouched, matching how recent features landed there (it gets sync'd for removals, not additions).
- The list epilog documents the restore path (`vastai copy vast.CONTRACT_ID:/path INSTANCE_ID:/path`) and the non-guessable asymmetry: an instance's filesystem lives under `upper/`, while a backed-up volume sits at the root of its own contract id.
- `instance-backup-files` prints the authorization token separately from the URLs, because the URLs 401 without it, and surfaces the server's `truncated` flag — a partial listing must not read as the whole backup when someone is verifying before wiping a machine.
- Backups outlive their instances, so entries stay listed after teardown; `type` reports `unknown` for a contract archived out of the live tables.

## Testing

Verified end-to-end against a local stack with a real Backblaze account:

- both commands register and render help
- the api layer builds exactly `/instance_backups/`, `/instance_backups/?contract_id=N`, `/instance_backups/N/download/`
- a real 10 GB backup listed correctly (251 objects), and a 537 MB object downloaded with the token — byte count matched the manifest, and the same URL 401s without it
- CLI suite at baseline: 12 failed / 1518 passed / 12 errors both with and without this change (pre-existing `test_tar_utils` failures plus two network-dependent suites)