### PR TITLE
Secure credential files in both CLI implementations

### DIFF
--- a/tests/cli/test_auth_commands.py
+++ b/tests/cli/test_auth_commands.py
@@ -1,6 +1,8 @@
 """Integration tests for auth CLI commands with mocked HTTP."""
 
 import argparse
+import os
+import stat
 from unittest.mock import patch
 
 import pytest
@@ -98,6 +100,24 @@ class TestSetApiKey:
         set__api_key(argparse.Namespace(new_api_key="test-key-abc-123"))
         assert key_file.read_bytes() == b"test-key-abc-123"
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX file mode test")
+    def test_replaces_api_key_with_owner_only_permissions(self, tmp_path, monkeypatch):
+        key_file = tmp_path / "vast_api_key"
+        key_file.write_text("old-key")
+        key_file.chmod(0o644)
+        monkeypatch.setattr("vastai.cli.util.APIKEY_FILE", str(key_file))
+        monkeypatch.setattr("vastai.cli.util.APIKEY_FILE_HOME", str(tmp_path / ".vast_api_key"))
+
+        old_umask = os.umask(0o022)
+        try:
+            from vastai.cli.commands.auth import set__api_key
+            set__api_key(argparse.Namespace(new_api_key="new-key"))
+        finally:
+            os.umask(old_umask)
+
+        assert key_file.read_bytes() == b"new-key"
+        assert stat.S_IMODE(key_file.stat().st_mode) == 0o600
+
     def test_sdk_reads_back_key_written_by_cli(self, tmp_path, monkeypatch):
         # End-to-end: `set api-key` writes the file; VastAI() picks it up.
         monkeypatch.setenv("HOME", str(tmp_path))
@@ -117,6 +137,95 @@ class TestSetApiKey:
         with patch("vastai.sdk.VastClient") as MockClient:
             VastAI()
             assert MockClient.call_args[0][0] == "round-trip-key"
+
+
+class TestBackupCodeFiles:
+    def test_saves_backup_codes(self, tmp_path):
+        from vastai.cli.commands.auth import _save_to_file
+
+        backup_file = tmp_path / "backups" / "codes.txt"
+
+        assert _save_to_file("backup-code", str(backup_file))
+        assert backup_file.read_text() == "backup-code"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX file mode test")
+    def test_atomically_replaces_with_owner_only_permissions(self, tmp_path):
+        from vastai.cli.commands.auth import _save_to_file
+
+        backup_file = tmp_path / "codes.txt"
+        backup_file.write_text("old-codes")
+        backup_file.chmod(0o644)
+        old_inode = backup_file.stat().st_ino
+
+        old_umask = os.umask(0o022)
+        try:
+            assert _save_to_file("new-codes", str(backup_file))
+        finally:
+            os.umask(old_umask)
+
+        assert backup_file.read_text() == "new-codes"
+        assert stat.S_IMODE(backup_file.stat().st_mode) == 0o600
+        assert backup_file.stat().st_ino != old_inode
+
+
+class TestTfaLogin:
+    def test_saves_session_key(self, tmp_path, monkeypatch):
+        from vastai.cli import util
+        from vastai.cli.commands import auth
+
+        session_file = tmp_path / "vast_tfa_key"
+        monkeypatch.setattr(util, "TFAKEY_FILE", str(session_file))
+        monkeypatch.setattr(auth, "get_client", lambda args: object())
+        monkeypatch.setattr(
+            auth.auth_api,
+            "tfa_login",
+            lambda client, **kwargs: {"session_key": "new-session"},
+        )
+        args = argparse.Namespace(
+            api_key="api-key",
+            backup_code=None,
+            code="123456",
+            method_id=None,
+            method_type="totp",
+            secret=None,
+        )
+
+        auth.tfa__login(args)
+
+        assert session_file.read_text() == "new-session"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX file mode test")
+    def test_replaces_session_key_with_owner_only_permissions(self, tmp_path, monkeypatch):
+        from vastai.cli import util
+        from vastai.cli.commands import auth
+
+        session_file = tmp_path / "vast_tfa_key"
+        session_file.write_text("old-session")
+        session_file.chmod(0o644)
+        monkeypatch.setattr(util, "TFAKEY_FILE", str(session_file))
+        monkeypatch.setattr(auth, "get_client", lambda args: object())
+        monkeypatch.setattr(
+            auth.auth_api,
+            "tfa_login",
+            lambda client, **kwargs: {"session_key": "new-session"},
+        )
+        args = argparse.Namespace(
+            api_key="api-key",
+            backup_code=None,
+            code="123456",
+            method_id=None,
+            method_type="totp",
+            secret=None,
+        )
+
+        old_umask = os.umask(0o022)
+        try:
+            auth.tfa__login(args)
+        finally:
+            os.umask(old_umask)
+
+        assert session_file.read_text() == "new-session"
+        assert stat.S_IMODE(session_file.stat().st_mode) == 0o600
 
 
 class TestTfaStatus:

