### PR TITLE
fix: parse date strings before arithmetic in show invoices-v1

### DIFF
--- a/vast.py
+++ b/vast.py
@@ -5439,9 +5439,9 @@ def show__invoices_v1(args):
     if not args.start_date and not args.end_date:
         args.end_date = int(time.time())  # Set end date to current time if both are missing
     if not args.start_date:
-        args.start_date = args.end_date - 7 * 24*60*60  # Default to 7 days before given end date
+        args.start_date = to_timestamp_(args.end_date) - 7 * 24*60*60  # Default to 7 days before given end date
     elif not args.end_date:
-        args.end_date = args.start_date + 7 * 24*60*60  # Default to 7 days after given start date
+        args.end_date = to_timestamp_(args.start_date) + 7 * 24*60*60  # Default to 7 days after given start date
     
     try:
         # Parse dates - handle both YYYY-MM-DD format and timestamps

--- a/vastai/cli/commands/billing.py
+++ b/vastai/cli/commands/billing.py
@@ -397,9 +397,9 @@ def show__invoices_v1(args):
     if not args.start_date and not args.end_date:
         args.end_date = int(time.time())
     if not args.start_date:
-        args.start_date = args.end_date - 7 * 24 * 60 * 60
+        args.start_date = to_timestamp_(args.end_date) - 7 * 24 * 60 * 60
     elif not args.end_date:
-        args.end_date = args.start_date + 7 * 24 * 60 * 60
+        args.end_date = to_timestamp_(args.start_date) + 7 * 24 * 60 * 60
 
     try:
         start_timestamp = to_timestamp_(args.start_date)


### PR DESCRIPTION
## Summary

- `show invoices-v1` crashes with `TypeError` when `--start-date` is provided as a date string without `--end-date` (or vice versa)
- The fallback branch does int arithmetic (`+ 7*24*60*60`) on the raw string before it's parsed
- Fix: call `to_timestamp_()` before the arithmetic so both date strings and unix timestamps work
- Applied to both `vastai/cli/commands/billing.py` and the legacy `vast.py`

## Reproduction

```bash
vastai show invoices-v1 --invoices -s "2025-05-01"
# TypeError: can only concatenate str (not "int") to str
```

## Test plan

- [x] `vastai show invoices-v1 --invoices -s 2025-05-01` — no longer crashes, defaults end date to +7 days
- [x] `vastai show invoices-v1 --invoices -e 2025-05-08` — no longer crashes, defaults start date to -7 days
- [x] Both dates provided — unchanged behavior
- [x] Neither date provided — unchanged behavior (defaults to `now`)

Fixes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)