### PR TITLE
fix(AUTO-1913): pin removed workergroup scaling params out of the sdk

### DIFF
--- a/tests/scripts/test_sdk_documented_params.py
+++ b/tests/scripts/test_sdk_documented_params.py
@@ -232,6 +232,27 @@ def test_cloud_copy_no_longer_publishes_scheduling(documented_methods):
     assert not published & {"schedule", "day", "hour", "start_date", "end_date"}
 
 
+@pytest.mark.parametrize("method_name", ["create_workergroup", "update_workergroup"])
+def test_workergroup_no_longer_publishes_endpoint_scaling(documented_methods, method_name):
+    """AUTO-1912 took these off the workergroup CLI; the generator scrapes the CLI.
+
+    A workergroup never reads them, so publishing them here is what sent people
+    to tune knobs with no effect.
+    """
+    method = next(m for m in documented_methods if m.name == method_name)
+    published = {p.name for p in method.params}
+    assert not published & {"min_load", "cold_workers", "test_workers",
+                            "target_util", "cold_mult"}
+
+
+@pytest.mark.parametrize("method_name", ["create_endpoint", "update_endpoint"])
+def test_endpoint_still_publishes_its_scaling(documented_methods, method_name):
+    """The same names are real on the endpoint group and must keep being documented."""
+    method = next(m for m in documented_methods if m.name == method_name)
+    published = {p.name for p in method.params}
+    assert {"min_load", "cold_workers", "target_util", "cold_mult"} <= published
+
+
 def test_converted_methods_are_not_open_signatures():
     """The docs verifier cannot judge extra params on a **kwargs method.
 

--- a/tests/sdk/test_backwards_compatibility.py
+++ b/tests/sdk/test_backwards_compatibility.py
@@ -13,6 +13,7 @@ import pytest
 
 from vastai.api import instances as instances_api
 from vastai.api import offers as offers_api
+from vastai.data.workergroup import WorkergroupConfig
 from vastai.sdk import VastAI
 
 
@@ -208,3 +209,65 @@ class TestSearchQueryStrings:
         payload = sent[-1]
         filters = payload.get("select_filters", payload)
         assert filters["disk_space"] == {"gte": 7}
+
+
+WORKERGROUP_DEAD_PARAMS = ("min_load", "cold_workers", "test_workers",
+                           "target_util", "cold_mult")
+
+
+class TestWorkergroupScalingParams:
+    """Deliberate removal, not an oversight.
+
+    AUTO-1912 took these off the workergroup CLI and out of WorkergroupConfig:
+    the autoscaler reads them from the endpoint group, and a workergroup never
+    reads them at all. The generated SDK reference is scraped from the CLI
+    flags, so leaving them anywhere here would put them back in the docs.
+    """
+
+    def test_config_no_longer_takes_them(self):
+        for name in WORKERGROUP_DEAD_PARAMS:
+            assert name not in WorkergroupConfig.__dataclass_fields__
+
+    def test_create_payload_omits_them(self, sdk, sent):
+        sdk.create_workergroup(template_hash="abc", endpoint_id=3)
+        for name in WORKERGROUP_DEAD_PARAMS:
+            assert name not in sent[-1]
+
+    def test_update_payload_omits_them(self, sdk, sent):
+        sdk.update_workergroup(42, gpu_ram=32.0)
+        for name in WORKERGROUP_DEAD_PARAMS:
+            assert name not in sent[-1]
+
+    def test_passing_them_is_tolerated_and_dropped(self, sdk, sent):
+        """Every **kwargs method on VastAI swallows unknown kwargs.
+
+        Raising for these five alone would break scripts that pass them today
+        without error, and gain nothing: the values never reached the wire.
+        """
+        sdk.create_workergroup(template_hash="abc", endpoint_id=3,
+                               **{name: 1 for name in WORKERGROUP_DEAD_PARAMS})
+        for name in WORKERGROUP_DEAD_PARAMS:
+            assert name not in sent[-1]
+
+    def test_show_workergroups_returns_what_the_api_sends(self, sdk, monkeypatch):
+        """The API still returns four of them; dropping the request fields must not hide that."""
+        api_row = {
+            "id": 4242, "min_load": 100.0, "target_util": 0.9, "cold_mult": 3.0,
+            "cold_workers": 5, "template_hash": "abc", "template_id": 7,
+            "search_query": {"gpu_ram": {"gte": 8}}, "launch_args": "--disk 64",
+            "gpu_ram": 32.0, "endpoint_name": "LLama", "endpoint_id": 2,
+            "api_key": "tok", "created_at": 1.0, "user_id": 9,
+        }
+
+        class Response:
+            status_code = 200
+
+            def json(self):
+                return {"success": True, "results": [api_row]}
+
+            def raise_for_status(self):
+                return None
+
+        monkeypatch.setattr("vastai.api.client.VastClient.get",
+                            lambda self, url, **kwargs: Response())
+        assert sdk.show_workergroups() == [api_row]

--- a/vastai/data/workergroup.py
+++ b/vastai/data/workergroup.py
@@ -7,6 +7,10 @@ from typing import Optional
 class WorkergroupConfig:
     """Configuration for creating a workergroup (autoscale job).
 