--- a/tests/cli/test_util.py
+++ b/tests/cli/test_util.py
@@ -1,9 +1,170 @@
 """Tests for vastai/cli/util.py — parse_env, parse_vast_url, validate_seconds, etc."""
 
 import argparse
+import errno
+import os
+import stat
+
 import pytest
 from datetime import datetime, timedelta
 from unittest.mock import Mock
+
+
+class TestWriteSecretFile:
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX file mode test")
+    def test_atomically_replaces_file_with_owner_only_permissions(self, tmp_path):
+        from vastai.cli.util import write_secret_file
+
+        secret_file = tmp_path / "secret"
+        secret_file.write_bytes(b"old-secret")
+        secret_file.chmod(0o644)
+        old_inode = secret_file.stat().st_ino
+
+        old_umask = os.umask(0o022)
+        try:
+            write_secret_file(secret_file, "new-secret")
+        finally:
+            os.umask(old_umask)
+
+        assert secret_file.read_bytes() == b"new-secret"
+        assert stat.S_IMODE(secret_file.stat().st_mode) == 0o600
+        assert secret_file.stat().st_ino != old_inode
+
+    def test_no_clobber_publish_preserves_existing_file(self, tmp_path):
+        from vastai.cli.util import write_secret_file
+
+        secret_file = tmp_path / "secret"
+        secret_file.write_bytes(b"existing-secret")
+
+        with pytest.raises(FileExistsError):
+            write_secret_file(secret_file, b"new-secret", overwrite=False)
+
+        assert secret_file.read_bytes() == b"existing-secret"
+        assert list(tmp_path.iterdir()) == [secret_file]
+
+    def test_no_clobber_falls_back_when_hard_links_are_unsupported(
+        self, tmp_path, monkeypatch
+    ):
+        from vastai.cli import util
+
+        secret_file = tmp_path / "secret"
+        monkeypatch.setattr(
+            util.os,
+            "link",
+            Mock(side_effect=OSError(errno.EPERM, "hard links unsupported")),
+        )
+
+        util.write_secret_file(secret_file, b"secret", overwrite=False)
+
+        assert secret_file.read_bytes() == b"secret"
+        assert list(tmp_path.iterdir()) == [secret_file]
+
+    def test_removes_temporary_file_after_replace_failure(self, tmp_path, monkeypatch):
+        from vastai.cli import util
+
+        secret_file = tmp_path / "secret"
+        monkeypatch.setattr(util.os, "replace", Mock(side_effect=OSError("replace failed")))
+
+        with pytest.raises(OSError, match="replace failed"):
+            util.write_secret_file(secret_file, "secret")
+
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestLegacyApiKeyMigration:
+    def test_migrates_and_removes_legacy_file(self, tmp_path, monkeypatch):
+        from vastai.cli import util
+
+        legacy_file = tmp_path / ".vast_api_key"
+        key_file = tmp_path / "vast_api_key"
+        legacy_file.write_bytes(b"legacy-key")
+        monkeypatch.setattr(util, "APIKEY_FILE_HOME", str(legacy_file))
+        monkeypatch.setattr(util, "APIKEY_FILE", str(key_file))
+
+        util._migrate_legacy_api_key()
+
+        assert key_file.read_bytes() == b"legacy-key"
+        assert not legacy_file.exists()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX file mode test")
+    def test_migrates_with_owner_only_permissions(self, tmp_path, monkeypatch):
+        from vastai.cli import util
+
+        legacy_file = tmp_path / ".vast_api_key"
+        key_file = tmp_path / "vast_api_key"
+        legacy_file.write_bytes(b"legacy-key")
+        legacy_file.chmod(0o644)
+        monkeypatch.setattr(util, "APIKEY_FILE_HOME", str(legacy_file))
+        monkeypatch.setattr(util, "APIKEY_FILE", str(key_file))
+
+        old_umask = os.umask(0o022)
+        try:
+            util._migrate_legacy_api_key()
+        finally:
+            os.umask(old_umask)
+
+        assert stat.S_IMODE(key_file.stat().st_mode) == 0o600
+
+    def test_race_does_not_overwrite_new_api_key(self, tmp_path, monkeypatch):
+        from vastai.cli import util
+
+        legacy_file = tmp_path / ".vast_api_key"
+        key_file = tmp_path / "vast_api_key"
+        legacy_file.write_bytes(b"legacy-key")
+        monkeypatch.setattr(util, "APIKEY_FILE_HOME", str(legacy_file))
+        monkeypatch.setattr(util, "APIKEY_FILE", str(key_file))
+        original_write_secret_file = util.write_secret_file
+
+        def create_new_key_before_publish(path, secret, *, overwrite=True):
+            key_file.write_bytes(b"new-key")
+            return original_write_secret_file(path, secret, overwrite=overwrite)
+
+        monkeypatch.setattr(util, "write_secret_file", create_new_key_before_publish)
+
+        util._migrate_legacy_api_key()
+
+        assert key_file.read_bytes() == b"new-key"
+        assert legacy_file.read_bytes() == b"legacy-key"
+
+
+class TestExistingCredentialPermissions:
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX file mode test")
+    def test_secures_current_and_legacy_credentials(self, tmp_path, monkeypatch):
+        from vastai.cli import util
+
+        credential_files = [
+            tmp_path / "vast_api_key",
+            tmp_path / "vast_tfa_key",
+            tmp_path / ".vast_api_key",
+        ]
+        for credential_file in credential_files:
+            credential_file.write_bytes(b"secret")
+            credential_file.chmod(0o644)
+
+        monkeypatch.setattr(util, "APIKEY_FILE", str(credential_files[0]))
+        monkeypatch.setattr(util, "TFAKEY_FILE", str(credential_files[1]))
+        monkeypatch.setattr(util, "APIKEY_FILE_HOME", str(credential_files[2]))
+
+        util._secure_existing_credentials()
+
+        assert all(
+            stat.S_IMODE(credential_file.stat().st_mode) == 0o600
+            for credential_file in credential_files
+        )
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX file mode test")
+    def test_does_not_follow_symlinks(self, tmp_path):
+        from vastai.cli.util import secure_existing_secret_file
+
+        target = tmp_path / "target"
+        link = tmp_path / "secret"
+        target.write_bytes(b"not-a-credential")
+        target.chmod(0o644)
+        link.symlink_to(target)
+
+        secure_existing_secret_file(link)
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o644
 
 
 class TestParseEnv:

--- a/tests/test_legacy_vast.py
+++ b/tests/test_legacy_vast.py
@@ -3,9 +3,10 @@
 import importlib.util
 import json
 import os
+import stat
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -88,3 +89,94 @@ def test_http_request_preserves_explicit_headers(legacy_vast):
 
     prepared_request = send.call_args.args[0]
     assert prepared_request.headers["Authorization"] == "Bearer override"
+
+
+def _assert_owner_only(path):
+    if os.name != "nt":
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_migrates_legacy_api_key_securely(legacy_vast, tmp_path, monkeypatch):
+    legacy_file = tmp_path / ".vast_api_key"
+    key_file = tmp_path / "vast_api_key"
+    legacy_file.write_bytes(b"legacy-key")
+    legacy_file.chmod(0o644)
+    monkeypatch.setattr(legacy_vast, "APIKEY_FILE_HOME", str(legacy_file))
+    monkeypatch.setattr(legacy_vast, "APIKEY_FILE", str(key_file))
+
+    legacy_vast._migrate_legacy_api_key()
+
+    assert key_file.read_bytes() == b"legacy-key"
+    assert not legacy_file.exists()
+    _assert_owner_only(key_file)
+
+
+def test_set_api_key_replaces_file_securely(legacy_vast, tmp_path, monkeypatch):
+    key_file = tmp_path / "vast_api_key"
+    key_file.write_bytes(b"old-key")
+    key_file.chmod(0o644)
+    monkeypatch.setattr(legacy_vast, "APIKEY_FILE", str(key_file))
+    monkeypatch.setattr(legacy_vast, "APIKEY_FILE_HOME", str(tmp_path / ".vast_api_key"))
+
+    legacy_vast.set__api_key(SimpleNamespace(new_api_key="new-key"))
+
+    assert key_file.read_bytes() == b"new-key"
+    _assert_owner_only(key_file)
+
+
+def test_saves_backup_codes_securely(legacy_vast, tmp_path):
+    backup_file = tmp_path / "codes.txt"
+    backup_file.write_bytes(b"old-codes")
+    backup_file.chmod(0o644)
+
+    assert legacy_vast.save_to_file("new-codes", str(backup_file))
+
+    assert backup_file.read_bytes() == b"new-codes"
+    _assert_owner_only(backup_file)
+
+
+def test_tfa_login_saves_session_key_securely(legacy_vast, tmp_path, monkeypatch):
+    session_file = tmp_path / "vast_tfa_key"
+    session_file.write_bytes(b"old-session")
+    session_file.chmod(0o644)
+    monkeypatch.setattr(legacy_vast, "TFAKEY_FILE", str(session_file))
+    response = Mock()
+    response.json.return_value = {"session_key": "new-session"}
+    args = SimpleNamespace(
+        api_key="api-key",
+        backup_code=None,
+        code="123456",
+        method_id=None,
+        method_type="totp",
+        secret=None,
+    )
+
+    with (
+        patch.object(legacy_vast, "apiurl", return_value="https://example.test/tfa"),
+        patch.object(legacy_vast, "apiheaders", return_value={}),
+        patch.object(legacy_vast, "http_post", return_value=response),
+    ):
+        legacy_vast.tfa__login(args)
+
+    assert session_file.read_bytes() == b"new-session"
+    _assert_owner_only(session_file)
+
+
+def test_repairs_existing_credential_permissions(legacy_vast, tmp_path, monkeypatch):
+    credential_files = [
+        tmp_path / "vast_api_key",
+        tmp_path / "vast_tfa_key",
+        tmp_path / ".vast_api_key",
+    ]
+    for credential_file in credential_files:
+        credential_file.write_bytes(b"secret")
+        credential_file.chmod(0o644)
+
+    monkeypatch.setattr(legacy_vast, "APIKEY_FILE", str(credential_files[0]))
+    monkeypatch.setattr(legacy_vast, "TFAKEY_FILE", str(credential_files[1]))
+    monkeypatch.setattr(legacy_vast, "APIKEY_FILE_HOME", str(credential_files[2]))
+
+    legacy_vast._secure_existing_credentials()
+
+    for credential_file in credential_files:
+        _assert_owner_only(credential_file)

