### PR TITLE
feat(cli): make backup download URLs work on their own

### DIFF
--- a/tests/cli/test_storage_commands.py
+++ b/tests/cli/test_storage_commands.py
@@ -82,3 +82,67 @@ class TestCopy:
         call_args = patch_get_client.put.call_args
         assert "/commands/copy_direct/" in call_args[0][0]
         assert call_args[1]["json_data"]["src_id"] == "hf.101"
+
+
+class TestShowInstanceBackupFiles:
+    """The table's URLs must be fetchable on their own; --raw must stay a passthrough."""
+
+    PAYLOAD = {
+        "success": True,
+        "authorization_token": "4_002+abc/def=",
+        "expires_in_sec": 3600,
+        "truncated": False,
+        "files": [
+            {"name": "instance_backups/7/42/upper/model.safetensors",
+             "size": 2500000,
+             "url": "https://f002.backblazeb2.com/file/vast-instance-backups/"
+                    "instance_backups/7/42/upper/model.safetensors"},
+        ],
+    }
+
+    def _rows(self, capsys):
+        """The URL column of the printed table, minus row labels and color codes."""
+        import re
+        out = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().out)
+        return re.findall(r"https://\S+", out)
+
+    def test_url_carries_token(self, parse_argv, patch_get_client, mock_response, capsys):
+        import copy
+        patch_get_client.get.return_value = mock_response(200, copy.deepcopy(self.PAYLOAD))
+        args = parse_argv(["show", "instance-backup-files", "42"])
+        args.func(args)
+        assert "/instance_backups/42/download/" in patch_get_client.get.call_args[0][0]
+        # Token is percent-encoded: a raw '+' would decode to a space, and '/' and '='
+        # would end up as path/query syntax rather than token bytes.
+        assert self._rows(capsys) == [
+            "https://f002.backblazeb2.com/file/vast-instance-backups/"
+            "instance_backups/7/42/upper/model.safetensors"
+            "?Authorization=4_002%2Babc%2Fdef%3D"
+        ]
+
+    def test_raw_is_unmodified_passthrough(self, parse_argv, patch_get_client, mock_response):
+        import copy
+        patch_get_client.get.return_value = mock_response(200, copy.deepcopy(self.PAYLOAD))
+        args = parse_argv(["show", "instance-backup-files", "42", "--raw"])
+        assert args.func(args) == self.PAYLOAD
+
+    def test_existing_query_string_is_appended_to(self, parse_argv, patch_get_client,
+                                                  mock_response, capsys):
+        import copy
+        payload = copy.deepcopy(self.PAYLOAD)
+        payload["files"][0]["url"] += "?b2ContentDisposition=attachment"
+        patch_get_client.get.return_value = mock_response(200, payload)
+        args = parse_argv(["show", "instance-backup-files", "42"])
+        args.func(args)
+        assert self._rows(capsys)[0].endswith(
+            "?b2ContentDisposition=attachment&Authorization=4_002%2Babc%2Fdef%3D")
+
+    def test_missing_token_leaves_url_alone(self, parse_argv, patch_get_client,
+                                            mock_response, capsys):
+        import copy
+        payload = copy.deepcopy(self.PAYLOAD)
+        payload["authorization_token"] = None
+        patch_get_client.get.return_value = mock_response(200, payload)
+        args = parse_argv(["show", "instance-backup-files", "42"])
+        args.func(args)
+        assert self._rows(capsys)[0] == payload["files"][0]["url"]

--- a/vastai/api/storage.py
+++ b/vastai/api/storage.py
@@ -247,7 +247,9 @@ def instance_backup_files(client, contract_id):
     GET /instance_backups/<contract_id>/download/
 
     The returned URLs are not usable alone: each request must carry the
-    authorization_token. `truncated` is True when the backup holds more objects
+    authorization_token, either as an `Authorization` header or appended as an
+    `?Authorization=<token>` query parameter (what the CLI does, so the printed
+    URLs are clickable). `truncated` is True when the backup holds more objects
     than were listed.
 
     Args:

--- a/vastai/cli/commands/storage.py
+++ b/vastai/cli/commands/storage.py
@@ -4,6 +4,7 @@ import json
 import os
 import time
 import subprocess
+from urllib.parse import quote, urlparse
 
 from vastai.cli.parser import argument
 from vastai.cli.display import (
@@ -656,6 +657,20 @@ def show__volumes(args):
 # show instance-backups / show instance-backup-files
 # ---------------------------------------------------------------------------
 
+def _authorized_url(url, token):
+    """Fold the download token into `url` as a query parameter.
+
+    B2 takes the token either in the Authorization header or as an `Authorization`
+    query parameter, and the second form is what makes a URL usable on its own -- paste
+    it into a browser, or curl it without -H. Returns the url untouched when either
+    piece is missing, so a malformed payload still lists its files.
+    """
+    if not url or not token:
+        return url
+    sep = "&" if urlparse(url).query else "?"
+    return "{}{}Authorization={}".format(url, sep, quote(token, safe=""))
+
+
 @parser.command(
     argument("--contract-id", help="only show backups of this instance or volume contract id", type=int),
     usage="vastai show instance-backups [OPTIONS]",
@@ -704,13 +719,14 @@ def show__instance_backups(args):
     usage="vastai show instance-backup-files CONTRACT_ID [OPTIONS]",
     help="List the stored objects of one backup, with direct download URLs.",
     epilog=deindent("""
-        Lists the objects stored for one backup and prints a short-lived token for fetching
-        them. The URLs do not work on their own -- every request must carry the token:
+        Lists the objects stored for one backup. Each URL already carries a download token
+        scoped to this backup, so it works on its own -- open it in a browser, or:
 
-            curl -H "Authorization: <token>" -o model.safetensors "<url>"
+            curl -o model.safetensors "<url>"
 
-        The token covers only this backup and expires (the lifetime is printed), so re-run
-        this command rather than saving it.
+        The token is also printed on its own for the header form, `curl -H "Authorization:
+        <token>"`, which keeps it out of shell history and proxy logs. Either way it expires
+        (the lifetime is printed), so re-run this command rather than saving the URLs.
 
         If the listing reports itself truncated, the backup holds more objects than are
         shown; restore with `vastai copy vast.CONTRACT_ID:/ INSTANCE_ID:/path` instead of
@@ -726,9 +742,12 @@ def show__instance_backup_files(args):
     if args.raw:
         return blob
     files = blob.get("files") or []
+    # --raw stays a passthrough of the API payload; only the table gets ready-to-click URLs.
+    token = blob.get("authorization_token")
     for row in files:
         row["size_mb"] = (row.get("size") or 0) / 1e6
-    print("authorization token: {}".format(blob.get("authorization_token")))
+        row["url"] = _authorized_url(row.get("url"), token)
+    print("authorization token: {} (already embedded in the URLs below)".format(token))
     print("expires in: {} seconds".format(blob.get("expires_in_sec")))
     if blob.get("truncated"):
         print("WARNING: listing truncated -- this backup holds more objects than shown below.")


### PR DESCRIPTION
show instance-backup-files printed a token and a set of URLs that 404 without it, so every download meant hand-assembling a curl -H. B2 accepts the download token as an ?Authorization= query parameter as well as a header, so fold it in and the URLs become clickable as printed.

The token is percent-encoded -- B2 tokens contain +, / and =, and a raw + in a query string decodes to a space. It is still printed on its own for the header form, which keeps it out of shell history and proxy logs.

--raw stays a verbatim passthrough of the API payload.