+    Request-only. Workergroup responses come back as raw dicts from
+    show_workergroups, so fields the API returns but does not accept as input
+    do not belong here.
+
     Either endpoint_id or endpoint_name is required (endpoint_id is set
     automatically when using ManagedEndpoint.add_workergroup()).
     Either template_hash or template_id is required (template resolves image, search_query, etc.).


### PR DESCRIPTION
## AUTO-1913: pin the removed workergroup scaling params out of the SDK surface

Follow-up to AUTO-1912 (#501), which removed `test_workers`, `cold_workers`, `min_load`, `target_util`, and `cold_mult` from the workergroup CLI and from `WorkergroupConfig`. This closes the two things that survived it on the SDK side.

**Additive only.** 88 insertions, zero deletions, no behavior change. Almost all of it is tests.

### Background: most of the SDK was already fixed

The SDK ships from this repo in the same `vastai` distribution as the CLI, so #501 carried most of the SDK surface with it:

- **Generated SDK reference pages.** `generate_cli_sdk_docs.py` fabricates the parameter table for `**kwargs` methods by scraping the matching CLI command's argparse flags, so dropping the flags dropped the params. `sdk/python/reference/create-workergroup.mdx` now publishes 8 params and none of the dead ones.
- **Async / managed SDK.** `WorkergroupConfig(min_load=...)` and `ManagedEndpoint.add_workergroup(min_load=...)` now raise `TypeError`.
- `EndpointConfig`, `DeploymentConfig`, the `Autoscaling` TypedDict behind `configure_autoscaling`, and `ENDPOINT_CONFIG` in `benchmarks.py` are genuinely endpoint-level and were correctly untouched.

### What this PR adds

**1. The sync SDK still swallows the params, and that's intentional.**

`VastAI.create_workergroup(**kwargs)` forwards into api functions that read with `kwargs.get(...)`, so passing any of the five produces no error and no payload key. So does a nonsense `bogus_param=1` — every `**kwargs` method on `VastAI` behaves this way. Raising for these five alone would be inconsistent with the rest of the SDK and would newly break scripts that pass them today without error, for no behavioral gain: the values never reached the wire, and the real migration is to `create_endpoint`.

So the passthrough stays and the removal gets pinned instead, recorded the way CLN-2792's `disable_bundling` removal was:

- `tests/sdk/test_backwards_compatibility.py` → `TestWorkergroupScalingParams`: the five names are absent from `WorkergroupConfig.__dataclass_fields__` and from both workergroup payloads, and passing them through `VastAI` is tolerated-and-dropped, with the docstring recording why we don't raise.
- `tests/scripts/test_sdk_documented_params.py`: the workergroup SDK pages publish none of the five, **and** the endpoint pages still publish theirs. The second guard catches an over-broad future edit to the generator, which is the failure mode that would otherwise be invisible.

**2. `WorkergroupConfig` read as a response model.**

Review feedback on #501 asked whether the fields had to stay because the API still returns them. They don't, but nothing in the class said so. `vastai/data/endpoint.py` carries both halves of the pattern (`EndpointConfig` for writes, `EndpointData.from_dict()` for reads); `workergroup.py` only ever had the write half.

- Three docstring lines stating the class is request-only and that responses come back as raw dicts.
- A read-path regression test: a `GET /autojobs/` response carrying `min_load` / `target_util` / `cold_mult` / `cold_workers`, in the exact shape `web/views/serverless.py:696-711` returns, round-trips through `show_workergroups` byte-identical.

That last test is the direct answer to the review question. For the record, `WorkergroupConfig(**api_response)` was *already* a `TypeError` before #501 — the response carries `id`, `api_key`, `created_at`, `user_id`, and `search_query` (vs the config's `search_params`), none of which the old class accepted either. It was never usable for parsing responses.

### Testing

- **Mutation-tested the pins rather than trusting them.** Re-added `min_load` to the dataclass, the CLI parser, and the api payload the way a careless PR would: 4 tests failed across all three surfaces. Restoring made them pass. They pin something real.
- Acceptance suite (`tests/sdk tests/api tests/cli tests/scripts tests/test_data_objects.py tests/test_legacy_vast.py`): **862 passed**.
- Wider run: 365 failed / 1186 passed / 12 errors, against a stashed baseline of 365 failed / 1177 passed / 12 errors. Zero new failures; the +9 is exactly the new tests. The 365 are pre-existing local env gaps (missing `pytest-asyncio`, `pyOpenSSL`), not regressions.

### Deliberately not here

- Raising `TypeError` or emitting a `DeprecationWarning` for the five names on the `VastAI` workergroup methods. Both are breaking changes to a published surface; worth doing on purpose in their own ticket, not smuggled into a test PR.
- SDK-wide unknown-kwarg validation.
- A `WorkergroupData.from_dict()` read model mirroring `EndpointData`. Reasonable future work; nothing needs it today.
- Regenerating the MDX in vast-ai/docs, which follows the release tag and is its own PR.