--- a/vast.py
+++ b/vast.py
@@ -10,7 +10,10 @@ import re
 import json
 import sys
 import argparse
+import errno
 import os
+import stat
+import tempfile
 import time
 from typing import Dict, List, Tuple, Optional
 from datetime import date, datetime, timedelta, timezone
@@ -242,9 +245,104 @@ APIKEY_FILE = os.path.join(DIRS['config'], "vast_api_key")
 APIKEY_FILE_HOME = os.path.expanduser("~/.vast_api_key") # Legacy
 TFAKEY_FILE = os.path.join(DIRS['config'], "vast_tfa_key")
 
-if not os.path.exists(APIKEY_FILE) and os.path.exists(APIKEY_FILE_HOME):
-  #print(f'copying key from {APIKEY_FILE_HOME} -> {APIKEY_FILE}')
-  shutil.copyfile(APIKEY_FILE_HOME, APIKEY_FILE)
+
+def _publish_without_overwrite(temporary_path, path):
+    """Publish a complete file without replacing an existing destination."""
+    try:
+        os.link(temporary_path, path)
+    except OSError as error:
+        unsupported_link_errors = {
+            errno.EPERM,
+            getattr(errno, "ENOTSUP", errno.EPERM),
+            getattr(errno, "EOPNOTSUPP", errno.EPERM),
+            getattr(errno, "ENOSYS", errno.EPERM),
+        }
+        if error.errno not in unsupported_link_errors:
+            raise
+
+        placeholder_fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        os.close(placeholder_fd)
+        try:
+            os.replace(temporary_path, path)
+        except Exception:
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+            raise
+    else:
+        os.unlink(temporary_path)
+
+
+def write_secret_file(path, secret, *, overwrite=True):
+    """Atomically publish a secret file with owner-only permissions."""
+    path = os.fspath(path)
+    fd, temporary_path = tempfile.mkstemp(dir=os.path.dirname(os.path.abspath(path)))
+    try:
+        with os.fdopen(fd, "wb") as writer:
+            writer.write(secret.encode("utf-8") if isinstance(secret, str) else secret)
+
+        if overwrite:
+            os.replace(temporary_path, path)
+        else:
+            _publish_without_overwrite(temporary_path, path)
+    except Exception:
+        try:
+            os.unlink(temporary_path)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def secure_existing_secret_file(path):
+    """Restrict an existing regular secret file without following symlinks."""
+    if os.name == "nt" or not hasattr(os, "fchmod"):
+        return
+
+    descriptor = None
+    try:
+        initial_stat = os.stat(path, follow_symlinks=False)
+        if not stat.S_ISREG(initial_stat.st_mode):
+            return
+
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+        opened_stat = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened_stat.st_mode)
+            or opened_stat.st_dev != initial_stat.st_dev
+            or opened_stat.st_ino != initial_stat.st_ino
+        ):
+            return
+        os.fchmod(descriptor, 0o600)
+    except OSError:
+        return
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _migrate_legacy_api_key():
+    if not os.path.exists(APIKEY_FILE) and os.path.exists(APIKEY_FILE_HOME):
+        with open(APIKEY_FILE_HOME, "rb") as reader:
+            try:
+                write_secret_file(APIKEY_FILE, reader.read(), overwrite=False)
+            except FileExistsError:
+                return
+
+        try:
+            os.remove(APIKEY_FILE_HOME)
+        except OSError:
+            secure_existing_secret_file(APIKEY_FILE_HOME)
+
+
+def _secure_existing_credentials():
+    for credential_file in (APIKEY_FILE, TFAKEY_FILE, APIKEY_FILE_HOME):
+        secure_existing_secret_file(credential_file)
+
+
+_migrate_legacy_api_key()
+_secure_existing_credentials()
 
 
 api_key_guard = object()
@@ -4751,8 +4849,7 @@ def set__api_key(args):
     """Caution: a bad API key will make it impossible to connect to the servers.
     :param argparse.Namespace args: should supply all the command-line options
     """
-    with open(APIKEY_FILE, "w") as writer:
-        writer.write(args.new_api_key)
+    write_secret_file(APIKEY_FILE, args.new_api_key)
     print("Your api key has been saved in {}".format(APIKEY_FILE))
     
     APIKEY_FILE_HOME = os.path.expanduser("~/.vast_api_key") # Legacy
@@ -6646,8 +6743,7 @@ def save_to_file(content, filepath):
         if parent_dir:
             os.makedirs(parent_dir, exist_ok=True)
         
-        with open(filepath, "w") as f:
-            f.write(content)
+        write_secret_file(filepath, content)
         return True
     except (IOError, OSError) as e:
         print(f"\n{FAIL} Error saving file: {e}")
@@ -7021,8 +7117,7 @@ def tfa__login(args):
             session_key = response_data["session_key"]
             if session_key != args.api_key:
                 # Write the session key to the TFA key file
-                with open(TFAKEY_FILE, "w") as f:
-                    f.write(session_key)
+                write_secret_file(TFAKEY_FILE, session_key)
                 print(f"{SUCCESS} 2FA login successful! Session key saved to {TFAKEY_FILE}")
             else:
                 print(f"{SUCCESS} 2FA login successful! Your session key has been refreshed.")

--- a/vastai/cli/commands/auth.py
+++ b/vastai/cli/commands/auth.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from vastai.cli.parser import argument
 from vastai.cli.display import deindent, display_table
 from vastai.api import auth as auth_api
-from vastai.cli.util import SUCCESS, WARN, FAIL, format_key_suffix
+from vastai.cli.util import SUCCESS, WARN, FAIL, format_key_suffix, write_secret_file
 
 
 # ---------------------------------------------------------------------------
@@ -111,8 +111,7 @@ def _save_to_file(content, filepath):
         parent_dir = os.path.dirname(filepath)
         if parent_dir:
             os.makedirs(parent_dir, exist_ok=True)
-        with open(filepath, "w") as f:
-            f.write(content)
+        write_secret_file(filepath, content)
         return True
     except (IOError, OSError) as e:
         print(f"\n{FAIL} Error saving file: {e}")
@@ -205,8 +204,7 @@ def set__api_key(args):
     """Set the api-key."""
     from vastai.cli.util import APIKEY_FILE, APIKEY_FILE_HOME
 
-    with open(APIKEY_FILE, "w") as writer:
-        writer.write(args.new_api_key)
+    write_secret_file(APIKEY_FILE, args.new_api_key)
     print("Your api key has been saved in {}".format(APIKEY_FILE))
 
     if os.path.exists(APIKEY_FILE_HOME):
@@ -503,8 +501,7 @@ def tfa__login(args):
         if "session_key" in response_data:
             session_key = response_data["session_key"]
             if session_key != args.api_key:
-                with open(TFAKEY_FILE, "w") as f:
-                    f.write(session_key)
+                write_secret_file(TFAKEY_FILE, session_key)
                 print(f"{SUCCESS} 2FA login successful! Session key saved to {TFAKEY_FILE}")
             else:
                 print(f"{SUCCESS} 2FA login successful! Your session key has been refreshed.")

--- a/vastai/cli/util.py
+++ b/vastai/cli/util.py
@@ -11,11 +11,13 @@ import re
 import json
 import sys
 import argparse
+import errno
 import os
+import stat
 import time
 import math
 import subprocess
-import shutil
+import tempfile
 import requests
 import getpass
 from pathlib import Path
@@ -178,9 +180,109 @@ APIKEY_FILE = os.path.join(DIRS['config'], "vast_api_key")
 APIKEY_FILE_HOME = os.path.expanduser("~/.vast_api_key")  # Legacy
 TFAKEY_FILE = os.path.join(DIRS['config'], "vast_tfa_key")
 
-if not os.path.exists(APIKEY_FILE) and os.path.exists(APIKEY_FILE_HOME):
-    #print(f'copying key from {APIKEY_FILE_HOME} -> {APIKEY_FILE}')
-    shutil.copyfile(APIKEY_FILE_HOME, APIKEY_FILE)
+
+def _publish_without_overwrite(temporary_path, path):
+    """Publish a complete file without replacing an existing destination."""
+    try:
+        os.link(temporary_path, path)
+    except OSError as error:
+        unsupported_link_errors = {
+            errno.EPERM,
+            getattr(errno, "ENOTSUP", errno.EPERM),
+            getattr(errno, "EOPNOTSUPP", errno.EPERM),
+            getattr(errno, "ENOSYS", errno.EPERM),
+        }
+        if error.errno not in unsupported_link_errors:
+            raise
+
+        # Reserve the name without a check-then-create race, then atomically
+        # replace the empty owner-only placeholder with the completed file.
+        placeholder_fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        os.close(placeholder_fd)
+        try:
+            os.replace(temporary_path, path)
+        except Exception:
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+            raise
+    else:
+        os.unlink(temporary_path)
+
+
+def write_secret_file(path, secret, *, overwrite=True):
+    """Atomically publish a secret file with owner-only permissions."""
+    path = os.fspath(path)
+    fd, temporary_path = tempfile.mkstemp(dir=os.path.dirname(os.path.abspath(path)))
+    try:
+        with os.fdopen(fd, "wb") as writer:
+            writer.write(secret.encode("utf-8") if isinstance(secret, str) else secret)
+
+        if overwrite:
+            os.replace(temporary_path, path)
+        else:
+            _publish_without_overwrite(temporary_path, path)
+    except Exception:
+        try:
+            os.unlink(temporary_path)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def secure_existing_secret_file(path):
+    """Restrict an existing regular secret file without following symlinks."""
+    if os.name == "nt" or not hasattr(os, "fchmod"):
+        return
+
+    descriptor = None
+    try:
+        initial_stat = os.stat(path, follow_symlinks=False)
+        if not stat.S_ISREG(initial_stat.st_mode):
+            return
+
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+        opened_stat = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened_stat.st_mode)
+            or opened_stat.st_dev != initial_stat.st_dev
+            or opened_stat.st_ino != initial_stat.st_ino
+        ):
+            return
+        os.fchmod(descriptor, 0o600)
+    except OSError:
+        # Credential reads retain their existing error handling when a
+        # filesystem does not permit mode repair.
+        return
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _migrate_legacy_api_key():
+    if not os.path.exists(APIKEY_FILE) and os.path.exists(APIKEY_FILE_HOME):
+        # Do not overwrite an API key created after the existence check.
+        with open(APIKEY_FILE_HOME, "rb") as reader:
+            try:
+                write_secret_file(APIKEY_FILE, reader.read(), overwrite=False)
+            except FileExistsError:
+                return
+
+        try:
+            os.remove(APIKEY_FILE_HOME)
+        except OSError:
+            secure_existing_secret_file(APIKEY_FILE_HOME)
+
+
+def _secure_existing_credentials():
+    for credential_file in (APIKEY_FILE, TFAKEY_FILE, APIKEY_FILE_HOME):
+        secure_existing_secret_file(credential_file)
+
+
+_migrate_legacy_api_key()
+_secure_existing_credentials()
 
 
 def format_key_suffix(k):


### PR DESCRIPTION
## Summary

- write API keys, 2FA session keys, and saved backup codes through owner-only same-directory temporary files in both the package CLI and backwards-compatible standalone client
- atomically replace explicit API/session/backup outputs while preserving their existing overwrite behavior
- migrate legacy API keys without clobbering a concurrently created current key, including on filesystems without hard-link support
- repair existing regular credential files on startup without following symlinks, and remove the old legacy file after successful migration
- clean up temporary files after publication failures

The previous direct `open(..., "w")` and `shutil.copyfile(...)` paths followed the process umask for new files and preserved permissive modes when truncating existing files. Under a common umask of 0022, credentials and backup codes could therefore remain readable by other local users. Existing affected files also stayed permissive indefinitely unless rewritten.

Completed same-directory files are now atomically published at owner-only permissions. Legacy migration uses race-free no-clobber publication: it prefers a hard link and falls back to reserving the destination with `O_CREAT|O_EXCL` before atomic replacement when hard links are unsupported. Existing files are tightened through verified regular-file descriptors so symlinks are not followed.

## Tests

- atomic 0600 creation/replacement and byte-exact writes
- cleanup after failed replacement
- portable no-clobber fallback and migration race behavior
- startup repair for current API, TFA, and legacy keys
- successful migration removes the legacy source
- API/session/backup/migration coverage for the deprecated standalone client
- focused security suite: 86 passed
- broader offline API/CLI/SDK/script/standalone suite: 850 passed

This adapts the downstream fix from https://github.com/NixOS/nixpkgs/pull/559251 and extends it to current upstream backup-code, upgrade-remediation, portability, and standalone-client paths.

## AI disclosure

Pi coding agent using OpenAI `gpt-5.6-sol` assisted with inspecting the current source, adapting the patch, addressing review findings, adding tests, and running offline validation. The resulting diff and validation evidence were reviewed before submission.
